### PR TITLE
Corrected errors when running N1QL queries as bare strings

### DIFF
--- a/Src/Couchbase.Tests/N1QL/CouchbaseBucket_N1QL_Tests.cs
+++ b/Src/Couchbase.Tests/N1QL/CouchbaseBucket_N1QL_Tests.cs
@@ -51,7 +51,7 @@ namespace Couchbase.Tests.N1QL
         {
             using (var bucket = _cluster.OpenBucket())
             {
-                var query = new QueryRequest("SELECT * FROM `beer-sample` LIMIT 10");
+                var query = "SELECT * FROM `beer-sample` LIMIT 10";
 
                 var result = bucket.Query<dynamic>(query);
                 Assert.IsTrue(result.Success);

--- a/Src/Couchbase.Tests/N1QL/QueryClientTests.cs
+++ b/Src/Couchbase.Tests/N1QL/QueryClientTests.cs
@@ -57,6 +57,53 @@ namespace Couchbase.Tests.N1QL
         }
 
         [Test]
+        public void Test_Query_HelloWorld_BareStringRequet()
+        {
+            var config = new ClientConfiguration();
+            var client = new QueryClient(new HttpClient(), new JsonDataMapper(config), config);
+            var uri = new Uri(string.Format("http://{0}:8093/query", _server));
+            var query = "SELECT 'Hello World' AS Greeting";
+
+            var result = client.Query<dynamic>(uri, query);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Hello World", result.Rows.First().Greeting.ToString());
+        }
+
+        [Test]
+        public void Test_Query_HelloWorld_Async()
+        {
+            var config = new ClientConfiguration();
+            var client = new QueryClient(new HttpClient(), new JsonDataMapper(config), config);
+            var uri = new Uri(string.Format("http://{0}:8093/query", _server));
+            var query = new QueryRequest("SELECT 'Hello World' AS Greeting").BaseUri(uri);
+
+            var task = client.QueryAsync<dynamic>(query);
+            task.Wait();
+
+            var result = task.Result;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Hello World", result.Rows.First().Greeting.ToString());
+        }
+
+        [Test]
+        public void Test_Query_HelloWorld_AsyncBareStringRequet()
+        {
+            var config = new ClientConfiguration();
+            var client = new QueryClient(new HttpClient(), new JsonDataMapper(config), config);
+            var uri = new Uri(string.Format("http://{0}:8093/query", _server));
+            var query = "SELECT 'Hello World' AS Greeting";
+
+            var task = client.QueryAsync<dynamic>(uri, query);
+            task.Wait();
+
+            var result = task.Result;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Hello World", result.Rows.First().Greeting.ToString());
+        }
+
+        [Test]
         public void Test_Query_Incorrect_Syntax()
         {
             var config = new ClientConfiguration();

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -1518,8 +1518,7 @@ namespace Couchbase
         public IQueryResult<T> Query<T>(string query)
         {
             CheckDisposed();
-            var server = _configInfo.GetServer();
-            return server.Send<T>(query);
+            return _requestExecuter.SendWithRetry<T>(new QueryRequest(query));
         }
 
         /// <summary>


### PR DESCRIPTION
Motivation
----------
When running a N1QL query using CouchbaseBucket.Query<T>(string),
QueryClient.Query<T>(Uri, string), or QueryClient.QueryAsync<T>(Uri,
string) the request is not formatted correctly.  N1QL will always return
an error that the statement is blank.

Modifications
-------------
Change QueryClient.Query<T>(Uri, string) and its Async counterpart to
simply format all queries as a QueryRequest and then process through their
counterparts that use a QueryRequest parameter.  For
CouchbaseBucket.Query<T>(string), changed it to use the _requestExecutor
and provide a QueryRequest parameter, just like its Async counterpart that
was already correct.  Updated unit tests to test for these bugs.