### PR TITLE
Update ViewRow.cs

### DIFF
--- a/Src/Couchbase/Views/ViewRow.cs
+++ b/Src/Couchbase/Views/ViewRow.cs
@@ -18,7 +18,7 @@ namespace Couchbase.Views
         /// The key emitted by the View Map function
         /// </summary>
         [JsonProperty("key")]
-        public object Key { get; set; }
+        public dynamic Key { get; set; }
 
         /// <summary>
         /// The value emitted by the View Map function or if a Reduce view, the value of the Reduce


### PR DESCRIPTION
NCBC-722 changed the result of a view so it is returned as ViewRow<T>, which is fine - BUT 
the Key here is returned as object instead of dynamic - making it a hassle to first unbox to dynamic/Jarray to be able to deserialize it / cast it to JValue and then convert. ( which make this unnecessary verbose and cluttered solution ) 
We need to use Key due to mapreduce - so a better solution is to bring it back as dynamic, like it was before.