### PR TITLE
Global connection pool setting for app.config

### DIFF
--- a/Src/Couchbase.Tests/App.config
+++ b/Src/Couchbase.Tests/App.config
@@ -7,6 +7,7 @@
       <section name="couchbase_2" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
       <section name="couchbase_3" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
       <section name="couchbase_4" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase_5" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
     <sectionGroup name="common">
       <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
@@ -74,6 +75,18 @@
         </add>
       </buckets>
     </couchbase_4>
+    <couchbase_5>
+      <servers>
+        <add uri="http://localhost:8091"></add>
+      </servers>
+      <buckets>
+        <add name="default">
+          <connectionPool maxSize="4" />
+        </add>
+        <add name="default2" useSsl="true" />
+      </buckets>
+      <connectionPool maxSize="3" />
+    </couchbase_5>
   </couchbaseClients>
   <common>
     <logging>

--- a/Src/Couchbase.Tests/Configuration/Client/ClientClientSectionTests.cs
+++ b/Src/Couchbase.Tests/Configuration/Client/ClientClientSectionTests.cs
@@ -275,6 +275,29 @@ namespace Couchbase.Tests.Configuration.Client
                 Assert.AreEqual("testvalue", result2.Value);
             }
         }
+
+        [Test]
+        public void Test_Connection_Pool_Settings_Inheritance()
+        {
+            //use section with client-wide connection pool settings and one bucket overriding the settings
+            var section = (CouchbaseClientSection)ConfigurationManager.GetSection("couchbaseClients/couchbase_5");
+            var config = new ClientConfiguration(section);
+            config.Initialize();
+
+            Assert.AreEqual(4, config.BucketConfigs["default"].PoolConfiguration.MaxSize, "Bucket specific setting of MaxSize=4 should have been used.");
+            Assert.AreEqual(3, config.BucketConfigs["default2"].PoolConfiguration.MaxSize, "Client default setting of MaxSize=3 should have been used.");
+
+            //use section with no connection pool definitions at all
+            section = (CouchbaseClientSection)ConfigurationManager.GetSection("couchbaseClients/couchbase_2");
+            config = new ClientConfiguration(section);
+            config.Initialize();
+
+            //get default value for connection pool max size
+            var propInfo = typeof(ConnectionPoolElement).GetProperty("MaxSize");
+            var confProp = (ConfigurationPropertyAttribute)Attribute.GetCustomAttribute(propInfo, typeof(ConfigurationPropertyAttribute));
+
+            Assert.AreEqual(confProp.DefaultValue, config.BucketConfigs["default"].PoolConfiguration.MaxSize, "Default setting of MaxSize should have been used.");
+        }
     }
 }
 

--- a/Src/Couchbase/Configuration/Client/Providers/CouchbaseClientSection.cs
+++ b/Src/Couchbase/Configuration/Client/Providers/CouchbaseClientSection.cs
@@ -283,7 +283,7 @@ namespace Couchbase.Configuration.Client.Providers
         /// <value>
         /// The transcoder.
         /// </value>
-        [ConfigurationProperty("transcoder", DefaultValue = null, IsRequired = false)]
+        [ConfigurationProperty("transcoder", IsRequired = false)]
         public TranscoderElement Transcoder
         {
             get { return (TranscoderElement)this["transcoder"]; }
@@ -296,7 +296,7 @@ namespace Couchbase.Configuration.Client.Providers
         /// <value>
         /// The converter.
         /// </value>
-        [ConfigurationProperty("converter", DefaultValue = null, IsRequired = false)]
+        [ConfigurationProperty("converter", IsRequired = false)]
         public ConverterElement Converter
         {
             get { return (ConverterElement)this["converter"]; }
@@ -309,7 +309,7 @@ namespace Couchbase.Configuration.Client.Providers
         /// <value>
         /// The serializer.
         /// </value>
-        [ConfigurationProperty("serializer", DefaultValue = null, IsRequired = false)]
+        [ConfigurationProperty("serializer", IsRequired = false)]
         public SerializerElement Serializer
         {
             get { return (SerializerElement)this["serializer"]; }
@@ -330,6 +330,18 @@ namespace Couchbase.Configuration.Client.Providers
             set { this["nodeAvailableCheckInterval"] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the default connection pool settings.
+        /// </summary>
+        /// <value>
+        /// The default connection pool settings.
+        /// </value>
+        [ConfigurationProperty("connectionPool", IsRequired = false)]
+        public ConnectionPoolElement ConnectionPool
+        {
+            get { return (ConnectionPoolElement)this["connectionPool"]; }
+            set { this["connectionPool"] = value; }
+        }
     }
 }
 


### PR DESCRIPTION
Programmatic configuration allowed setting up connection pools on global level. Add same functionality to configuration through app.config. Also removing DefaultValue=null for optional configuration elements, because null doesn't work anyway.