### PR TITLE
Add BucketType property to IBucket

### DIFF
--- a/Src/Couchbase.Tests/Core/Buckets/CouchbaseBucketTests.cs
+++ b/Src/Couchbase.Tests/Core/Buckets/CouchbaseBucketTests.cs
@@ -1040,6 +1040,15 @@ namespace Couchbase.Tests.Core.Buckets
             }
         }
 
+        [Test]
+        public void Test_Couchbase_BucketType()
+        {
+            using (var bucket = _cluster.OpenBucket("beer-sample"))
+            {
+                Assert.AreEqual(Couchbase.Core.Buckets.BucketTypeEnum.Couchbase, bucket.BucketType);
+            }
+        }
+
         [TestFixtureTearDown]
         public void TestFixtureTearDown()
         {

--- a/Src/Couchbase.Tests/Core/Buckets/MemcachedBucketTests.cs
+++ b/Src/Couchbase.Tests/Core/Buckets/MemcachedBucketTests.cs
@@ -415,6 +415,15 @@ namespace Couchbase.Tests.Core.Buckets
             }
         }
 
+        [Test]
+        public void Test_Memcached_BucketType()
+        {
+            using (var bucket = _cluster.OpenBucket("memcached"))
+            {
+                Assert.AreEqual(Couchbase.Core.Buckets.BucketTypeEnum.Memcached, bucket.BucketType);
+            }
+        }
+
         [TearDown]
         public void TestFixtureTearDown()
         {

--- a/Src/Couchbase/Core/IBucket.cs
+++ b/Src/Couchbase/Core/IBucket.cs
@@ -21,6 +21,11 @@ namespace Couchbase.Core
         string Name { get; }
 
         /// <summary>
+        /// Returns type of the bucket (either Couchbase or Memcached)
+        /// </summary>
+        Couchbase.Core.Buckets.BucketTypeEnum BucketType { get; }
+
+        /// <summary>
         /// Performs 'observe' on a given key to ensure that it's durability requirements with respect to persistence and replication are satified.
         /// </summary>
         /// <param name="key">The key to 'observe'.</param>

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -63,6 +63,17 @@ namespace Couchbase
         public string Name { get; set; }
 
         /// <summary>
+        /// Returns type of the bucket. In this implementation the value is constant: Couchbase.
+        /// </summary>
+        public BucketTypeEnum BucketType 
+        {
+            get
+            {
+                return BucketTypeEnum.Couchbase;
+            }
+        }
+
+        /// <summary>
         /// Called when a configuration update has occurred from the server.
         /// </summary>
         /// <param name="configInfo">The new configuration</param>

--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -59,6 +59,17 @@ namespace Couchbase
         public string Name { get; set; }
 
         /// <summary>
+        /// Returns type of the bucket. In this implementation the value is constant: Memcached.
+        /// </summary>
+        public Couchbase.Core.Buckets.BucketTypeEnum BucketType
+        {
+            get
+            {
+                return Couchbase.Core.Buckets.BucketTypeEnum.Memcached;
+            }
+        }
+
+        /// <summary>
         /// Returns true if bucket is using SSL encryption between the client and the server.
         /// </summary>
         public bool IsSecure


### PR DESCRIPTION
User code should be able to distinguish Memcached and Couchbase buckets
without relying on SDK implementation details (calling `bucket.GetType()
== typeof(CouchbaseBucket)`)
