### PR TITLE
Fix exception when decoding char type

### DIFF
--- a/Src/Couchbase.Tests/Core/Transcoders/DefaultTranscoderTests.cs
+++ b/Src/Couchbase.Tests/Core/Transcoders/DefaultTranscoderTests.cs
@@ -260,6 +260,23 @@ namespace Couchbase.Tests.Core.Transcoders
         }
 
         [Test]
+        public void Test_Deserialize_Char()
+        {
+            var transcoder = new DefaultTranscoder(new DefaultConverter());
+            var value = 'o';
+
+            var flags = new Flags {
+                Compression = Compression.None,
+                DataFormat = DataFormat.Reserved,
+                TypeCode = value.GetTypeCode()
+            };
+
+            var bytes = Encoding.UTF8.GetBytes(value.ToString());
+            var actual = transcoder.Decode<char>(bytes, 0, bytes.Length, flags, OperationCode.Get);
+            Assert.AreEqual(value, actual);
+        }
+
+        [Test]
         public void Test_Byte_Array()
         {
             var transcoder = new DefaultTranscoder(new DefaultConverter());

--- a/Src/Couchbase/Core/Transcoders/DefaultTranscoder.cs
+++ b/Src/Couchbase/Core/Transcoders/DefaultTranscoder.cs
@@ -187,7 +187,7 @@ namespace Couchbase.Core.Transcoders
                 case DataFormat.Json:
                     if (typeof (T) == typeof (string))
                     {
-                        value = Decode(buffer, offset, length);
+                        value = DecodeString(buffer, offset, length);
                     }
                     else
                     {
@@ -209,11 +209,18 @@ namespace Couchbase.Core.Transcoders
                     break;
 
                 case DataFormat.String:
-                    value = Decode(buffer, offset, length);
+                    if (typeof(T) == typeof(char))
+                    {
+                        value = DecodeChar(buffer, offset, length);
+                    }
+                    else
+                    {
+                        value = DecodeString(buffer, offset, length);
+                    }
                     break;
 
                 default:
-                    value = Decode(buffer, offset, length);
+                    value = DecodeString(buffer, offset, length);
                     break;
             }
             return (T)value;
@@ -238,8 +245,11 @@ namespace Couchbase.Core.Transcoders
                 case TypeCode.Empty:
                 case TypeCode.DBNull:
                 case TypeCode.String:
+                    value = DecodeString(buffer, offset, length);
+                    break;
+
                 case TypeCode.Char:
-                    value = Decode(buffer, offset, length);
+                    value = DecodeChar(buffer, offset, length);
                     break;
 
                 case TypeCode.Int16:
@@ -361,18 +371,44 @@ namespace Couchbase.Core.Transcoders
         }
 
         /// <summary>
-        /// Decodes the specified buffer.
+        /// Decodes the specified buffer as string.
         /// </summary>
         /// <param name="buffer">The buffer.</param>
         /// <param name="offset">The offset.</param>
         /// <param name="length">The length.</param>
         /// <returns></returns>
-        private string Decode(byte[] buffer, int offset, int length)
+        private string DecodeString(byte[] buffer, int offset, int length)
         {
             var result = string.Empty;
             if (buffer != null && buffer.Length > 0 && length > 0)
             {
                 result = Encoding.UTF8.GetString(buffer, offset, length);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Decodes the specified buffer as char.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The offset.</param>
+        /// <param name="length">The length.</param>
+        /// <returns></returns>
+        private char DecodeChar(byte[] buffer, int offset, int length)
+        {
+            char result = default(char);
+            if (buffer != null && buffer.Length > 0 && length > 0)
+            {
+                var str = Encoding.UTF8.GetString(buffer, offset, length);
+                if (str.Length == 1)
+                {
+                    result = str[0];
+                }
+                else if (str.Length > 1)
+                {
+                    var msg = string.Format("Can not convert string \"{0}\" to char", str);
+                    throw new InvalidCastException(msg);
+                }
             }
             return result;
         }


### PR DESCRIPTION
Decode of char type used to lead to invalid cast exception. The exception would flag both save and read operation types as failure. This is now fixed as char is handled separately from string.