### PR TITLE
NCBC-1020: Exists should return false if key is LogicalDeleted

### DIFF
--- a/Src/Couchbase.Tests/CouchbaseBucketTests.cs
+++ b/Src/Couchbase.Tests/CouchbaseBucketTests.cs
@@ -66,6 +66,18 @@ namespace Couchbase.Tests
             }
         }
 
+        [Test]
+        public void When_Key_Was_Just_Removed_Exists_Returns_False()
+        {
+            var key = "thekeythatdidexist";
+            using (var bucket = _cluster.OpenBucket())
+            {
+                bucket.Upsert(key, "somevalue");
+                bucket.Remove(key);
+                var result = bucket.Exists(key);
+                Assert.IsFalse(result);
+            }
+        }
 
         /// <summary>
         /// Note that Couchbase Server returns an auth error if the bucket doesn't exist.


### PR DESCRIPTION
Motivation
----------
Exists function shouldn't need to wait until after a Remove is persisted
to disk before it returns the expected result of false.

Modifications
-------------
Return false for KeyState.LogicalDeleted in addition to KeyState.NotFound.

To support unit testing, added an internal overload to the CouchbaseBucket
constructor that accepts an IRequestExecuter.  Also modified the
_requestExecuter field to store it as an IRequestExecuter instead of a
CouchbaseRequestExecuter.