### PR TITLE
Allow Serializer Customization

### DIFF
--- a/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
+++ b/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
@@ -16,6 +16,16 @@ namespace Couchbase.Extensions
 {
 	public static class CouchbaseClientExtensions
 	{
+	    public static JsonSerializerSettings JsonSerializerSettings;
+
+	    static CouchbaseClientExtensions()
+	    {
+	        JsonSerializerSettings = new JsonSerializerSettings
+	            {
+	                ContractResolver = new DocumentIdContractResolver()
+	            };
+	    }
+
 	    private const string Null = "null";
 
 		#region No expiry
@@ -139,12 +149,9 @@ namespace Couchbase.Extensions
 
 		private static string SerializeObject(object value)
 		{
-			var json = JsonConvert.SerializeObject(value,
+		    var json = JsonConvert.SerializeObject(value,
 									Formatting.None,
-									new JsonSerializerSettings
-									{
-										ContractResolver = new DocumentIdContractResolver()
-									});
+									JsonSerializerSettings);
 			return json;
 		}
 


### PR DESCRIPTION
Hi there,

I have some custom serialization requirements; however, currently the `CouchbaseClientExtensions` does not allow me to customize the `Newtonsoft.Json` serializer.

This patch allows serializer customization by placeing a static field on`CouchbaseClientExtensions.JsonSerializerSettings` that enables users of the couchbase extension class to customize the serializer.

Also added a static constructor to `CouchbaseClientExtensions` which maintains defaults.

Thanks,
Brian
