### PR TITLE
Use default server configuration when there is no bucket config

### DIFF
--- a/Src/Couchbase/Configuration/Server/Providers/ConfigProviderBase.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/ConfigProviderBase.cs
@@ -106,7 +106,10 @@ namespace Couchbase.Configuration.Server.Providers
                 {
                     bucketConfiguration = new BucketConfiguration
                     {
-                        BucketName = bucketName
+                        BucketName = bucketName,
+                        PoolConfiguration = ClientConfig.PoolConfiguration,
+                        Servers = ClientConfig.Servers,
+                        UseSsl = ClientConfig.UseSsl
                     };
                 }
                 else


### PR DESCRIPTION
If in the web.config `<couchbase>` section we only have a `<servers>` section, but no `<buckets>` section (because we don't want to statically configure any buckets), then when we try to open a bucket using its name, the client tries to use localhost:8091 instead of the server configured `<servers>`.  
The scenario is when our config looks like the following

    <couchbaseClients>
      <couchbase useSsl="false" operationLifespan="1000">
        <servers>
          <add uri="http://1.2.3.4:8091/pools"></add>
        </servers>
      </couchbase>
    </couchbaseClients>

This causes two problems.

- If we have no Couchbase server running at localhost:8091, opening the bucket can take seconds, because the client is trying to connect to localhost at first, and only after that fails does it connect to the configured server. This problem and a workaround is described in detail here: http://stackoverflow.com/questions/34183342/why-can-opening-a-couchbase-bucket-be-very-slow.
- If we actually do have a server at localhost:8091, then that is getting used instead of the one configured in `<servers>`. This is clearly a bug.

With this PR, when we get the configuration for a bucket, the server configuration is getting used even if there is no `<buckets>` section.