### PR TITLE
* Respects JsonSerializer settings for deserialization

### DIFF
--- a/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
+++ b/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
@@ -150,7 +150,7 @@ namespace Couchbase.Extensions
             {
                 value = DocHelper.InsertId(value, key);
             }
-            return JsonConvert.DeserializeObject<T>(value);
+            return JsonConvert.DeserializeObject<T>(value, JsonSerializerSettings);
         }
 
         private static string SerializeObject(object value)


### PR DESCRIPTION
`JsonSerializerSettings` are used for serialization, but not for deserialization.

This pull request corrects this issue, so that both ser/deser use the same `JsonSerializerSettings`.

Thanks,
Brian