### PR TITLE
Allow programmatically configure IO multiplexing

### DIFF
--- a/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
+++ b/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
@@ -462,7 +462,7 @@ namespace Couchbase.Configuration.Client
         /// The io service.
         /// </value>
         [JsonIgnore]
-        internal Func<IConnectionPool, IIOService> IOServiceCreator { get; set; }
+        public Func<IConnectionPool, IIOService> IOServiceCreator { get; set; }
 
         /// <summary>
         /// Gets or sets the connection pool creator.
@@ -471,7 +471,7 @@ namespace Couchbase.Configuration.Client
         /// The connection pool creator.
         /// </value>
         [JsonIgnore]
-        internal Func<PoolConfiguration, IPEndPoint, IConnectionPool> ConnectionPoolCreator { get; set; }
+        public Func<PoolConfiguration, IPEndPoint, IConnectionPool> ConnectionPoolCreator { get; set; }
 
         /// <summary>
         /// Gets or sets the create sasl mechanism.

--- a/Src/Couchbase/IO/Connection.cs
+++ b/Src/Couchbase/IO/Connection.cs
@@ -10,13 +10,13 @@ using Couchbase.Utils;
 
 namespace Couchbase.IO
 {
-    internal class Connection : ConnectionBase
+    public class Connection : ConnectionBase
     {
         private readonly SocketAsyncEventArgs _eventArgs;
         private readonly AutoResetEvent _requestCompleted = new AutoResetEvent(false);
         private readonly BufferAllocator _allocator;
 
-        public Connection(IConnectionPool connectionPool, Socket socket, IByteConverter converter, BufferAllocator allocator)
+        internal Connection(IConnectionPool connectionPool, Socket socket, IByteConverter converter, BufferAllocator allocator)
             : base(socket, converter)
         {
             ConnectionPool = connectionPool;

--- a/Src/Couchbase/IO/ConnectionBase.cs
+++ b/Src/Couchbase/IO/ConnectionBase.cs
@@ -11,7 +11,7 @@ using Couchbase.IO.Operations;
 
 namespace Couchbase.IO
 {
-    internal abstract class ConnectionBase : IConnection
+    public abstract class ConnectionBase : IConnection
     {
         protected readonly static ILog Log = LogManager.GetLogger<ConnectionBase>();
         protected readonly Guid _identity = Guid.NewGuid();
@@ -33,7 +33,7 @@ namespace Couchbase.IO
         {
         }
 
-        protected ConnectionBase(Socket socket, OperationAsyncState asyncState, IByteConverter converter, BufferManager bufferManager)
+        internal ConnectionBase(Socket socket, OperationAsyncState asyncState, IByteConverter converter, BufferManager bufferManager)
         {
             _socket = socket;
             _state = asyncState;
@@ -42,7 +42,7 @@ namespace Couchbase.IO
             EndPoint = socket.RemoteEndPoint;
         }
 
-        protected ConnectionBase(Socket socket, OperationAsyncState asyncState, IByteConverter converter, BufferManager bufferManager, IPEndPoint endPoint)
+        internal ConnectionBase(Socket socket, OperationAsyncState asyncState, IByteConverter converter, BufferManager bufferManager, IPEndPoint endPoint)
         {
             _socket = socket;
             _state = asyncState;
@@ -51,7 +51,7 @@ namespace Couchbase.IO
             EndPoint = endPoint;
         }
 
-        public OperationAsyncState State
+        internal OperationAsyncState State
         {
             get { return _state; }
         }

--- a/Src/Couchbase/IO/ConnectionPoolFactory.cs
+++ b/Src/Couchbase/IO/ConnectionPoolFactory.cs
@@ -8,7 +8,7 @@ namespace Couchbase.IO
     /// <summary>
     /// A factory creator for <see cref="IConnectionPool"/> instances.
     /// </summary>
-    internal class ConnectionPoolFactory
+    public class ConnectionPoolFactory
     {
         /// <summary>
         /// Gets the factory.
@@ -59,10 +59,6 @@ namespace Couchbase.IO
             return (config, endpoint) =>
             {
                 var type = typeof (T);
-                if (type == null)
-                {
-                    throw new TypeLoadException(string.Format("Could not create ConnectionPool from Factory.")  );
-                }
                 var connectionPool = (IConnectionPool)Activator.CreateInstance(type, config, endpoint);
                 return connectionPool;
             };

--- a/Src/Couchbase/IO/IOServiceFactory.cs
+++ b/Src/Couchbase/IO/IOServiceFactory.cs
@@ -8,7 +8,7 @@ namespace Couchbase.IO
     /// <summary>
     /// Contains Factory methods for creating <see cref="IIOService"/> implementations.
     /// </summary>
-    internal static class IOServiceFactory
+    public static class IOServiceFactory
     {
         /// <summary>
         /// Gets a <see cref="Func{IConnectionPool, IIOService}"/> that will create a <see cref="PooledIOService"/> instance.
@@ -44,10 +44,6 @@ namespace Couchbase.IO
             return (p) =>
             {
                 var type = typeof (T);
-                if (type == null)
-                {
-                    throw new TypeLoadException(string.Format("Could not create IIOService from factory."));
-                }
                 return (IIOService)Activator.CreateInstance(type, p);
             };
         }

--- a/Src/Couchbase/IO/MultiplexingConnection.cs
+++ b/Src/Couchbase/IO/MultiplexingConnection.cs
@@ -13,7 +13,7 @@ namespace Couchbase.IO
     /// <summary>
     /// Represents a connection for pipelining Memcached requests/responses to and from a server.
     /// </summary>
-    internal class MultiplexingConnection : ConnectionBase
+    public class MultiplexingConnection : ConnectionBase
     {
         private readonly ConcurrentDictionary<uint, IState> _statesInFlight;
         private readonly Queue<SyncState> _statePool;
@@ -22,7 +22,7 @@ namespace Couchbase.IO
         private byte[] _receiveBuffer;
         private int _receiveBufferLength;
 
-        public MultiplexingConnection(IConnectionPool connectionPool, Socket socket, IByteConverter converter,
+        internal MultiplexingConnection(IConnectionPool connectionPool, Socket socket, IByteConverter converter,
             BufferAllocator allocator)
             : base(socket, converter)
         {

--- a/Src/Couchbase/IO/Services/MultiplexingIOService.cs
+++ b/Src/Couchbase/IO/Services/MultiplexingIOService.cs
@@ -17,7 +17,7 @@ namespace Couchbase.IO.Services
     /// <summary>
     /// An IO service that dispatches without using a pool.
     /// </summary>
-    internal class MultiplexingIOService : IIOService
+    public class MultiplexingIOService : IIOService
     {
         private readonly static ILog Log = LogManager.GetLogger<MultiplexingIOService>();
         private readonly IConnectionPool _connectionPool;

--- a/Src/Couchbase/IO/Services/PooledIOService.cs
+++ b/Src/Couchbase/IO/Services/PooledIOService.cs
@@ -18,7 +18,7 @@ namespace Couchbase.IO.Services
     /// <summary>
     /// The default service for performing IO
     /// </summary>
-    internal class PooledIOService : IIOService
+    public class PooledIOService : IIOService
     {
         private readonly static ILog Log = LogManager.GetLogger<PooledIOService>();
         private readonly IConnectionPool _connectionPool;

--- a/Src/Couchbase/IO/SslConnection.cs
+++ b/Src/Couchbase/IO/SslConnection.cs
@@ -14,7 +14,7 @@ using Couchbase.Utils;
 
 namespace Couchbase.IO
 {
-    internal class SslConnection : ConnectionBase
+    public class SslConnection : ConnectionBase
     {
         private readonly SslStream _sslStream;
         private volatile bool _timingEnabled;


### PR DESCRIPTION
ClientConfiguration now exposes IOServiceCreator and ConnectionPoolCreator so the user can configure IO multiplexing in code. To do that access modifiers were changed from internal to public for given factories and related classes. Please consider if you want to keep some constructors public as they were before or change them to internal if you don't want to let the user explicitly create these classes without factory objects. Additionally removed dead code from factories because typeof(T) == null is always false.