### PR TITLE
Fix: switched values for TcpKeepAlive in ClientConf

### DIFF
--- a/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
+++ b/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
@@ -68,8 +68,8 @@ namespace Couchbase.Configuration.Client
             BufferSize = 1024 * 16;
             DefaultOperationLifespan = 2500;//ms
             EnableTcpKeepAlives = true;
-            TcpKeepAliveInterval = 2*60*60*1000;
-            TcpKeepAliveTime = 1000;
+            TcpKeepAliveTime = 2*60*60*1000;
+            TcpKeepAliveInterval = 1000;
 
             //the default serializer
             Serializer = SerializerFactory.GetSerializer();


### PR DESCRIPTION
Fix: switched around values for TcpKeepAliveTime and
TcpKeepAliveInterval in ClientConfiguration.cs