### PR TITLE
Make JsonSerializerSettings externally configurable.

### DIFF
--- a/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
+++ b/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
@@ -8,6 +8,7 @@ using Couchbase.Configuration.Server.Serialization;
 using Couchbase.Core;
 using Couchbase.IO;
 using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Couchbase.Configuration.Client
 {
@@ -46,8 +47,8 @@ namespace Couchbase.Configuration.Client
             ViewHardTimeout = 30000; //ms
             HeartbeatConfigInterval = 10000; //ms
             EnableConfigHeartBeat = true;
-            SerializationContractResolver = new CamelCasePropertyNamesContractResolver();
-            DeserializationContractResolver = new CamelCasePropertyNamesContractResolver();
+            SerializationSettings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+            DeserializationSettings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
             ViewRequestTimeout = 5000; //ms
             DefaultConnectionLimit = 5; //connections
 
@@ -83,8 +84,8 @@ namespace Couchbase.Configuration.Client
             ObserveTimeout = couchbaseClientSection.ObserveTimeout;
             MaxViewRetries = couchbaseClientSection.MaxViewRetries;
             ViewHardTimeout = couchbaseClientSection.ViewHardTimeout;
-            SerializationContractResolver = new CamelCasePropertyNamesContractResolver();
-            DeserializationContractResolver = new CamelCasePropertyNamesContractResolver();
+            SerializationSettings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+            DeserializationSettings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
             EnableConfigHeartBeat = couchbaseClientSection.EnableConfigHeartBeat;
             HeartbeatConfigInterval = couchbaseClientSection.HeartbeatConfigInterval;
             ViewRequestTimeout = couchbaseClientSection.ViewRequestTimeout;
@@ -239,9 +240,15 @@ namespace Couchbase.Configuration.Client
             }
         }
 
-        public IContractResolver SerializationContractResolver { get; set; }
+        /// <summary>
+        /// The incoming serializer settings for the JSON serializer.
+        /// </summary>
+        public JsonSerializerSettings SerializationSettings { get; set; }
 
-        public IContractResolver DeserializationContractResolver { get; set; }
+        /// <summary>
+        /// The outgoing serializer settings for the JSON serializer.
+        /// </summary>
+        public JsonSerializerSettings DeserializationSettings { get; set; }
 
 
         /// <summary>

--- a/Src/Couchbase/Core/ClusterController.cs
+++ b/Src/Couchbase/Core/ClusterController.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Core
             },
             SaslFactory.GetFactory3(),
             new AutoByteConverter(),
-            new DefaultTranscoder(new AutoByteConverter(), clientConfig.DeserializationContractResolver, clientConfig.SerializationContractResolver))
+            new DefaultTranscoder(new AutoByteConverter(), clientConfig.DeserializationSettings, clientConfig.SerializationSettings))
         {
         }
 
@@ -78,7 +78,7 @@ namespace Couchbase.Core
                 return connectionPool;
             }, SaslFactory.GetFactory3(),
             new AutoByteConverter(),
-            new DefaultTranscoder(new AutoByteConverter(), clientConfig.DeserializationContractResolver, clientConfig.SerializationContractResolver))
+            new DefaultTranscoder(new AutoByteConverter(), clientConfig.DeserializationSettings, clientConfig.SerializationSettings))
         {
         }
 

--- a/Src/Couchbase/Core/Transcoders/DefaultTranscoder.cs
+++ b/Src/Couchbase/Core/Transcoders/DefaultTranscoder.cs
@@ -14,19 +14,19 @@ namespace Couchbase.Core.Transcoders
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
         private readonly IByteConverter _converter;
-        private readonly IContractResolver _outgoingContractResolver;
-        private readonly IContractResolver _incomingContractResolver;
+        private readonly JsonSerializerSettings _outgoingSerializerSettings;
+        private readonly JsonSerializerSettings _incomingSerializerSettings;
 
         public DefaultTranscoder(IByteConverter converter)
-            : this(converter, new DefaultContractResolver(), new CamelCasePropertyNamesContractResolver())
+            : this(converter, new JsonSerializerSettings(), new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() })
         {
         }
 
-        public DefaultTranscoder(IByteConverter converter, IContractResolver incomingContractResolver, IContractResolver outgoingContractResolver)
+        public DefaultTranscoder(IByteConverter converter, JsonSerializerSettings incomingSerializerSettings, JsonSerializerSettings outgoingSerializerSettings)
         {
             _converter = converter;
-            _incomingContractResolver = incomingContractResolver;
-            _outgoingContractResolver = outgoingContractResolver;
+            _incomingSerializerSettings = incomingSerializerSettings;
+            _outgoingSerializerSettings = outgoingSerializerSettings;
         }
 
         public byte[] Encode<T>(T value, Flags flags)
@@ -253,10 +253,7 @@ namespace Couchbase.Core.Transcoders
                 {
                     using (var jr = new JsonTextReader(sr))
                     {
-                        var serializer = new JsonSerializer
-                        {
-                            ContractResolver = _incomingContractResolver
-                        };
+                        var serializer = JsonSerializer.Create(_incomingSerializerSettings);
                         value = serializer.Deserialize<T>(jr);
                     }
                 }
@@ -277,10 +274,7 @@ namespace Couchbase.Core.Transcoders
                 {
                     using (var jr = new JsonTextWriter(sw))
                     {
-                        var serializer = new JsonSerializer
-                        {
-                            ContractResolver = _outgoingContractResolver
-                        };
+                        var serializer = JsonSerializer.Create(_outgoingSerializerSettings);
                         serializer.Serialize(jr, value);
                     }
                 }


### PR DESCRIPTION
While not totally externalizing the serializer itself, this does at least make the Json.Net settings available to be configured from the outside.
