### PR TITLE
PerformMultipleGet returns records for all keys, including not-found and failed

### DIFF
--- a/src/Enyim.Caching/MemcachedClient.Results.cs
+++ b/src/Enyim.Caching/MemcachedClient.Results.cs
@@ -185,14 +185,25 @@ namespace Enyim.Caching
 		/// <returns>a Dictionary holding all items indexed by their key.</returns>
 		public IDictionary<string, IGetOperationResult> ExecuteGet(IEnumerable<string> keys)
 		{
-			return PerformMultiGet<IGetOperationResult>(keys, (mget, kvp) =>
-			{
-				var result = GetOperationResultFactory.Create();
-				result.Value = this.transcoder.Deserialize(kvp.Value);
-				result.Cas = mget.Cas[kvp.Key];
-				result.Success = true;
-				return result;
-			});
+			return PerformMultiGet<IGetOperationResult>(
+				keys,
+				(mget, kvp) =>
+				{
+					var result = GetOperationResultFactory.Create();
+					result.Value = this.transcoder.Deserialize(kvp.Value);
+					result.Cas = mget.Cas[kvp.Key];
+					result.Success = true;
+					return result;
+				},
+				opResult =>
+				{
+					var result = GetOperationResultFactory.Create();
+					result.Success = false;
+					result.StatusCode = opResult.StatusCode;
+					result.Message = opResult.Message;
+					result.Exception = opResult.Exception;
+					return result;
+				});
 		}
 
 		#endregion


### PR DESCRIPTION
This would fix these issues:
NCBC-81 ExecuteGet() for DictionaryType on multiple keys does not throw a exception if it is not able to connect to a node
NCBC-293    enhance or create new multiget to allow getting details on missing items

It will always returns items for all keys. Currently it only returns successful items and it is not possible to determine whether key was not there or some error occured.
