### PR TITLE
Provide access to cluster from IBucket

### DIFF
--- a/Src/Couchbase.Tests/CouchbaseBucketTests.cs
+++ b/Src/Couchbase.Tests/CouchbaseBucketTests.cs
@@ -43,6 +43,15 @@ namespace Couchbase.Tests
         }
 
         [Test]
+        public void Test_GetBucket_HasCluster()
+        {
+            using (var bucket = _cluster.OpenBucket("default"))
+            {
+                Assert.AreEqual(_cluster, bucket.Cluster);
+            }
+        }
+
+        [Test]
         public void When_Key_Does_Not_Exist_Exists_Returns_False()
         {
             var key = "thekeythatdoesnotexists_perhaps";

--- a/Src/Couchbase/Cluster.cs
+++ b/Src/Couchbase/Cluster.cs
@@ -54,8 +54,13 @@ namespace Couchbase
         /// </summary>
         /// <param name="configuration">The ClientCOnfiguration to use for initialization.</param>
         public Cluster(ClientConfiguration configuration)
-            : this(configuration, new ClusterController(configuration))
         {
+            // can't use ": this(" to call the other constructor because we need to pass "this" to the ClusterController constructor
+            // so we have a bit of code duplication here
+
+            _configuration = configuration;
+            _clusterController = new ClusterController(this, configuration);
+            LogConfigurationAndVersion(_configuration);
         }
 
         /// <summary>

--- a/Src/Couchbase/ClusterHelper.cs
+++ b/Src/Couchbase/ClusterHelper.cs
@@ -192,7 +192,7 @@ namespace Couchbase
             }
 
             configuration.Initialize();
-            var factory = new Func<Cluster>(() => new Cluster(configuration, new ClusterController(configuration)));
+            var factory = new Func<Cluster>(() => new Cluster(configuration));
             Initialize(factory);
         }
 
@@ -220,7 +220,7 @@ namespace Couchbase
             var configuration = new ClientConfiguration(configurationSection);
             configuration.Initialize();
 
-            var factory = new Func<Cluster>(() => new Cluster(configuration, new ClusterController(configuration)));
+            var factory = new Func<Cluster>(() => new Cluster(configuration));
             Initialize(factory);
         }
 

--- a/Src/Couchbase/Core/ClusterController.cs
+++ b/Src/Couchbase/Core/ClusterController.cs
@@ -65,6 +65,12 @@ namespace Couchbase.Core
         {
         }
 
+        public ClusterController(ICluster cluster, ClientConfiguration clientConfig)
+            : this(clientConfig)
+        {
+            Cluster = cluster;
+        }
+
         public ClusterController(ClientConfiguration clientConfig, Func<IConnectionPool, IOStrategy> ioStrategyFactory)
             : this(clientConfig,
             ioStrategyFactory,
@@ -102,6 +108,8 @@ namespace Couchbase.Core
             Transcoder = transcoder;
             Initialize();
         }
+
+        public ICluster Cluster { get; private set; }
 
         public IByteConverter Converter { get; private set; }
 

--- a/Src/Couchbase/Core/IBucket.cs
+++ b/Src/Couchbase/Core/IBucket.cs
@@ -27,6 +27,11 @@ namespace Couchbase.Core
         Buckets.BucketTypeEnum BucketType { get; }
 
         /// <summary>
+        /// Returns the <see cref="ICluster"/> that this bucket belongs to
+        /// </summary>
+        ICluster Cluster { get; }
+
+        /// <summary>
         /// Checks for the existance of a given key.
         /// </summary>
         /// <param name="key">The key to check.</param>

--- a/Src/Couchbase/Core/IClusterController.cs
+++ b/Src/Couchbase/Core/IClusterController.cs
@@ -9,6 +9,8 @@ namespace Couchbase.Core
 {
     internal interface IClusterController : IConfigPublisher, IDisposable
     {
+        ICluster Cluster { get; }
+
         List<IConfigProvider> ConfigProviders { get; }
 
         ClientConfiguration Configuration { get; }

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -95,6 +95,14 @@ namespace Couchbase
         public string Name { get; set; }
 
         /// <summary>
+        /// Returns the <see cref="ICluster"/> that this bucket belongs to
+        /// </summary>
+        public ICluster Cluster
+        {
+            get { return _clusterController != null ? _clusterController.Cluster : null; }
+        }
+
+        /// <summary>
         /// Called when a configuration update has occurred from the server.
         /// </summary>
         /// <param name="configInfo">The new configuration</param>

--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -80,6 +80,14 @@ namespace Couchbase
         }
 
         /// <summary>
+        /// Returns the <see cref="ICluster"/> that this bucket belongs to
+        /// </summary>
+        public ICluster Cluster
+        {
+            get { return _clusterController != null ? _clusterController.Cluster : null; }
+        }
+
+        /// <summary>
         /// Returns true if bucket is using SSL encryption between the client and the server.
         /// </summary>
         /// <remarks>If the server is not available (<see cref="ServerUnavailableException"/>), will default to false.</remarks>


### PR DESCRIPTION
Motivation
----------
Some activites on a bucket might need to access information about the
cluster, such as the number of nodes, cluster status, etc.  Currently,
this information is unavailable from IBucket.

This is based on my own experience creating a set of reactive extensions
for Couchbase:
https://github.com/brantburnett/Rx-Couchbase/commit/99a1480e01f02897f2b404a62dbef11f9e26e31c#diff-d29a87c81f7ee323271660849b15521bR32
In this case it would be helpful to be able to adjust the degrees of
parallelism based on the total number of nodes in the cluster.

This is also based on a conversaion on the forums:
https://forums.couchbase.com/t/cluster-info-from-bucket/5476
In this case, the user was forced to use server info from configuration
only.  They didn't have access to all the servers in the cluster, only the
ones that were configured in advance.

Modifications
-------------
Added a new Cluster property to IBucket to reference the cluster the
bucket was created from.  To access this information easily, the internal
IClusterController interface was modified to include an ICluster property.

Modified the constructors for Cluster to automatically link the
ClusterController to the Cluster when the cluster is created, except in
some unit testing scenarios when the ClusterController is created first.

Also updated ClusterHelper to use the constructor which does this linking
automatically.

Created a test that confirms that the link is in place all the way from
Cluster through to the IBucket implementation.

Results
-------
Both the CouchbaseBucket and MemcachedBucket implementations now provide
easy access to their ICluster.