### PR TITLE
NBCB-1022: Throw ObjectDisposedException for Upsert commands

### DIFF
--- a/Src/Couchbase.UnitTests/CouchbaseBucketTests.cs
+++ b/Src/Couchbase.UnitTests/CouchbaseBucketTests.cs
@@ -95,6 +95,317 @@ namespace Couchbase.UnitTests
 
         #endregion
 
+        #region Upsert
+
+        #region Upsert Disposed Bucket
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDocument_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Document<FakeDocument>
+            {
+                Id = "key",
+                Content = new FakeDocument()
+            });
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDocumentReplicateTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Document<FakeDocument>
+            {
+                Id = "key",
+                Content = new FakeDocument()
+            },
+            ReplicateTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDocumentReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Document<FakeDocument>
+            {
+                Id = "key",
+                Content = new FakeDocument()
+            },
+            ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValue_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument());
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueReplicateTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), ReplicateTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueExpirationTS_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), TimeSpan.Zero);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueExpirationTSReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), TimeSpan.Zero, ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueExpiration_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0U);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueExpirationReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0U, ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueCas_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0UL);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueCasExpirationTS_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0UL, TimeSpan.Zero);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueCasExpirationTSReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0UL, TimeSpan.Zero, ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueCasExpiration_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0UL, 0U);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertKeyValueCasExpirationReplicateToPersistTo_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert("key", new FakeDocument(), 0UL, 0U, ReplicateTo.One, PersistTo.One);
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDictionary_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Dictionary<string, FakeDocument>
+            {
+                { "key", new FakeDocument() }
+            });
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDictionaryParallelOptions_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Dictionary<string, FakeDocument>
+            {
+                { "key", new FakeDocument() }
+            },
+            new ParallelOptions());
+        }
+
+        [Test()]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void UpsertDictionaryParallelOptionsRangeSize_DisposedBucket_ThrowsObjectDisposedException()
+        {
+            // Arrange
+
+            var mockRequestExecuter = new Mock<IRequestExecuter>();
+            var bucket = new CouchbaseBucket(mockRequestExecuter.Object, new DefaultConverter(), new DefaultTranscoder());
+            bucket.Dispose();
+
+            // Act
+
+            bucket.Upsert(new Dictionary<string, FakeDocument>
+            {
+                { "key", new FakeDocument() }
+            },
+            new ParallelOptions(), 0);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Helpers
+
+        private class FakeDocument
+        {
+        }
+
+        #endregion
+
     }
 }
 

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -2508,6 +2508,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Upsert<T>(string key, T value)
         {
+            CheckDisposed();
             var operation = new Set<T>(key, value, null, _transcoder, _operationLifespanTimeout);
             return _requestExecuter.SendWithRetry(operation);
         }
@@ -2572,6 +2573,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Upsert<T>(string key, T value, ulong cas, uint expiration)
         {
+            CheckDisposed();
             var operation = new Set<T>(key, value, null, _transcoder, _operationLifespanTimeout)
             {
                 Cas = cas,
@@ -2645,6 +2647,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Upsert<T>(string key, T value, ReplicateTo replicateTo, PersistTo persistTo)
         {
+            CheckDisposed();
             var operation = new Set<T>(key, value, null, _transcoder, _operationLifespanTimeout);
             return _requestExecuter.SendWithDurability(operation, false, replicateTo, persistTo);
         }
@@ -2664,6 +2667,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Upsert<T>(string key, T value, uint expiration, ReplicateTo replicateTo, PersistTo persistTo)
         {
+            CheckDisposed();
             var operation = new Set<T>(key, value, null, _transcoder, _operationLifespanTimeout)
             {
                 Expires = expiration
@@ -2704,6 +2708,7 @@ namespace Couchbase
         /// <returns>An object implementing the <see cref="IOperationResult{T}"/>interface.</returns>
         public IOperationResult<T> Upsert<T>(string key, T value, ulong cas, uint expiration, ReplicateTo replicateTo, PersistTo persistTo)
         {
+            CheckDisposed();
             var operation = new Set<T>(key, value, null, _transcoder, _operationLifespanTimeout)
             {
                 Expires = expiration,
@@ -2740,6 +2745,7 @@ namespace Couchbase
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
         public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items)
         {
+            CheckDisposed();
             var results = new ConcurrentDictionary<string, IOperationResult<T>>();
             if (items != null && items.Count > 0)
             {
@@ -2770,6 +2776,7 @@ namespace Couchbase
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
         public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options)
         {
+            CheckDisposed();
             var results = new ConcurrentDictionary<string, IOperationResult<T>>();
             if (items != null && items.Count > 0)
             {
@@ -2801,6 +2808,7 @@ namespace Couchbase
         /// <remarks>Use the <see cref="ParallelOptions"/> parameter to control the level of parallelism to use and/or to associate a <see cref="CancellationToken"/> with the operation.</remarks>
         public IDictionary<string, IOperationResult<T>> Upsert<T>(IDictionary<string, T> items, ParallelOptions options, int rangeSize)
         {
+            CheckDisposed();
             var results = new ConcurrentDictionary<string, IOperationResult<T>>();
             if (items != null && items.Count > 0)
             {


### PR DESCRIPTION
Motivation
----------
Other bucket commands consistently throw ObjectDisposedException if called
after the bucket is Disposed.  Upsert is currently returning a timeout
error instead.

Modifications
-------------
Added CheckDisposed() calls to all Upsert methods, except those forwarding
the call to other Upsert methods.  Also added to dicionary Upsert method
so that it could throw the exception early, rather than throwing an
AggregateException with InnerExceptions for all of the individual upserts.

Also added unit tests.  For future-proofing, unit tests were added for
every Upsert call, not just calls that aren't forwarded.

Results
-------
Calls to Upsert now throw exceptions consistent with other commands on
buckets.