### PR TITLE
Add option to affect operation flags with value fomatting

### DIFF
--- a/Src/Couchbase.Tests/Core/Transcoders/CustomTranscoderTests.cs
+++ b/Src/Couchbase.Tests/Core/Transcoders/CustomTranscoderTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Couchbase.Core.Transcoders;
+using Couchbase.IO.Operations;
+using NUnit.Framework;
+
+namespace Couchbase.Tests.Core.Transcoders
+{
+	[TestFixture]
+	public class CustomTranscoderTests
+	{
+		private class TestStringTranscoder : DefaultTranscoder, ITypeTranscoder
+		{
+			Flags ITypeTranscoder.GetFormat<T>(T value)
+			{
+				if (value == null || value.GetType() != typeof(string))
+				{
+					throw new InvalidOperationException("This test transcoder is supposed to use string only");
+				}
+				return new Flags() { Compression = Compression.None, DataFormat = DataFormat.String, TypeCode = TypeCode.String };
+			}
+		}
+
+		[Test]
+		public void TestCustomTranscoder()
+		{
+			//passing string value wrapped in object should result in JSON object with default transcoder
+			Add<object> add = new Add<object>("text_key", "text", null, new DefaultTranscoder(), 2500);
+			
+			byte[] expectedExtras = new byte[] { 0x02, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00 };
+			byte[] expectedBody = new byte[] { 0x22, 0x74, 0x65, 0x78, 0x74, 0x22 }; //note the extra 0x22 quotes for JSON text escaping
+			DataFormat expectedFormat = DataFormat.Json;
+
+			byte[] actualExtras = add.CreateExtras();
+			Assert.AreEqual(expectedFormat, add.Format);
+			Assert.AreEqual(expectedExtras, actualExtras);
+
+			byte[] actualBody = add.CreateBody();
+			Assert.AreEqual(expectedBody, actualBody);
+			
+			//passing string value wrapped in object should result in plain string value with our test transcoder
+			add = new Add<object>("text_key", "text", null, new TestStringTranscoder(), 2500);
+
+			expectedExtras = new byte[] { 0x04, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00 };
+			expectedBody = new byte[] { 0x74, 0x65, 0x78, 0x74 }; //note that there are no extra quote characters
+			expectedFormat = DataFormat.String;
+
+			actualExtras = add.CreateExtras();
+			Assert.AreEqual(expectedFormat, add.Format);
+			Assert.AreEqual(expectedExtras, actualExtras);
+
+			actualBody = add.CreateBody();
+			Assert.AreEqual(expectedBody, actualBody);
+		}
+	}
+}

--- a/Src/Couchbase.Tests/Core/Transcoders/DefaultTranscoderTests.cs
+++ b/Src/Couchbase.Tests/Core/Transcoders/DefaultTranscoderTests.cs
@@ -347,7 +347,7 @@ namespace Couchbase.Tests.Core.Transcoders
             };
             var expectedJsonBytes = Encoding.UTF8.GetBytes("{\"SomeProperty\":\"SOME\",\"SomeIntProperty\":12345,\"HasPascalCase\":true}");
             var actualJsonBytes = transcoder.SerializeAsJson(data);
-            var actualJsonEncoded = transcoder.Encode(data, OperationCode.Get);
+            var actualJsonEncoded = transcoder.Encode(data, TypeCode.Object, OperationCode.Get);
 
             Assert.AreEqual(expectedJsonBytes, actualJsonBytes);
             Assert.AreEqual(expectedJsonBytes, actualJsonEncoded);

--- a/Src/Couchbase.Tests/Couchbase.Tests.csproj
+++ b/Src/Couchbase.Tests/Couchbase.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Core\Diagnostics\OperationTimerTests.cs" />
     <Compile Include="Core\Diagnostics\TimerFactoryTests.cs" />
     <Compile Include="Core\NodeAdapterTests.cs" />
+    <Compile Include="Core\Transcoders\CustomTranscoderTests.cs" />
     <Compile Include="Core\Transcoders\TranscoderFactoryTests.cs" />
     <Compile Include="Core\Transcoders\DefaultTranscoderTests.cs" />
     <Compile Include="ClusterHelperTests.cs" />

--- a/Src/Couchbase.Tests/Fakes/FakeTranscoder.cs
+++ b/Src/Couchbase.Tests/Fakes/FakeTranscoder.cs
@@ -34,6 +34,11 @@ namespace Couchbase.Tests.Fakes
 
         public IByteConverter Converter { get; set; }
 
+        public Flags GetFormat<T>(T value)
+        {
+            throw new NotImplementedException();
+        }
+
         public byte[] Encode<T>(T value, Flags flags, OperationCode opcode)
         {
             throw new NotImplementedException();

--- a/Src/Couchbase/Core/Transcoders/ITypeTranscoder.cs
+++ b/Src/Couchbase/Core/Transcoders/ITypeTranscoder.cs
@@ -11,6 +11,14 @@ namespace Couchbase.Core.Transcoders
     public interface ITypeTranscoder
     {
         /// <summary>
+        /// Get data formatting based on the generic type and/or the actual value.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">Value to be formatted.</param>
+        /// <returns>Flags used to format value written to operation payload.</returns>
+        Flags GetFormat<T>(T value);
+
+        /// <summary>
         /// Encodes the specified value.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/Src/Couchbase/IO/Operations/Append.cs
+++ b/Src/Couchbase/IO/Operations/Append.cs
@@ -24,16 +24,9 @@ namespace Couchbase.IO.Operations
 
         public override byte[] CreateExtras()
         {
-            var format = (byte)GetFormat();
-            const byte compression = (byte)Compression.None;
-
-            var typeCode = (ushort)Type.GetTypeCode(typeof(T));
-            Format = (DataFormat)format;
-            Compression = compression;
-
-            Flags.DataFormat = Format;
-            Flags.Compression = Compression;
-            Flags.TypeCode = (TypeCode)typeCode;
+            Flags = Transcoder.GetFormat<T>(RawValue);
+            Format = Flags.DataFormat;
+            Compression = Flags.Compression;
             return new byte[0];
         }
 

--- a/Src/Couchbase/IO/Operations/Prepend.cs
+++ b/Src/Couchbase/IO/Operations/Prepend.cs
@@ -24,16 +24,9 @@ namespace Couchbase.IO.Operations
 
         public override byte[] CreateExtras()
         {
-            var format = (byte)GetFormat();
-            const byte compression = (byte)Compression.None;
-
-            var typeCode = (ushort)Type.GetTypeCode(typeof(T));
-            Format = (DataFormat)format;
-            Compression = compression;
-
-            Flags.DataFormat = Format;
-            Flags.Compression = Compression;
-            Flags.TypeCode = (TypeCode)typeCode;
+            Flags = Transcoder.GetFormat<T>(RawValue);
+            Format = Flags.DataFormat;
+            Compression = Flags.Compression;
             return new byte[0];
         }
 


### PR DESCRIPTION
The original implementation of ITypeTranscoder does not allow full customization of encoded values. It still binds the encoding by hard wired formatting flags based on the generic type of operation. The new implementation allows for full encoding customization like unwrapping of values passed in as object generic type.