### PR TITLE
Fix connection leak on Memcached bucket dispose

### DIFF
--- a/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpStreamingProvider.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpStreamingProvider.cs
@@ -304,6 +304,7 @@ namespace Couchbase.Configuration.Server.Providers.Streaming
                     IConfigInfo configInfo;
                     if (Configs.TryRemove(observer.Name, out configInfo))
                     {
+                        configInfo.Dispose();
                         Log.Info(m => m("Removing config for {0}", observer.Name));
                     }
                 }


### PR DESCRIPTION
Memcached buckets are using HttpStreamingProvider for Couchbase server
node configuration. This implementation did not properly Dispose
underlying ConnectionPools instances.