### PR TITLE
Make ListenForConfigChanges thread a background thread

### DIFF
--- a/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpStreamingProvider.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpStreamingProvider.cs
@@ -124,7 +124,10 @@ namespace Couchbase.Configuration.Server.Providers.Streaming
 
                 var configThreadState = new ConfigThreadState(bucketConfig, ConfigChangedHandler, ErrorOccurredHandler,
                     cancellationTokenSource.Token);
-                var thread = new Thread(configThreadState.ListenForConfigChanges);
+                var thread = new Thread(configThreadState.ListenForConfigChanges)
+                {
+                    IsBackground = true
+                };
 
                 if (_threads.TryAdd(observer.Name, thread) && ConfigObservers.TryAdd(observer.Name, observer))
                 {


### PR DESCRIPTION
Use a background thread for ListenForConfigChanges so that the main
process isn't prevented from terminating.