### PR TITLE
Checking 'Errors' list property in QueryResult's ToString() method to avoid NRE

### DIFF
--- a/Src/Couchbase/N1QL/QueryResult.cs
+++ b/Src/Couchbase/N1QL/QueryResult.cs
@@ -154,9 +154,12 @@ namespace Couchbase.N1QL
             var sb = new StringBuilder();
             sb.AppendFormat("ClientContextId: {0}", ClientContextId);
             sb.AppendFormat("Message: {0}", Message);
-            foreach (var error in Errors)
+            if (Errors != null)
             {
-                sb.AppendFormat("Error: {0} {1}", error.Code, error.Message);
+                foreach (var error in Errors)
+                {
+                    sb.AppendFormat("Error: {0} {1}", error.Code, error.Message);
+                }
             }
             return sb.ToString();
         }


### PR DESCRIPTION
The 'Errors' field is initialized with an empty List in the QueryResult constructor but it can be null once mapped elsewhere.

For instance in Couchbase\N1QL\QueryClient.cs, l.387 :
**queryResult = GetDataMapper(queryRequest).Map<QueryResult<T>>(response);**

If no errors are in the _response_, depending on the deserialization settings, the 'Errors' property of the QueryResult object can be set to null, hence resulting in a null ref exception during the following ToString() method.

That's a case we encountered in my company.