### PR TITLE
Upsert should take IDictionary input param

### DIFF
--- a/Src/Couchbase/Core/IBucket.cs
+++ b/Src/Couchbase/Core/IBucket.cs
@@ -148,33 +148,33 @@ namespace Couchbase.Core
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
-        IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items);
+        IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items);
 
         /// <summary>
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options);
+        IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options);
 
         /// <summary>
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <param name="rangeSize">The size of each subrange</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options, int rangeSize);
+        IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options, int rangeSize);
 
         /// <summary>
         /// Replaces a document if it exists, otherwise fails.

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -459,11 +459,11 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();
@@ -485,12 +485,12 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();
@@ -512,13 +512,13 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <param name="rangeSize">The size of each subrange</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options, int rangeSize)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options, int rangeSize)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();

--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -291,11 +291,11 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();
@@ -317,12 +317,12 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();
@@ -344,13 +344,13 @@ namespace Couchbase
         /// Inserts or replaces a range of items into Couchbase Server.
         /// </summary>
         /// <typeparam name="T">The Type of the value to be inserted.</typeparam>
-        /// <param name="items">A <see cref="Dictionary{K, T}"/> of items to be stored in Couchbase.</param>
+        /// <param name="items">A <see cref="IDictionary{K, T}"/> of items to be stored in Couchbase.</param>
         /// <param name="options">A <see cref="ParallelOptions"/> instance with the options for the given operation.</param>
         /// <param name="rangeSize">The size of each subrange</param>
         /// <returns>A <see cref="IDictionary{K, V}"/> of <see cref="IOperationResult"/> which for which each is the result of the individual operation.</returns>
         /// <remarks>An item is <see cref="KeyValuePair{K, V}"/> where K is a <see cref="string"/> and V is the <see cref="Type"/>of the value use wish to store.</remarks>
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
-        public IDictionary<string, IOperationResult<T>> Upsert<T>(Dictionary<string, T> items, ParallelOptions options, int rangeSize)
+        public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options, int rangeSize)
         {
             var keys = items.Keys.ToList();
             var results = new Dictionary<string, IOperationResult<T>>();


### PR DESCRIPTION
The whole IBucket interface has very clean definitions using interfaces
where appropriate. Upsert operation seems to stand out of the line there
with defining Dictionary input parameter instead of IDictionary. This
seemed as an oversight.
