### PR TITLE
Fixed PagedView with only one page

### DIFF
--- a/src/Couchbase/PagedView.cs
+++ b/src/Couchbase/PagedView.cs
@@ -52,7 +52,7 @@ namespace Couchbase
                 this.nextKey = pageInfo.LastKey;
                 this.state = 1;
 
-                return this.nextId != null;
+                return (this.nextId != null && this.items.Count > 0);
             }
 
             // can't go further


### PR DESCRIPTION
When using a PageView with a page size larger than the number of items
in the result set, the MoveNext() operation indicates there are no items
in the current page and returns false.

The fix changes the expression to check if there the nextId is not null
and if the current page contains any items.