### PR TITLE
fixing method overloading ambiguity with named parameters

### DIFF
--- a/src/Couchbase/CouchbaseClient.cs
+++ b/src/Couchbase/CouchbaseClient.cs
@@ -1309,7 +1309,7 @@ namespace Couchbase
         /// <returns></returns>
 		public IView<IViewRow> GetView(string designName, string viewName)
         {
-            return GetView<IViewRow>(designName, viewName, false);
+            return GetView<IViewRow>(designName, viewName, urlEncode : false);
         }
 
 


### PR DESCRIPTION
method overloading is differentiated with return type only hence wrong method was invoked from 

line 1311: public IView<IViewRow> GetView(string designName, string viewName)

In order to fix this i have added named parameter from the correct method definition.