### PR TITLE
NCBC-1074: Prevent MVC deadlock on async view queries

### DIFF
--- a/Src/Couchbase.IntegrationTests/Couchbase.IntegrationTests.csproj
+++ b/Src/Couchbase.IntegrationTests/Couchbase.IntegrationTests.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CouchbaseBucket_KeyValue_Tests.cs" />
+    <Compile Include="CouchbaseBucket_ViewQuery_Tests.cs" />
     <Compile Include="CouchbaseBucket_Ssl_Tests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Src/Couchbase.IntegrationTests/CouchbaseBucket_ViewQuery_Tests.cs
+++ b/Src/Couchbase.IntegrationTests/CouchbaseBucket_ViewQuery_Tests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Couchbase.Core;
+using Couchbase.IO;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.IntegrationTests
+{
+    [TestFixture]
+    public class CouchbaseBucketViewQueryTests
+    {
+        private ICluster _cluster;
+        private IBucket _bucket;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _cluster = new Cluster(Utils.TestConfiguration.GetConfiguration("basic"));
+            _bucket = _cluster.OpenBucket();
+        }
+
+        [Test]
+        public void Test_QueryAsyncNoDeadlock()
+        {
+            // NCBC-1074 https://issues.couchbase.com/browse/NCBC-1074
+            // Using an asynchronous view query within an MVC Web API action causes
+            // a deadlock if you wait for the result synchronously.
+
+            var context = new Mock<SynchronizationContext>
+            {
+                CallBase = true
+            };
+
+            SynchronizationContext.SetSynchronizationContext(context.Object);
+            try
+            {
+                var query = _bucket.CreateQuery("beer", "brewery_beers")
+                    .Limit(1);
+
+                _bucket.QueryAsync<object>(query).Wait();
+
+                // If view queries are incorrectly awaiting on the current SynchronizationContext
+                // We will see calls to Post or Send on the mock
+
+                context.Verify(m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never);
+                context.Verify(m => m.Send(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+            }
+        }
+
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            _cluster.CloseBucket(_bucket);
+            _cluster.Dispose();
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase/Core/Buckets/CouchbaseRequestExecuter.cs
+++ b/Src/Couchbase/Core/Buckets/CouchbaseRequestExecuter.cs
@@ -626,7 +626,7 @@ namespace Couchbase.Core.Buckets
                     var task = RetryViewEveryAsync(async (e, c) =>
                     {
                         var server = c.GetViewNode();
-                        return await server.SendAsync<T>(query);
+                        return await server.SendAsync<T>(query).ContinueOnAnyContext();
                     },
                     query, ConfigInfo, cancellationTokenSource.Token).ConfigureAwait(false);
 


### PR DESCRIPTION
Motivation
----------
When working within MVC actions, executing an asynchronous view query and
then waiting for it to complete synchronously causes a deadlock.

Modifications
-------------
CouchbaseRequestExecutor for aysnchronous view queries needed an
additional call to ContinueOnAnyContext before an await.

Also created an integration test which successfully detects this problem
if it occurs in the future.

Results
-------
MVC actions no longer deadlock in this scenario.