### PR TITLE
Lost error message and exception

### DIFF
--- a/src/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/src/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -575,7 +575,6 @@ namespace Enyim.Caching.Memcached
 			}
 			else
 			{
-				readResult.Combine(result);
 				return result;
 			}
 


### PR DESCRIPTION
When Acquire fails, it may return meaningful error message and exception.

Within ExecuteOperation, "readResult.Combine(result);" overwrites this result with the values of "readResult", which in this block is always blank.

Dropping it just gave me back the error I was looking for.

I've reported the bug in the tracking tool: http://www.couchbase.com/issues/browse/NCBC-281