### PR TITLE
NCBC-375: preferring ipv4-address

### DIFF
--- a/src/Couchbase/CouchbasePool.cs
+++ b/src/Couchbase/CouchbasePool.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using Couchbase.Management;
 using Enyim.Caching.Configuration;
@@ -299,7 +300,7 @@ namespace Couchbase
 					foreach (IPAddress item in items)
 						log.DebugFormat("Found address {0} for {1}", item, hostname);
 
-				var retval = items[0];
+				var retval = items.FirstOrDefault(item => item.AddressFamily == AddressFamily.InterNetwork) ?? items[0];
 
 				if (log.IsDebugEnabled)
 					log.DebugFormat("Using address {0} for {1}", retval, hostname);


### PR DESCRIPTION
See http://www.couchbase.com/issues/browse/NCBC-375
Preferring ipv4-adress over ipv6 
(see also http://www.couchbase.com/issues/browse/MB-6378 and http://www.couchbase.com/communities/q-and-a/net-client-wont-communicate-cluster-successfully-configured-hostnames?current=node/640)
