### PR TITLE
CouchbaseBucket holds its own non-configurable ITypeTranscoder with a DefaultSerializer

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <solution>
-    <add key="disableSourceControlIntegration" value="true" />
-  </solution>
-</configuration>

--- a/src/Couchbase.Net35/Couchbase.Net35.csproj
+++ b/src/Couchbase.Net35/Couchbase.Net35.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\Couchbase\Extensions\UriExtensions.cs">
       <Link>Extensions\UriExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Couchbase\Extensions\SocketExtensions.cs">
+      <Link>Extensions\SocketExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Couchbase\Extensions\InterfaceContractResolver.cs">
       <Link>Extensions\InterfaceContractResolver.cs</Link>
     </Compile>

--- a/src/Couchbase.Net35/Couchbase.Net35.csproj
+++ b/src/Couchbase.Net35/Couchbase.Net35.csproj
@@ -57,6 +57,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Couchbase\Extensions\UriExtensions.cs">
+      <Link>Extensions\UriExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Couchbase\Extensions\InterfaceContractResolver.cs">
       <Link>Extensions\InterfaceContractResolver.cs</Link>
     </Compile>

--- a/src/Couchbase.Tests/App.config
+++ b/src/Couchbase.Tests/App.config
@@ -15,6 +15,8 @@
     <section name="httpclient-config-initconn" type="Couchbase.Configuration.CouchbaseClientSection, Couchbase" />
     <section name="httpclient-config-noinitconn" type="Couchbase.Configuration.CouchbaseClientSection, Couchbase" />
     <section name="bad-config" type="Couchbase.Configuration.CouchbaseClientSection, Couchbase" />
+    <section name="keep-alives-disabled" type="Couchbase.Configuration.CouchbaseClientSection, Couchbase" />
+    <section name="keep-alives-custom" type="Couchbase.Configuration.CouchbaseClientSection, Couchbase" />
     <!--
         Logger needs to be disabled until next NuGet push, which will start
         using the local, versioned and signed build of Enyim.Caching
@@ -146,4 +148,19 @@
       <add uri="http://badconfigdomain:8091/pools" />
     </servers>
   </bad-config>
+
+  <keep-alives-disabled>
+    <servers bucket="default">
+      <add uri="http://localhost:8091/pools" />
+    </servers>
+    <socketPool enableTcpKeepAlives="false" />
+  </keep-alives-disabled>
+
+  <keep-alives-custom>
+    <servers bucket="default">
+      <add uri="http://localhost:8091/pools" />
+    </servers>
+    <socketPool enableTcpKeepAlives="true" tcpKeepAliveTime="60000"  tcpKeepAliveInterval="10000" />
+  </keep-alives-custom>
+
 </configuration>

--- a/src/Couchbase.Tests/CouchbaseClientStoreTests.cs
+++ b/src/Couchbase.Tests/CouchbaseClientStoreTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Couchbase.Tests.Utils;
 using NUnit.Framework;
 using Enyim.Caching.Memcached;
@@ -132,6 +133,24 @@ namespace Couchbase.Tests
             var result2 = TestUtils.Store(Client, TimeSpan.FromSeconds(ttl), StoreMode.Add, "key_ttl_test", document);
             TestUtils.StoreAssertPass(result1);
             TestUtils.StoreAssertPass(result2);
+        }
+
+        [Test]
+        public void Store()
+        {
+            using (var client = new CouchbaseClient())
+            {
+                var result1 = client.ExecuteStore(StoreMode.Set, "a", 1, DateTime.UtcNow.AddMilliseconds(500));
+                var result2 = client.ExecuteStore(StoreMode.Set, "b", 1, TimeSpan.FromMilliseconds(500));
+
+                Assert.IsTrue(client.ExecuteGet("a").Success);
+                Assert.IsTrue(client.ExecuteGet("b").Success);
+
+                Thread.Sleep(2000);
+
+                Assert.IsFalse(client.ExecuteGet("a").Success);
+                Assert.IsFalse(client.ExecuteGet("b").Success);
+            }
         }
     }
 }

--- a/src/Couchbase.Tests/CouchbaseClientViewPagingTests.cs
+++ b/src/Couchbase.Tests/CouchbaseClientViewPagingTests.cs
@@ -49,6 +49,13 @@ namespace Couchbase.Tests
             testPageSizes(view);
         }
 
+        [Test]
+        public void When_PageSize_Is_Greater_Than_Number_Of_Items_MoveNext_Returns_True()
+        {
+            var view = Client.GetView<City>("cities", "by_name", true).GetPagedView(1000, "Id", "Name");
+            Assert.IsTrue(view.MoveNext());
+        }
+
         /// <summary>
         /// @test: Get view results with generic type, key and id are set, paging view count is correct
         /// @pre: Default configuration to initialize client in app.config, configure view name 'by_name' with design name 'cities'

--- a/src/Couchbase.Tests/DefaultCouchbaseClientConfigurationTests.cs
+++ b/src/Couchbase.Tests/DefaultCouchbaseClientConfigurationTests.cs
@@ -226,6 +226,33 @@ namespace Couchbase.Tests
             Assert.That(config.Servers.ObserveTimeout, Is.EqualTo(TimeSpan.FromSeconds(30)));
         }
 
+        [Test]
+        public void When_EnableTcpKeepAlives_Is_Not_Set_The_Defaults_Are_Used()
+        {
+            var config = new CouchbaseClientConfiguration();
+            Assert.IsTrue(config.SocketPool.EnableTcpKeepAlives);
+            Assert.AreEqual(2*60*60*1000, config.SocketPool.TcpKeepAliveTime);
+            Assert.AreEqual(1000, config.SocketPool.TcpKeepAliveInterval);
+        }
+
+        [Test]
+        public void When_EnableTcpKeepAlives_Is_False_In_AppConfig_The_EnableTcpKeepAlive_Is_Disabled()
+        {
+            var config = ConfigurationManager.GetSection("keep-alives-disabled") as CouchbaseClientSection;
+            Assert.IsFalse(config.SocketPool.EnableTcpKeepAlives);
+            Assert.AreEqual(2 * 60 * 60 * 1000, config.SocketPool.TcpKeepAliveTime);
+            Assert.AreEqual(1000, config.SocketPool.TcpKeepAliveInterval);
+        }
+
+        [Test]
+        public void When_EnableTcpKeepAlives_Is_True_In_AppConfig_The_EnableTcpKeepAlive_Is_Enabled()
+        {
+            var config = ConfigurationManager.GetSection("keep-alives-custom") as CouchbaseClientSection;
+            Assert.IsTrue(config.SocketPool.EnableTcpKeepAlives);
+            Assert.AreEqual(60000, config.SocketPool.TcpKeepAliveTime);
+            Assert.AreEqual(10000, config.SocketPool.TcpKeepAliveInterval);
+        }
+
         #endregion
 
         #region HttpClient

--- a/src/Couchbase/Configuration/CouchbaseClientConfiguration.cs
+++ b/src/Couchbase/Configuration/CouchbaseClientConfiguration.cs
@@ -423,6 +423,9 @@ namespace Couchbase.Configuration
                 this.fpf = original.FailurePolicyFactory;
                 _lingerTime = original.LingerTime;
                 _lingerEnabled = original.LingerEnabled;
+                EnableTcpKeepAlives = original.EnableTcpKeepAlives;
+                TcpKeepAliveInterval = original.TcpKeepAliveInterval;
+                TcpKeepAliveTime = original.TcpKeepAliveTime;
             }
 
             int ISocketPoolConfiguration.MinPoolSize { get { return this.minPoolSize; } set { } }
@@ -451,6 +454,32 @@ namespace Couchbase.Configuration
                 get { return _lingerEnabled; }
                 set { _lingerEnabled = value; }
             }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether enable TCP keep alives.
+            /// </summary>
+            /// <value>
+            /// <c>true</c> to enable TCP keep alives; otherwise, <c>false</c>.
+            /// </value>
+            public bool EnableTcpKeepAlives { get; set; }
+
+            /// <summary>
+            /// Specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent.
+            /// </summary>
+            /// <value>
+            /// The TCP keep alive time in milliseconds.
+            /// </value>
+            /// <remarks>The default is 2hrs.</remarks>
+            public uint TcpKeepAliveTime { get; set; }
+
+            /// <summary>
+            /// Specifies the interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
+            /// </summary>
+            /// <value>
+            /// The TCP keep alive interval in milliseconds..
+            /// </value>
+            /// <remarks>The default is 1 second.</remarks>
+            public uint TcpKeepAliveInterval { get; set; }
         }
 
         private class HBM : IHeartbeatMonitorConfiguration

--- a/src/Couchbase/Couchbase.csproj
+++ b/src/Couchbase/Couchbase.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Extensions\CouchbaseClientExtensions.cs" />
     <Compile Include="Extensions\CouchbaseClientConfigurationExtensions.cs" />
     <Compile Include="Extensions\InterfaceContractResolver.cs" />
+    <Compile Include="Extensions\SocketExtensions.cs" />
     <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="GenericViewRowTransformer.cs" />
     <Compile Include="Helpers\DocHelper.cs" />

--- a/src/Couchbase/Couchbase.csproj
+++ b/src/Couchbase/Couchbase.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Extensions\CouchbaseClientExtensions.cs" />
     <Compile Include="Extensions\CouchbaseClientConfigurationExtensions.cs" />
     <Compile Include="Extensions\InterfaceContractResolver.cs" />
+    <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="GenericViewRowTransformer.cs" />
     <Compile Include="Helpers\DocHelper.cs" />
     <Compile Include="Helpers\JsonHelper.cs" />

--- a/src/Couchbase/CouchbaseClient.cs
+++ b/src/Couchbase/CouchbaseClient.cs
@@ -669,7 +669,7 @@ namespace Couchbase
         /// <returns></returns>
         public CasResult<T> GetWithLock<T>(string key)
         {
-            return GetWithLock<T>(key, TimeSpan.Zero);
+            return GetWithLock<T>(key, TimeSpan.FromSeconds(15));
         }
 
         /// <summary>

--- a/src/Couchbase/CouchbasePool.cs
+++ b/src/Couchbase/CouchbasePool.cs
@@ -4,11 +4,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using Couchbase.Extensions;
 using Couchbase.Management;
 using Enyim.Caching.Configuration;
 using Enyim.Caching.Memcached;
 using Enyim.Caching.Memcached.Protocol.Binary;
 using Couchbase.Configuration;
+using Couchbase.Extensions;
 
 namespace Couchbase
 {
@@ -323,7 +325,10 @@ namespace Couchbase
                 return new CouchbaseNode(endpoint, configuration.SocketPool, auth);
             }
 
-            return new CouchbaseNode(endpoint, new Uri(couchApiBase), this.configuration, auth);
+            //Create URI and enable iriParsing per: https://connect.microsoft.com/VisualStudio/feedback/details/758479/system-uri-tostring-behaviour-change
+            var uri = new Uri(couchApiBase);
+            uri.EnableIriParsing(true);
+            return new CouchbaseNode(endpoint, uri, this.configuration, auth);
         }
 
         void IDisposable.Dispose()

--- a/src/Couchbase/CouchbasePool.cs
+++ b/src/Couchbase/CouchbasePool.cs
@@ -99,7 +99,7 @@ namespace Couchbase
 
         private void InitNodes(ClusterConfig config)
         {
-            if (log.IsInfoEnabled) log.Info("Received new configuration.");
+            if (log.IsDebugEnabled) log.DebugFormat("Received new configuration.");
 
             // we cannot overwrite the config while the timer is is running
             lock (_syncObj)
@@ -125,7 +125,7 @@ namespace Couchbase
 
             if (config == null)
             {
-                if (log.IsInfoEnabled) log.Info("Config is empty, all nodes are down.");
+                if (log.IsDebugEnabled) log.DebugFormat("Config is empty, all nodes are down.");
                 return; //continue to use current state and wait for config update
             }
 
@@ -215,7 +215,7 @@ namespace Couchbase
             // so we we'll use this for initializing the locator
             var vbsm = config.vBucketServerMap;
 
-            if (log.IsInfoEnabled) log.Info("Has vbucket. Server count: " + (vbsm.serverList == null ? 0 : vbsm.serverList.Length));
+            if (log.IsDebugEnabled) log.DebugFormat("Has vbucket. Server count: " + (vbsm.serverList == null ? 0 : vbsm.serverList.Length));
 
             // parse the ip addresses of the servers in the vbucket map
             // make sure we have a proper vbucket map
@@ -270,7 +270,7 @@ namespace Couchbase
 
         private InternalState InitBasic(ClusterConfig config, ISaslAuthenticationProvider auth)
         {
-            if (log.IsInfoEnabled) log.Info("No vbucket. Server count: " + (config.nodes == null ? 0 : config.nodes.Length));
+            if (log.IsDebugEnabled) log.DebugFormat("No vbucket. Server count: " + (config.nodes == null ? 0 : config.nodes.Length));
 
             // the cluster can return host names in the server list, so
             // we ha ve to make sure they are converted to IP addresses

--- a/src/Couchbase/CouchbasePool.cs
+++ b/src/Couchbase/CouchbasePool.cs
@@ -327,7 +327,15 @@ namespace Couchbase
 
             //Create URI and enable iriParsing per: https://connect.microsoft.com/VisualStudio/feedback/details/758479/system-uri-tostring-behaviour-change
             var uri = new Uri(couchApiBase);
-            uri.EnableIriParsing(true);
+
+            try
+            {
+                uri.EnableIriParsing(true);
+            }
+            catch (Exception e)
+            {
+                log.Warn("IriParsing not supported", e);
+            }
             return new CouchbaseNode(endpoint, uri, this.configuration, auth);
         }
 

--- a/src/Couchbase/CouchbasePooledSocket.cs
+++ b/src/Couchbase/CouchbasePooledSocket.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using Enyim.Caching.Memcached;
 
@@ -159,7 +160,36 @@ namespace Couchbase
 
         public void Reset()
         {
-            throw new NotImplementedException();
+            // discard any buffered data
+            _stream.Flush();
+
+            if (_helper2 != null) _helper2.DiscardBuffer();
+
+            int available = _socket.Available;
+
+            if (available > 0)
+            {
+                if (Log.IsWarnEnabled)
+                {
+                    Log.WarnFormat(
+                        "Socket bound to {0} has {1} unread data! This is probably a bug in the code. InstanceID was {2}.",
+                        _socket.RemoteEndPoint, available, this.InstanceId);
+                }
+
+                byte[] data = new byte[available];
+
+                Read(data, 0, available);
+
+                if (Log.IsWarnEnabled)
+                {
+                    Log.Warn(Encoding.ASCII.GetString(data));
+                }
+            }
+
+            if (Log.IsDebugEnabled)
+            {
+                Log.DebugFormat("Socket {0} was reset", this.InstanceId);
+            }
         }
 
         [Obsolete("Will be removed in later versions")]

--- a/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
+++ b/src/Couchbase/Extensions/CouchbaseClientExtensions.cs
@@ -150,7 +150,7 @@ namespace Couchbase.Extensions
             {
                 value = DocHelper.InsertId(value, key);
             }
-            return JsonConvert.DeserializeObject<T>(value);
+            return JsonConvert.DeserializeObject<T>(value, JsonSerializerSettings);
         }
 
         private static string SerializeObject(object value)

--- a/src/Couchbase/Extensions/SocketExtensions.cs
+++ b/src/Couchbase/Extensions/SocketExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Couchbase.Extensions
+{
+    public static  class SocketExtensions
+    {
+        /// <summary>
+        /// Enable TCP keep-alives, the time and interval on a managed Socket.
+        /// </summary>
+        /// <param name="socket">The socket to enable keep-alives on.</param>
+        /// <param name="on">if set to <c>true</c> keep-alives are enabled; false to disable.</param>
+        /// <param name="time">The duration between two keepalive transmissions in idle condition.</param>
+        /// <param name="interval">The duration between two successive keepalive retransmissions, if acknowledgement to the previous keepalive transmission is not received.</param>
+        /// <remarks>Credit: <see href="http://blogs.msdn.com/b/lcleeton/archive/2006/09/15/754932.aspx"/></remarks>
+        public static void SetKeepAlives(this Socket socket, bool on, uint time, uint interval)
+        {
+            const uint temp = 0;
+            var values = new byte[Marshal.SizeOf(temp) * 3];
+            BitConverter.GetBytes((uint)(on ? 1 : 0)).CopyTo(values, 0);
+            BitConverter.GetBytes(time).CopyTo(values, Marshal.SizeOf(temp));
+            BitConverter.GetBytes(interval).CopyTo(values, Marshal.SizeOf(temp) * 2);
+            socket.IOControl(IOControlCode.KeepAliveValues, values, null);
+        }
+    }
+}

--- a/src/Couchbase/Extensions/UriExtensions.cs
+++ b/src/Couchbase/Extensions/UriExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Couchbase.Extensions
+{
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Enables IRI parsing: https://connect.microsoft.com/VisualStudio/feedback/details/758479/system-uri-tostring-behaviour-change
+        /// Note that this only applies to .NET versions before 4.5
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="enable"></param>
+        public static void EnableIriParsing(this Uri uri, bool enable)
+        {
+            //Imp: initialize internal static field s_IriParsing once
+            Uri.IsWellFormedUriString("http://microsoft.com/", UriKind.Absolute);
+
+            var assembly = Assembly.GetAssembly(uri.GetType());
+            if (assembly != null)
+            {
+                var uriType = assembly.GetType("System.Uri");
+                var iriParsing = uriType.InvokeMember("s_IriParsing", BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic, null, null, new object[] { });
+                if (iriParsing != null)
+                {
+                    uriType.InvokeMember("s_IriParsing", BindingFlags.Static | BindingFlags.SetField | BindingFlags.NonPublic, null, null, new object[] { enable });
+                }
+            }
+        }
+    }
+}

--- a/src/Couchbase/PagedView.cs
+++ b/src/Couchbase/PagedView.cs
@@ -52,7 +52,7 @@ namespace Couchbase
                 this.nextKey = pageInfo.LastKey;
                 this.state = 1;
 
-                return this.nextId != null;
+                return this.items.Count > 0;
             }
 
             // can't go further

--- a/src/Couchbase/SocketPool.cs
+++ b/src/Couchbase/SocketPool.cs
@@ -265,7 +265,7 @@ namespace Couchbase
                         {
                             if (Log.IsInfoEnabled)
                             {
-                                Log.InfoFormat("Gracefully closing {0} on server {1}", socket.InstanceId, _node.EndPoint);
+                                Log.DebugFormat("Gracefully closing {0} on server {1}", socket.InstanceId, _node.EndPoint);
                             }
                             socket.Close();
                             itemsDisposed++;
@@ -280,12 +280,12 @@ namespace Couchbase
                         {
                             if (Log.IsInfoEnabled)
                             {
-                                Log.InfoFormat("Force closing {0} on server {1}", socket.InstanceId, _node.EndPoint);
+                                Log.DebugFormat("Force closing {0} on server {1}", socket.InstanceId, _node.EndPoint);
                             }
                             socket.Close();
                             if (Log.IsInfoEnabled)
                             {
-                                Log.InfoFormat("Force closed {0} on server {1}", socket.InstanceId, _node.EndPoint);
+                                Log.DebugFormat("Force closed {0} on server {1}", socket.InstanceId, _node.EndPoint);
                             }
                             itemsDisposed++;
                         }
@@ -309,7 +309,7 @@ namespace Couchbase
         {
             if(Log.IsDebugEnabled)
             {
-                Log.InfoFormat("Finalizing {0}", GetType().Name);
+                Log.DebugFormat("Finalizing {0}", GetType().Name);
             }
             Dispose(false);
         }

--- a/src/Couchbase/SocketPool.cs
+++ b/src/Couchbase/SocketPool.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Collections;
 using Couchbase.Exceptions;
+using Couchbase.Extensions;
 using Enyim.Caching;
 using Enyim.Caching.Configuration;
 using Enyim.Caching.Memcached;
@@ -64,8 +65,6 @@ namespace Couchbase
                 SendTimeout = (int)_config.ReceiveTimeout.TotalMilliseconds,
                 NoDelay = true
             };
-
-            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, (int)_config.ReceiveTimeout.TotalMilliseconds);
 
             if (_config.LingerEnabled)
@@ -74,6 +73,12 @@ namespace Couchbase
                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, lingerOptions);
             }
             socket.Connect(_node.EndPoint);
+            if (_config.EnableTcpKeepAlives)
+            {
+                socket.SetKeepAlives(_config.EnableTcpKeepAlives,
+                    _config.TcpKeepAliveTime,
+                    _config.TcpKeepAliveInterval);
+            }
 
             var pooledSocket = new CouchbasePooledSocket(this, socket);
             if (_provider != null && !Authenticate(pooledSocket))

--- a/src/Couchbase/SocketPool.cs
+++ b/src/Couchbase/SocketPool.cs
@@ -150,6 +150,10 @@ namespace Couchbase
                 {
                     socket = _queue.Dequeue();
                     socket.IsInUse = true;
+                    if (socket.IsAlive)
+                    {
+                        socket.Reset();
+                    }
                 }
                 catch (InvalidOperationException e)
                 {

--- a/src/Enyim.Caching/Configuration/ISocketPoolConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/ISocketPoolConfiguration.cs
@@ -79,6 +79,32 @@ namespace Enyim.Caching.Configuration
         bool LingerEnabled { get; set; }
 
         INodeFailurePolicyFactory FailurePolicyFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enable TCP keep alives.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to enable TCP keep alives; otherwise, <c>false</c>.
+        /// </value>
+        bool EnableTcpKeepAlives { get; set; }
+
+        /// <summary>
+        /// Specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive time in milliseconds.
+        /// </value>
+        /// <remarks>The default is 2hrs.</remarks>
+        uint TcpKeepAliveTime { get; set; }
+
+        /// <summary>
+        /// Specifies the interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive interval in milliseconds..
+        /// </value>
+        /// <remarks>The default is 1 second.</remarks>
+        uint TcpKeepAliveInterval { get; set; }
     }
 }
 

--- a/src/Enyim.Caching/Configuration/SocketPoolConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/SocketPoolConfiguration.cs
@@ -18,6 +18,13 @@ namespace Enyim.Caching.Configuration
         private bool _lingerEnabled = false;
         private TimeSpan _lingerTime = new TimeSpan(0, 0, 10);
 
+        public SocketPoolConfiguration()
+        {
+            EnableTcpKeepAlives = true;
+            TcpKeepAliveTime = (uint) 2*60*60*1000;
+            TcpKeepAliveInterval = ((uint) 1000);
+        }
+
         int ISocketPoolConfiguration.MinPoolSize
         {
             get { return this.minPoolSize; }
@@ -128,6 +135,32 @@ namespace Enyim.Caching.Configuration
             get { return _lingerEnabled; }
             set { _lingerEnabled = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enable TCP keep alives.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to enable TCP keep alives; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableTcpKeepAlives { get; set; }
+
+        /// <summary>
+        /// Specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive time in milliseconds.
+        /// </value>
+        /// <remarks>The default is 2hrs.</remarks>
+        public uint TcpKeepAliveTime { get; set; }
+
+        /// <summary>
+        /// Specifies the interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive interval in milliseconds..
+        /// </value>
+        /// <remarks>The default is 1 second.</remarks>
+        public uint TcpKeepAliveInterval { get; set; }
     }
 }
 

--- a/src/Enyim.Caching/Configuration/SocketPoolElement.cs
+++ b/src/Enyim.Caching/Configuration/SocketPoolElement.cs
@@ -154,6 +154,48 @@ namespace Enyim.Caching.Configuration
             get { return (bool)base["lingerEnabled"]; }
             set { base["lingerEnabled"] = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enable TCP keep alives.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to enable TCP keep alives; otherwise, <c>false</c>.
+        /// </value>
+        /// <remarks>The default is true; TCP Keep Alives are enabled.</remarks>
+        [ConfigurationProperty("enableTcpKeepAlives", DefaultValue = true, IsRequired = false)]
+        public bool EnableTcpKeepAlives
+        {
+            get { return (bool)this["enableTcpKeepAlives"]; }
+            set { this["enableTcpKeepAlives"] = value; }
+        }
+
+        /// <summary>
+        /// Specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive time in milliseconds.
+        /// </value>
+        /// <remarks>The default is 2hrs.</remarks>
+        [ConfigurationProperty("tcpKeepAliveTime", DefaultValue = ((uint)2 * 60 * 60 * 1000), IsRequired = false)]
+        public uint TcpKeepAliveTime
+        {
+            get { return (uint)this["tcpKeepAliveTime"]; }
+            set { this["tcpKeepAliveTime"] = value; }
+        }
+
+        /// <summary>
+        /// Specifies the interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
+        /// </summary>
+        /// <value>
+        /// The TCP keep alive interval in milliseconds..
+        /// </value>
+        /// <remarks>The default is 1 second.</remarks>
+        [ConfigurationProperty("tcpKeepAliveInterval", DefaultValue = ((uint)1000), IsRequired = false)]
+        public uint TcpKeepAliveInterval
+        {
+            get { return (uint)this["tcpKeepAliveInterval"]; }
+            set { this["tcpKeepAliveInterval"] = value; }
+        }
     }
 }
 

--- a/src/Enyim.Caching/Memcached/Locators/KetamaNodeLocator.cs
+++ b/src/Enyim.Caching/Memcached/Locators/KetamaNodeLocator.cs
@@ -112,21 +112,23 @@ namespace Enyim.Caching.Memcached
 
         private uint GetKeyHash(string key)
         {
-            var hashAlgo = this.factory();
-            var uintHash = hashAlgo as IUIntHashAlgorithm;
-
-            var keyData = Encoding.UTF8.GetBytes(key);
-
-            // shortcut for internal hash algorithms
-            if (uintHash == null)
+            using (var hashAlgo = this.factory())
             {
-                var data = hashAlgo.ComputeHash(keyData);
+                var uintHash = hashAlgo as IUIntHashAlgorithm;
 
-                return ((uint)data[3] << 24) | ((uint)data[2] << 16) | ((uint)data[1] << 8) | ((uint)data[0]);
-            }
-            else
-            {
-                return uintHash.ComputeHash(keyData);
+                var keyData = Encoding.UTF8.GetBytes(key);
+
+                // shortcut for internal hash algorithms
+                if (uintHash == null)
+                {
+                    var data = hashAlgo.ComputeHash(keyData);
+
+                    return ((uint) data[3] << 24) | ((uint) data[2] << 16) | ((uint) data[1] << 8) | ((uint) data[0]);
+                }
+                else
+                {
+                    return uintHash.ComputeHash(keyData);
+                }
             }
         }
 

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/MultiGetOperation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/MultiGetOperation.cs
@@ -180,9 +180,10 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
                 this.result[key] = new CacheItem((ushort)flags, response.Data);
                 this.Cas[key] = response.CAS;
             }
-
+            result.StatusCode = response.StatusCode;
             // finished reading but we did not find the NOOP
-            return result.Fail("Found response with CorrelationId {0}, but no key is matching it.");
+            return result.Fail(String.Format("Found response with CorrelationId {0}, but no key is matching it. Status {1}",
+                                              response.CorrelationId, response.StatusCode));
         }
 
         public Dictionary<string, CacheItem> Result

--- a/src/Enyim.Caching/MemcachedClient.cs
+++ b/src/Enyim.Caching/MemcachedClient.cs
@@ -1042,8 +1042,8 @@ namespace Enyim.Caching
                 // infinity
                 if (validFor == TimeSpan.Zero || validFor == TimeSpan.MaxValue) return 0;
 
-                // NCBC-485 send small TTLs (less than 30 days) in seconds, not EPOCH.
-                if(validFor < TimeSpan.FromSeconds(((60*60) * 24)*30))
+                // NCBC-485 & NCBC-643 send small TTLs (less than 30 days) in seconds, not EPOCH.
+                if (TimeSpan.FromSeconds(1) <= validFor && validFor < TimeSpan.FromSeconds(((60 * 60) * 24) * 30))
                 {
                     return (uint)validFor.GetValueOrDefault().TotalSeconds;
                 }


### PR DESCRIPTION
When using a custom `ITypeSerializer`, for example in order to add a custom JSON converter, it may not be used by certain methods of `CouchbaseBucket`, like `GetAsync<T>(key)` .

So, while the method `QueryAsync<T>(queryRequest)` ends up using the correct, configured ITypeSerializer, this is ignored by the method `GetAsync<T>(key)`.

In my codebase I horribly solved this with reflection after every creation of a bucket instance:
```
                                var bucket = _cluster.OpenBucket(bucketName);
				var transcoder = bucket.GetType().GetField("_transcoder", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(bucket);
				var serializer = (DefaultSerializer)((DefaultTranscoder)transcoder).Serializer;
				serializer.DeserializationSettings.Converters.Add(new SerializableAbstractTypeConverter());
```