### PR TITLE
Support for more deserialization controls via ITypeSerializers

### DIFF
--- a/Src/Couchbase.UnitTests/Core/Serialization/DefaultSerializerTests.cs
+++ b/Src/Couchbase.UnitTests/Core/Serialization/DefaultSerializerTests.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core.Serialization;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests.Core.Serialization
+{
+    [TestFixture]
+    public class DefaultSerializerTests
+    {
+        #region DeserializationOptions
+
+        [Test]
+        public void DeserializationOptions_Modification_UpdatesEffectiveSettings()
+        {
+            // Arrange
+
+            var options = new DeserializationOptions();
+            var effectiveSettings = new JsonSerializerSettings();
+
+            var serializer = new Mock<DefaultSerializer>
+            {
+                CallBase = true
+            };
+
+            serializer.Setup(p => p.GetDeserializationSettings(It.IsAny<JsonSerializerSettings>(), options))
+                .Returns(effectiveSettings);
+
+            // Act
+
+            serializer.Object.DeserializationOptions = options;
+
+            // Assert
+
+            Assert.AreEqual(effectiveSettings, serializer.Object.EffectiveDeserializationSettings);
+        }
+
+        #endregion
+
+        #region Deserialize With ICustomObjectCreator
+
+        [Test]
+        public void Deserialize_Stream_WithICustomObjectCreator_CreatesCustomObjects()
+        {
+            // Arrange
+
+            var creator = new FakeCustomObjectCreator();
+
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var serializer = new DefaultSerializer(settings, settings)
+            {
+                DeserializationOptions = new DeserializationOptions()
+                {
+                    CustomObjectCreator = creator
+                }
+            };
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes("{\"subNode\":{\"property\":\"value\"}}"));
+
+            // Act
+
+            var result = serializer.Deserialize<JsonDocument>(stream);
+
+            // Assert
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.SubNode);
+            Assert.AreEqual(typeof(DocumentSubNodeInherited), result.SubNode.GetType());
+            Assert.AreEqual("value", result.SubNode.Property);
+        }
+
+        [Test]
+        public void Deserialize_ByteArray_WithICustomObjectCreator_CreatesCustomObjects()
+        {
+            // Arrange
+
+            var creator = new FakeCustomObjectCreator();
+
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var serializer = new DefaultSerializer(settings, settings)
+            {
+                DeserializationOptions = new DeserializationOptions()
+                {
+                    CustomObjectCreator = creator
+                }
+            };
+
+            var jsonBuffer = Encoding.UTF8.GetBytes("{\"subNode\":{\"property\":\"value\"}}");
+
+            // Act
+
+            var result = serializer.Deserialize<JsonDocument>(jsonBuffer, 0, jsonBuffer.Length);
+
+            // Assert
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.SubNode);
+            Assert.AreEqual(typeof(DocumentSubNodeInherited), result.SubNode.GetType());
+            Assert.AreEqual("value", result.SubNode.Property);
+        }
+
+        #endregion
+
+        #region GetMemberName
+
+        [Test]
+        public void GetMemberName_Null_ArgumentNullException()
+        {
+            // Arrange
+
+            var serializer = new DefaultSerializer();
+
+            // Act/Assert
+
+            Assert.Throws<ArgumentNullException>(() => serializer.GetMemberName(null));
+        }
+
+        [Test]
+        public void GetMemberName_BasicProperty_ReturnsPropertyName()
+        {
+            // Arrange
+
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var serializer = new DefaultSerializer(settings, settings);
+
+            // Act
+
+            var result = serializer.GetMemberName(typeof (JsonDocument).GetProperty("BasicProperty"));
+
+            // Assert
+
+            Assert.AreEqual("basicProperty", result);
+        }
+
+        [Test]
+        public void GetMemberName_NamedProperty_ReturnsNameFromAttribute()
+        {
+            // Arrange
+
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var serializer = new DefaultSerializer(settings, settings);
+
+            // Act
+
+            var result = serializer.GetMemberName(typeof(JsonDocument).GetProperty("NamedProperty"));
+
+            // Assert
+
+            Assert.AreEqual("useThisName", result);
+        }
+
+        [Test]
+        public void GetMemberName_IgnoredProperty_ReturnsNull()
+        {
+            // Arrange
+
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var serializer = new DefaultSerializer(settings, settings);
+
+            // Act
+
+            var result = serializer.GetMemberName(typeof(JsonDocument).GetProperty("IgnoredProperty"));
+
+            // Assert
+
+            Assert.IsNull(result);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private class JsonDocument
+        {
+            public string BasicProperty { get; set; }
+
+            [JsonProperty("useThisName")]
+            public string NamedProperty { get; set; }
+
+            [JsonIgnore]
+            public string IgnoredProperty { get; set; }
+
+            public DocumentSubNode SubNode { get; set; }
+        }
+
+        private class DocumentSubNode
+        {
+            public string Property { get; set; }
+        }
+
+        private class DocumentSubNodeInherited : DocumentSubNode
+        {
+        }
+
+        private class FakeCustomObjectCreator : ICustomObjectCreator
+        {
+            public bool CanCreateObject(Type type)
+            {
+                return type == typeof (DocumentSubNode);
+            }
+
+            public object CreateObject(Type type)
+            {
+                return new DocumentSubNodeInherited();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.UnitTests/Core/Serialization/DeserializationOptionsTests.cs
+++ b/Src/Couchbase.UnitTests/Core/Serialization/DeserializationOptionsTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core.Serialization;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests.Core.Serialization
+{
+    [TestFixture]
+    public class DeserializationOptionsTests
+    {
+        #region HasSettings
+
+        [Test]
+        public void HasSettings_DefaultObject_ReturnsFalse()
+        {
+            // Arrange
+
+            var settings = new DeserializationOptions();
+
+            // Act
+
+            var result = settings.HasSettings;
+
+            // Assert
+
+            Assert.False(result);
+        }
+
+        [Test]
+        public void HasSettings_WithCustomObjectCreator_ReturnsTrue()
+        {
+            // Arrange
+
+            var settings = new DeserializationOptions()
+            {
+                CustomObjectCreator = new Mock<ICustomObjectCreator>().Object
+            };
+
+            // Act
+
+            var result = settings.HasSettings;
+
+            // Assert
+
+            Assert.True(result);
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.UnitTests/Couchbase.UnitTests.csproj
+++ b/Src/Couchbase.UnitTests/Couchbase.UnitTests.csproj
@@ -69,7 +69,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Core\Serialization\DefaultSerializerTests.cs" />
+    <Compile Include="Core\Serialization\DeserializationOptionsTests.cs" />
     <Compile Include="CouchbaseBucketTests.cs" />
+    <Compile Include="N1Ql\QueryClientTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/Couchbase.UnitTests/N1Ql/QueryClientTests.cs
+++ b/Src/Couchbase.UnitTests/N1Ql/QueryClientTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Configuration.Client;
+using Couchbase.N1QL;
+using Couchbase.Views;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests.N1Ql
+{
+    [TestFixture]
+    public class QueryClientTests
+    {
+        #region GetDataMapper
+
+        [Test]
+        public void GetDataMapper_IQueryRequest_ReturnsClientDataMapper()
+        {
+            // Arrange
+
+            var dataMapper = new Mock<IDataMapper>();
+
+            var queryRequest = new Mock<IQueryRequest>();
+
+            var queryClient = new QueryClient(new HttpClient(), dataMapper.Object, new ClientConfiguration(),
+                new ConcurrentDictionary<string, QueryPlan>());
+
+            // Act
+
+            var result = queryClient.GetDataMapper(queryRequest.Object);
+
+            // Assert
+
+            Assert.AreEqual(dataMapper.Object, result);
+        }
+
+        [Test]
+        public void GetDataMapper_IQueryRequestWithDataMapper_NoDataMapper_ReturnsClientDataMapper()
+        {
+            // Arrange
+
+            var clientDataMapper = new Mock<IDataMapper>();
+
+            var queryRequest = new Mock<IQueryRequestWithDataMapper>();
+            queryRequest.SetupProperty(p => p.DataMapper, null);
+
+            var queryClient = new QueryClient(new HttpClient(), clientDataMapper.Object, new ClientConfiguration(),
+                new ConcurrentDictionary<string, QueryPlan>());
+
+            // Act
+
+            var result = queryClient.GetDataMapper(queryRequest.Object);
+
+            // Assert
+
+            Assert.AreEqual(clientDataMapper.Object, result);
+        }
+
+        [Test]
+        public void GetDataMapper_IQueryRequestWithDataMapper_HasDataMapper_ReturnsRequestDataMapper()
+        {
+            // Arrange
+
+            var clientDataMapper = new Mock<IDataMapper>();
+            var requestDataMapper = new Mock<IDataMapper>();
+
+            var queryRequest = new Mock<IQueryRequestWithDataMapper>();
+            queryRequest.SetupProperty(p => p.DataMapper, requestDataMapper.Object);
+
+            var queryClient = new QueryClient(new HttpClient(), clientDataMapper.Object, new ClientConfiguration(),
+                new ConcurrentDictionary<string, QueryPlan>());
+
+            // Act
+
+            var result = queryClient.GetDataMapper(queryRequest.Object);
+
+            // Assert
+
+            Assert.AreEqual(requestDataMapper.Object, result);
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase/Core/Serialization/DeserializationOptions.cs
+++ b/Src/Couchbase/Core/Serialization/DeserializationOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Core.Serialization
+{
+    /// <summary>
+    /// Options to control deserialization process in an <see cref="IExtendedTypeSerializer"/>.
+    /// </summary>
+    public class DeserializationOptions
+    {
+        /// <summary>
+        /// Returns true if any custom options are set
+        /// </summary>
+        public bool HasSettings
+        {
+            get
+            {
+                return CustomObjectCreator != null;
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ICustomObjectCreator"/> to use when creating objects during deserialization.
+        /// Null will uses the <see cref="IExtendedTypeSerializer"/> defaults for type creation.
+        /// </summary>
+        public ICustomObjectCreator CustomObjectCreator { get; set; }
+    }
+}

--- a/Src/Couchbase/Core/Serialization/ICustomObjectCreator.cs
+++ b/Src/Couchbase/Core/Serialization/ICustomObjectCreator.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Core.Serialization
+{
+    /// <summary>
+    /// Used to control type creation during deserialization.  For example, it can be used to create object proxies.
+    /// </summary>
+    public interface ICustomObjectCreator
+    {
+        /// <summary>
+        /// Determine if this creator can create a particular type.
+        /// </summary>
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if this creator can create a particular type.</returns>
+        /// <remarks>Results of this method should be consistent for every call so that they can be cached.</remarks>
+        bool CanCreateObject(Type type);
+
+        /// <summary>
+        /// Create an instance of a particular type with default values, ready to be populated by the deserializer.
+        /// </summary>
+        /// <param name="type">Type to create.</param>
+        /// <returns>New instance of the type with default values, ready to be populated by the deserializer.</returns>
+        object CreateObject(Type type);
+    }
+}

--- a/Src/Couchbase/Core/Serialization/IExtendedTypeSerializer.cs
+++ b/Src/Couchbase/Core/Serialization/IExtendedTypeSerializer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Core.Serialization
+{
+    /// <summary>
+    /// Provides an interface for serialization and deserialization of K/V pairs, with support for more
+    /// advanced deserialization features.
+    /// </summary>
+    public interface IExtendedTypeSerializer : ITypeSerializer
+    {
+        /// <summary>
+        /// Informs consumers what deserialization options this <see cref="IExtendedTypeSerializer"/> supports.
+        /// </summary>
+        SupportedDeserializationOptions SupportedDeserializationOptions { get; }
+
+        /// <summary>
+        /// Provides custom deserialization options.  Options not listed in <see cref="IExtendedTypeSerializer.SupportedDeserializationOptions"/>
+        /// will be ignored.  If null, then defaults will be used.
+        /// </summary>
+        DeserializationOptions DeserializationOptions { get; set; }
+
+        /// <summary>
+        /// Get the name which will be used for a given member during serialization/deserialization.
+        /// </summary>
+        /// <param name="member">Returns the name of this member.</param>
+        /// <returns>
+        /// The name which will be used for a given member during serialization/deserialization,
+        /// or null if if will not be serialized.
+        /// </returns>
+        string GetMemberName(MemberInfo member);
+    }
+}

--- a/Src/Couchbase/Core/Serialization/JsonNetCustomObjectCreatorWrapper.cs
+++ b/Src/Couchbase/Core/Serialization/JsonNetCustomObjectCreatorWrapper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Couchbase.Core.Serialization
+{
+    /// <summary>
+    /// <see cref="JsonConverter"/> that wraps an <see cref="ICustomObjectCreator"/> to support Json.Net deserialization.
+    /// </summary>
+    /// <remarks>
+    /// Used by <see cref="DefaultSerializer"/> if an <see cref="ICustomObjectCreator"/> is supplied.
+    /// </remarks>
+    internal class JsonNetCustomObjectCreatorWrapper : JsonConverter
+    {
+        private readonly ICustomObjectCreator _creator;
+
+        public JsonNetCustomObjectCreatorWrapper(ICustomObjectCreator creator)
+        {
+            if (creator == null)
+            {
+                throw new ArgumentNullException("creator");
+            }
+
+            _creator = creator;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            object obj = _creator.CreateObject(objectType);
+            if (obj == null)
+            {
+                throw new ApplicationException("ICustomObjectCreator returned a null reference.");
+            }
+
+            serializer.Populate(reader, obj);
+
+            return obj;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return _creator.CanCreateObject(objectType);
+        }
+    }
+}

--- a/Src/Couchbase/Core/Serialization/SupportedDeserializationOptions.cs
+++ b/Src/Couchbase/Core/Serialization/SupportedDeserializationOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Core.Serialization
+{
+    /// <summary>
+    /// Supplied by <see cref="IExtendedTypeSerializer"/> to define which deserialization options it supports.
+    /// </summary>
+    /// <remarks>Intended to help support backwards compatibility as new deserialization options are added in the future.</remarks>
+    public class SupportedDeserializationOptions
+    {
+        /// <summary>
+        /// If true, the <see cref="IExtendedTypeSerializer"/> supports <see cref="DeserializationOptions.CustomObjectCreator"/>.
+        /// </summary>
+        public bool CustomObjectCreator { get; set; }
+    }
+}

--- a/Src/Couchbase/Couchbase.csproj
+++ b/Src/Couchbase/Couchbase.csproj
@@ -113,8 +113,13 @@
     <Compile Include="Core\NodeAdapter.cs" />
     <Compile Include="Core\NodeUnavailableException.cs" />
     <Compile Include="Core\Serialization\DefaultSerializer.cs" />
+    <Compile Include="Core\Serialization\IExtendedTypeSerializer.cs" />
+    <Compile Include="Core\Serialization\ICustomObjectCreator.cs" />
     <Compile Include="Core\Serialization\ITypeSerializer.cs" />
+    <Compile Include="Core\Serialization\JsonNetCustomObjectCreatorWrapper.cs" />
     <Compile Include="Core\Serialization\SerializerFactory.cs" />
+    <Compile Include="Core\Serialization\SupportedDeserializationOptions.cs" />
+    <Compile Include="Core\Serialization\DeserializationOptions.cs" />
     <Compile Include="Core\Services\ServiceNotSupportedException.cs" />
     <Compile Include="Core\Transcoders\ITypeTranscoder.cs" />
     <Compile Include="Core\Transcoders\DefaultTranscoder.cs" />
@@ -248,6 +253,7 @@
     <Compile Include="N1QL\Compression.cs" />
     <Compile Include="N1QL\Encoding.cs" />
     <Compile Include="N1QL\Format.cs" />
+    <Compile Include="N1QL\IQueryRequestWithDataMapper.cs" />
     <Compile Include="N1QL\Method.cs" />
     <Compile Include="N1QL\IQueryRequest.cs" />
     <Compile Include="N1QL\IQueryResult%27.cs" />

--- a/Src/Couchbase/N1QL/IQueryRequestWithDataMapper.cs
+++ b/Src/Couchbase/N1QL/IQueryRequestWithDataMapper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Views;
+
+namespace Couchbase.N1QL
+{
+    /// <summary>
+    /// Extends <see cref="IQueryRequest"/> to provide a custom data mapper
+    /// </summary>
+    interface IQueryRequestWithDataMapper : IQueryRequest
+    {
+        /// <summary>
+        /// Custom <see cref="IDataMapper"/> to use when deserializing query results.
+        /// </summary>
+        /// <remarks>Null will use the default <see cref="IDataMapper"/>.</remarks>
+        IDataMapper DataMapper { get; set; }
+    }
+}

--- a/Src/Couchbase/N1QL/QueryClient.cs
+++ b/Src/Couchbase/N1QL/QueryClient.cs
@@ -311,6 +311,24 @@ namespace Couchbase.N1QL
             }
         }
 
+        /// <summary>
+        /// Returns the <see cref="IDataMapper"/> to use for a given <see cref="IQueryRequest"/>
+        /// </summary>
+        /// <param name="queryRequest">Request to get the <see cref="IDataMapper"/> for</param>
+        /// <returns><see cref="IDataMapper"/> to use for the request</returns>
+        internal IDataMapper GetDataMapper(IQueryRequest queryRequest)
+        {
+            var requestWithMapper = queryRequest as IQueryRequestWithDataMapper;
+
+            if (requestWithMapper != null)
+            {
+                return requestWithMapper.DataMapper ?? DataMapper;
+            }
+            else
+            {
+                return DataMapper;
+            }
+        }
 
         /// <summary>
         /// Executes the <see cref="IQueryRequest"/> using HTTP POST to the Couchbase Server.
@@ -341,7 +359,7 @@ namespace Couchbase.N1QL
                 var response = request.GetResponse();
                 using (var stream = response.GetResponseStream())
                 {
-                    queryResult = DataMapper.Map<QueryResult<T>>(stream);
+                    queryResult = GetDataMapper(queryRequest).Map<QueryResult<T>>(stream);
                     queryResult.Success = queryResult.Status == QueryStatus.Success;
                 }
             }
@@ -350,7 +368,7 @@ namespace Couchbase.N1QL
                 if (e.Response != null)
                 {
                     var stream = e.Response.GetResponseStream();
-                    queryResult = DataMapper.Map<QueryResult<T>>(stream);
+                    queryResult = GetDataMapper(queryRequest).Map<QueryResult<T>>(stream);
                     queryResult.HttpStatusCode = ((HttpWebResponse) e.Response).StatusCode;
                 }
                 queryResult.Exception = e;
@@ -380,7 +398,7 @@ namespace Couchbase.N1QL
                     var request = await HttpClient.PostAsync(queryRequest.GetBaseUri(), content);
                     using (var response = await request.Content.ReadAsStreamAsync())
                     {
-                        queryResult = DataMapper.Map<QueryResult<T>>(response);
+                        queryResult = GetDataMapper(queryRequest).Map<QueryResult<T>>(response);
                         queryResult.Success = queryResult.Status == QueryStatus.Success;
                     }
                 }

--- a/Src/Couchbase/N1QL/QueryRequest.cs
+++ b/Src/Couchbase/N1QL/QueryRequest.cs
@@ -6,13 +6,14 @@ using Newtonsoft.Json;
 using System.Net;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Couchbase.Views;
 
 namespace Couchbase.N1QL
 {
     /// <summary>
     /// Builds a N1QL query request.
     /// </summary>
-    public class QueryRequest : IQueryRequest
+    public class QueryRequest : IQueryRequestWithDataMapper
     {
         private string _statement;
         private QueryPlan _preparedPayload;
@@ -115,6 +116,12 @@ namespace Couchbase.N1QL
         /// </summary>
         /// <value><c>true</c> if this instance has been retried once, otherwise <c>false</c>.</value>
         public bool HasBeenRetried { get; set; }
+
+        /// <summary>
+        /// Custom <see cref="IDataMapper"/> to use when deserializing query results.
+        /// </summary>
+        /// <remarks>Null will use the default <see cref="IDataMapper"/>.</remarks>
+        public IDataMapper DataMapper { get; set; }
 
         /// <summary>
         /// If set to false, the client will try to perform optimizations


### PR DESCRIPTION
Motivation
----------
The current ITypeSerializer implementation works under the assumption that
all serialization/deserialization requests should have the same behavior.
Any client library which implements a custom ITypeSerializer overrides
this behavior for all requests to Couchbase.

However, there are instances where a specific request may require custom
options.  The particular example addressed here is change tracking in the
Linq2Couchbase library.  It needs to control the object creation process
for some deserialization requests in order to create change tracking
proxies.

Additionally, we need a method for custom ITypeSerializer implementations
to provide member name resolution information to consumers.  This will
allow Linq2Couchbase to determine the correct attribute names to use when
building N1QL queries.  Currently, it is forced to assume that the
Newtonsoft.Json behavior is in use.

Finally, there is currently no method to override the deserialization
process for N1QL queries on a per-request basis.

Modifications
-------------
Created a new interface which extends ITypeSerializer named
IExtendedTypeSerializer.

Added GetMemberName method to IExtendedTypeSerializer, which provides
member name resolution information to consumers.

Added DeserializationOptions to IExtendedTypeSerializer, which allows
consumers to set the options they'd like.  Currently, this object supports
only one option, CustomTypeCreator, which allows the consumer to override
the type creation process on a type-by-type basis.

Also provided a SupportedDeserializationOptions object.  This allows the
IExtendedTypeSerializer to define which options it does or does not
support.

Updated the DefaultSerializer to support all of the new interfaces,
methods, and options provided.

Additionally, created a new interface IQueryRequestWithMapper, inherited
form IQueryRequest, which adds a DataMapper to IQueryRequest.  Added this
interface to the default QueryRequest implentation.  This allows the data
mapper used for N1QL queries can be customized on a per-request basis.

Results
-------
For users using the DefaultSerializer based on Newtonsoft.Json, they will
immediately have access to the new features on IExtendedTypeSerializer.
This includes a method to resolve member names, and the ability to
override the type creation process.  This will allow Linq2Couchbase to
transparently implement change tracking proxies.

For projects using a custom ITypeSerializer implementation, consumers such
as Linq2Couchbase can detect support for advanced features by testing for
the IExtendedTypeSerializer interface.  If present, they can then test for
specific features via the SupportedDeserializationOptions property.

Backwards compatibility is fully maintained by these changes.
Additionally, the use of SupportedDeserializationOptions will allow the
addition of more deserialization options in the future without creating
backwards compatibility issues.