### PR TITLE
Remove log events from object finalizers

### DIFF
--- a/Src/Couchbase/Cluster.cs
+++ b/Src/Couchbase/Cluster.cs
@@ -175,6 +175,7 @@ namespace Couchbase
                 {
                     _clusterController.Dispose();
                 }
+                _disposed = true;
             }
         }
 
@@ -185,7 +186,6 @@ namespace Couchbase
         ~Cluster()
         {
             Dispose(false);
-            Log.Debug(m=>m("Finalizing {0}", GetType().Name));
         }
     }
 }

--- a/Src/Couchbase/Configuration/ConfigContextBase.cs
+++ b/Src/Couchbase/Configuration/ConfigContextBase.cs
@@ -274,7 +274,6 @@ namespace Couchbase.Configuration
         /// </summary>
         ~ConfigContextBase()
         {
-            Log.Debug(m => m("Finalizing ConfigContext for Rev#{0}", BucketConfig.Rev));
             Dispose(false);
         }
     }

--- a/Src/Couchbase/Configuration/Server/Providers/CarrierPublication/CarrierPublicationProvider.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/CarrierPublication/CarrierPublicationProvider.cs
@@ -271,7 +271,6 @@ namespace Couchbase.Configuration.Server.Providers.CarrierPublication
 
         ~CarrierPublicationProvider()
         {
-            Log.Debug(m => m("Finalizing ConfigurationProvider: {0}", GetType().Name));
             Dispose(false);
         }
     }

--- a/Src/Couchbase/Core/Server.cs
+++ b/Src/Couchbase/Core/Server.cs
@@ -231,7 +231,6 @@ namespace Couchbase.Core
 
         ~Server()
         {
-            Log.Debug(m => m("Finalizing Server for {0}", EndPoint));
             Dispose(false);
         }
     }

--- a/Src/Couchbase/IO/ConnectionPool.cs
+++ b/Src/Couchbase/IO/ConnectionPool.cs
@@ -199,7 +199,6 @@ namespace Couchbase.IO
 
         ~ConnectionPool()
         {
-            Log.Debug(m => m("Finalizing ConnectionPool for {0}", EndPoint));
             Dispose(false);
         }
 

--- a/Src/Couchbase/IO/Strategies/DefaultIOStrategy.cs
+++ b/Src/Couchbase/IO/Strategies/DefaultIOStrategy.cs
@@ -118,7 +118,6 @@ namespace Couchbase.IO.Strategies
 
         ~DefaultIOStrategy()
         {
-            Log.Debug(m => m("Finalizing DefaultIOStrategy for {0} - {1}", EndPoint, _identity));
             Dispose(false);
         }
     }

--- a/Src/Couchbase/IO/Strategies/EapConnection.cs
+++ b/Src/Couchbase/IO/Strategies/EapConnection.cs
@@ -142,7 +142,6 @@ namespace Couchbase.IO.Strategies
 
         ~EapConnection()
         {
-            Log.Debug(m=>m("Finalizing connection for {0}", ConnectionPool.EndPoint));
             Dispose(false);
         }
     }


### PR DESCRIPTION
Order of finalized objects is not guaranteed during application domain
shutdown. Trying to access another object in finalizer will often result
in an exception, when the accessed object was already finallized.

http://msdn.microsoft.com/en-us/library/system.object.finalize%28v=vs.110%29.aspx