### PR TITLE
Fix memcached bucket replace with cas.

### DIFF
--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -369,7 +369,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Replace<T>(string key, T value, ulong cas)
         {
-            var operation = new Add<T>(key, value, null, _converter, _transcoder, _operationLifespanTimeout);
+			var operation = new Replace<T>(key, value, cas, null, _converter, _transcoder, _operationLifespanTimeout);
             return _requestExecuter.SendWithRetry(operation);
         }
 


### PR DESCRIPTION
`IOperationResult<T> Replace<T>(string key, T value, ulong cas)` implementation on `MemcachedBucket` was broken and untested.

It was doing an `Add` instead of a `Replace`.

I added tests and implemented the fix.