### PR TITLE
breaking ViewResult dependency with Newtonsoft

### DIFF
--- a/Src/Couchbase.Tests/Couchbase.Tests.csproj
+++ b/Src/Couchbase.Tests/Couchbase.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Core\LifespanTests.cs" />
     <Compile Include="CouchbaseBucket_SpatialViewTests.cs" />
     <Compile Include="GlobalSetup.cs" />
+    <Compile Include="N1QL\QueryResponseTests.cs" />
     <Compile Include="ResourceHelper.cs" />
     <Compile Include="N1QL\QueryTimerTests.cs" />
     <Compile Include="Utils\ClientConfigUtil.cs" />
@@ -195,6 +196,7 @@
     <Compile Include="Views\SpatialViewQueryTests.cs" />
     <Compile Include="Views\ViewClientTests.cs" />
     <Compile Include="Views\ViewQueryTests.cs" />
+    <Compile Include="Views\ViewResultTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/Src/Couchbase.Tests/N1QL/QueryResponseTests.cs
+++ b/Src/Couchbase.Tests/N1QL/QueryResponseTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.N1QL;
+using NUnit.Framework;
+
+namespace Couchbase.Tests.N1QL
+{
+    [TestFixture]
+    public class QueryResponseTests
+    {
+        [Test]
+        public void Test_Query_Result_Data_Set()
+        {
+            var resultData = new QueryResultData<dynamic>
+            {
+                requestID = Guid.NewGuid(),
+                clientContextID = "clientContextTestId",
+                signature = "testSignature",
+                results = new dynamic[] {"{'testresult':'testresultvalue'}"},
+                status = QueryStatus.Completed,
+                errors = new[] {new ErrorData {code = 1, msg = "testMsg", name = "testName", sev = Severity.None, temp = true}},
+                warnings = new[] {new WarningData {code = 2, msg = "testWarningMsg"}},
+                metrics =
+                    new MetricsData
+                    {
+                        elapsedTime = "testElapsedTime",
+                        errorCount = 0,
+                        executionTime = "testExecutionTime",
+                        mutationCount = 1,
+                        resultCount = 2,
+                        resultSize = 3,
+                        sortCount = 4,
+                        warningCount = 5
+                    },
+            };
+
+            var result = resultData.ToQueryResult();
+
+            Assert.AreEqual(result.RequestId, resultData.requestID);
+            Assert.AreEqual(result.ClientContextId, resultData.clientContextID);
+            Assert.AreEqual(result.Signature, resultData.signature);
+            Assert.AreEqual(result.Rows.Count, resultData.results.Count());
+            Assert.IsTrue(result.Rows.All(r => resultData.results.Any(rd => r == rd)));
+            Assert.AreEqual(result.Status, resultData.status);
+            Assert.AreEqual(result.Errors.Count, resultData.errors.Count());
+            Assert.IsTrue(
+                result.Errors.All(
+                    e =>
+                        resultData.errors.Any(
+                            ed =>
+                                e.Temp == ed.temp && e.Code == ed.code && e.Message == ed.msg && e.Name == ed.name &&
+                                e.Severity == ed.sev)));
+            Assert.AreEqual(result.Warnings.Count, resultData.warnings.Count());
+            Assert.IsTrue(result.Warnings.All(w => resultData.warnings.Any(wd => w.Code == wd.code && w.Message == wd.msg)));
+            Assert.AreEqual(result.Metrics.ElaspedTime, resultData.metrics.elapsedTime);
+            Assert.AreEqual(result.Metrics.ErrorCount, resultData.metrics.errorCount);
+            Assert.AreEqual(result.Metrics.ExecutionTime, resultData.metrics.executionTime);
+            Assert.AreEqual(result.Metrics.MutationCount, resultData.metrics.mutationCount);
+            Assert.AreEqual(result.Metrics.ResultCount, resultData.metrics.resultCount);
+            Assert.AreEqual(result.Metrics.ResultSize, resultData.metrics.resultSize);
+            Assert.AreEqual(result.Metrics.SortCount, resultData.metrics.sortCount);
+            Assert.AreEqual(result.Metrics.WarningCount, resultData.metrics.warningCount);
+        }
+    }
+}

--- a/Src/Couchbase.Tests/Views/ViewResultTests.cs
+++ b/Src/Couchbase.Tests/Views/ViewResultTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Couchbase.Views;
+
+namespace Couchbase.Tests.Views
+{
+    [TestFixture]
+    public class ViewResultTests
+    {
+        [Test]
+        public void Test_View_Result_Data_Set()
+        {
+            var resultData = new ViewResultData<dynamic>
+            {
+                error = "testError",
+                reason = "testReason",
+                total_rows = 1,
+                rows = new []{new ViewRowData<dynamic> { id = "testViewRowId", key = "testKey", geometry = "testGeometry", value = "testValue"} },
+            };
+
+            var result = resultData.ToViewResult();
+
+            Assert.AreEqual(result.Error, resultData.error);
+            Assert.AreEqual(result.Message, resultData.reason);
+            Assert.AreEqual(result.TotalRows, resultData.total_rows);
+            Assert.AreEqual(result.Rows.Count(), resultData.rows.Count());
+            Assert.IsTrue(
+                result.Rows.All(
+                    r =>
+                        resultData.rows.Any(
+                            rd => r.Id == rd.id && r.Key == rd.key && r.Geometry == rd.geometry && r.Value == rd.value)));
+        }
+    }
+}

--- a/Src/Couchbase/N1QL/Error.cs
+++ b/Src/Couchbase/N1QL/Error.cs
@@ -3,22 +3,37 @@ using System.Runtime.Serialization;
 
 namespace Couchbase.N1QL
 {
-    [DataContract]
     public class Error
     {
-        [DataMember(Name = "msg")]
         public string Message { get; set; }
 
-        [DataMember(Name = "code")]
         public int Code { get; set; }
 
-        [DataMember(Name = "name")]
         public string Name { get; set; }
 
-        [DataMember(Name = "sev")]
         public Severity Severity { get; set; }
 
-        [DataMember(Name = "temp")]
         public bool Temp { get; set; }
+    }
+
+    internal class ErrorData
+    {
+        public string msg { get; set; }
+        public int code { get; set; }
+        public string name { get; set; }
+        public Severity sev { get; set; }
+        public bool temp { get; set; }
+
+        internal Error ToError()
+        {
+            return new Error
+            {
+                Message = msg,
+                Code = code,
+                Name = name,
+                Severity = sev,
+                Temp = temp,
+            };
+        }
     }
 }

--- a/Src/Couchbase/N1QL/Metrics.cs
+++ b/Src/Couchbase/N1QL/Metrics.cs
@@ -3,31 +3,49 @@ using System.Runtime.Serialization;
 
 namespace Couchbase.N1QL
 {
-    [DataContract]
     public class Metrics
     {
-        [DataMember(Name = "elapsedTime")]
         public string ElaspedTime { get; set; }
 
-        [DataMember(Name = "executionTime")]
         public string ExecutionTime { get; set; }
 
-        [DataMember(Name = "resultCount")]
         public uint ResultCount { get; set; }
 
-        [DataMember(Name = "resultSize")]
         public uint ResultSize { get; set; }
 
-        [DataMember(Name = "mutationCount")]
         public uint MutationCount { get; set; }
 
-        [DataMember(Name = "errorCount")]
         public uint ErrorCount { get; set; }
 
-        [DataMember(Name = "warningCount")]
         public uint WarningCount { get; set; }
 
-        [DataMember(Name = "sortCount")]
         public uint SortCount { get; set; }
+    }
+
+    internal class MetricsData
+    {
+        public string elapsedTime { get; set; }
+        public string executionTime { get; set; }
+        public uint resultCount { get; set; }
+        public uint resultSize { get; set; }
+        public uint mutationCount { get; set; }
+        public uint errorCount { get; set; }
+        public uint warningCount { get; set; }
+        public uint sortCount { get; set; }
+
+        internal Metrics ToMetrics()
+        {
+            return new Metrics
+            {
+                ElaspedTime = elapsedTime,
+                ExecutionTime = executionTime,
+                ResultCount = resultCount,
+                ResultSize = resultSize,
+                MutationCount = mutationCount,
+                ErrorCount = errorCount,
+                WarningCount = warningCount,
+                SortCount = sortCount,
+            };
+        }
     }
 }

--- a/Src/Couchbase/N1QL/QueryClient.cs
+++ b/Src/Couchbase/N1QL/QueryClient.cs
@@ -376,7 +376,7 @@ namespace Couchbase.N1QL
                         var request = await HttpClient.PostAsync(baseUri, content).ContinueOnAnyContext();
                         using (var response = await request.Content.ReadAsStreamAsync().ContinueOnAnyContext())
                         {
-                            queryResult = GetDataMapper(queryRequest).Map<QueryResult<T>>(response);
+                            queryResult = GetDataMapper(queryRequest).Map<QueryResultData<T>>(response).ToQueryResult();
                             queryResult.Success = queryResult.Status == QueryStatus.Success;
                             queryResult.HttpStatusCode = request.StatusCode;
                             Log.TraceFormat("Received query cid{0}: {1}", queryResult.ClientContextId, queryResult.ToString());

--- a/Src/Couchbase/N1QL/QueryResult.cs
+++ b/Src/Couchbase/N1QL/QueryResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Runtime.Serialization;
 using System.Text;
@@ -13,7 +14,6 @@ namespace Couchbase.N1QL
     /// <remarks>
     /// The dynamic keyword works well for the Type T.
     /// </remarks>
-    [DataContract]
     public class QueryResult<T> : IQueryResult<T>
     {
         public QueryResult()
@@ -45,7 +45,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The request identifier.
         /// </value>
-        [DataMember(Name = "requestID")]
         public Guid RequestId { get; internal set; }
 
         /// <summary>
@@ -54,7 +53,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The client context identifier.
         /// </value>
-        [DataMember(Name = "clientContextID")]
         public string ClientContextId { get; internal set; }
 
         /// <summary>
@@ -63,7 +61,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The signature of the schema of the request.
         /// </value>
-        [DataMember(Name = "signature")]
         public dynamic Signature { get; internal set; }
 
         /// <summary>
@@ -72,7 +69,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// A a list of all the objects returned by the query.
         /// </value>
-        [DataMember(Name="results")]
         public List<T> Rows { get; internal set; }
 
         /// <summary>
@@ -81,7 +77,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The status of the request.
         /// </value>
-        [DataMember(Name = "status")]
         public QueryStatus Status { get; internal set; }
 
         /// <summary>
@@ -90,7 +85,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The errors.
         /// </value>
-        [DataMember(Name = "errors")]
         public List<Error> Errors { get; internal set; }
 
         /// <summary>
@@ -99,7 +93,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The warnings.
         /// </value>
-        [DataMember(Name = "warnings")]
         public List<Warning> Warnings { get; internal set; }
 
         /// <summary>
@@ -108,7 +101,6 @@ namespace Couchbase.N1QL
         /// <value>
         /// The metrics.
         /// </value>
-        [DataMember(Name = "metrics")]
         public Metrics Metrics { get; internal set; }
 
         /// <summary>
@@ -163,6 +155,34 @@ namespace Couchbase.N1QL
             }
             return sb.ToString();
         }
+    }
+
+    internal class QueryResultData<T>
+    {
+        public Guid requestID { get; set; }
+        public string clientContextID { get; set; }
+        public dynamic signature { get; set; }
+        public IEnumerable<T> results { get; set; }
+        public QueryStatus status { get; set; }
+        public IEnumerable<ErrorData> errors { get; set; }
+        public IEnumerable<WarningData> warnings { get; set; }
+        public MetricsData metrics { get; set; }
+
+        internal QueryResult<T> ToQueryResult()
+        {
+            return new QueryResult<T>
+            {
+                RequestId = requestID,
+                ClientContextId = clientContextID,
+                Signature = signature,
+                Rows = results.ToList(),
+                Status = status,
+                Errors = errors != null ? errors.Select(e => e.ToError()).ToList() : null,
+                Warnings = warnings != null ? warnings.Select(w => w.ToWarning()).ToList() : null,
+                Metrics = metrics != null ? metrics.ToMetrics() : null,
+            };
+        }
+
     }
 }
 #region [ License information ]

--- a/Src/Couchbase/N1QL/Warning.cs
+++ b/Src/Couchbase/N1QL/Warning.cs
@@ -8,13 +8,25 @@ using Newtonsoft.Json;
 
 namespace Couchbase.N1QL
 {
-    [DataContract]
     public class Warning
     {
-        [JsonProperty("msg")]
         public string Message { get; set; }
 
-        [JsonProperty("code")]
         public int Code { get; set; }
+    }
+
+    internal class WarningData
+    {
+        public string msg { get; set; }
+        public int code { get; set; }
+
+        internal Warning ToWarning()
+        {
+            return new Warning
+            {
+                Message = msg,
+                Code = code,
+            };
+        } 
     }
 }

--- a/Src/Couchbase/Views/ViewClient.cs
+++ b/Src/Couchbase/Views/ViewClient.cs
@@ -44,7 +44,7 @@ namespace Couchbase.Views
                 var content = result.Content;
                 using (var stream = await content.ReadAsStreamAsync().ContinueOnAnyContext())
                 {
-                    viewResult = Mapper.Map<ViewResult<T>>(stream);
+                    viewResult = Mapper.Map<ViewResultData<T>>(stream).ToViewResult();
                     viewResult.Success = result.IsSuccessStatusCode;
                     viewResult.StatusCode = result.StatusCode;
                     viewResult.Message = Success;

--- a/Src/Couchbase/Views/ViewResult'.cs
+++ b/Src/Couchbase/Views/ViewResult'.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using Newtonsoft.Json;
 
 namespace Couchbase.Views
 {
@@ -18,16 +17,15 @@ namespace Couchbase.Views
             Error = string.Empty;
             Message = string.Empty;
         }
-            /// <summary>
+
+        /// <summary>
         /// The total number of rows.
         /// </summary>
-        [JsonProperty("total_rows")]
         public uint TotalRows { get; internal set; }
 
         /// <summary>
         /// The results of the query if successful as a <see cref="IEnumerable{T}"/>
         /// </summary>
-        [JsonProperty("rows")]
         public IEnumerable<ViewRow<T>> Rows { get; internal set; }
 
         /// <summary>
@@ -41,7 +39,6 @@ namespace Couchbase.Views
         /// <summary>
         /// An error message if one occured.
         /// </summary>
-        [JsonProperty("error")]
         public string Error { get; internal set; }
 
         /// <summary>
@@ -57,7 +54,6 @@ namespace Couchbase.Views
         /// <summary>
         /// An optional message returned by the server or the client
         /// </summary>
-        [JsonProperty("reason")]
         public string Message { get; internal set; }
 
         /// <summary>
@@ -78,7 +74,7 @@ namespace Couchbase.Views
                 {
                     case HttpStatusCode.OK:
                         break;
-                        //300's
+                    //300's
                     case HttpStatusCode.MultipleChoices:
                     case HttpStatusCode.MovedPermanently:
                     case HttpStatusCode.Found:
@@ -87,7 +83,7 @@ namespace Couchbase.Views
                     case HttpStatusCode.TemporaryRedirect:
                         cannotRetry = false;
                         break;
-                        //400's
+                    //400's
                     case HttpStatusCode.NotFound:
                         cannotRetry = Check404ForRetry();
                         break;
@@ -99,7 +95,7 @@ namespace Couchbase.Views
                     case HttpStatusCode.ExpectationFailed:
                         cannotRetry = false;
                         break;
-                        //500's
+                    //500's
                     case HttpStatusCode.InternalServerError:
                         cannotRetry = Check500ForRetry();
                         break;
@@ -139,6 +135,25 @@ namespace Couchbase.Views
         public bool ShouldRetry()
         {
             throw new System.NotImplementedException();
+        }
+    }
+
+    internal class ViewResultData<T>
+    {
+        public string error { get; set; }
+        public string reason { get; set; }
+        public uint total_rows { get; set; }
+        public IEnumerable<ViewRowData<T>> rows { get; set; }
+
+        internal ViewResult<T> ToViewResult()
+        {
+            return new ViewResult<T>
+            {
+                Error = error,
+                Message = reason,
+                TotalRows = total_rows,
+                Rows = rows.Select(r => r.ToViewRow()),
+            };
         }
     }
 }

--- a/Src/Couchbase/Views/ViewResult'.cs
+++ b/Src/Couchbase/Views/ViewResult'.cs
@@ -152,7 +152,7 @@ namespace Couchbase.Views
                 Error = error,
                 Message = reason,
                 TotalRows = total_rows,
-                Rows = rows != null ? rows.Select(r => r.ToViewRow()) : new ViewRow<T>[0],
+                Rows = rows != null ? rows.Select(r => r.ToViewRow()) : null,
             };
         }
     }

--- a/Src/Couchbase/Views/ViewResult'.cs
+++ b/Src/Couchbase/Views/ViewResult'.cs
@@ -152,7 +152,7 @@ namespace Couchbase.Views
                 Error = error,
                 Message = reason,
                 TotalRows = total_rows,
-                Rows = rows.Select(r => r.ToViewRow()),
+                Rows = rows != null ? rows.Select(r => r.ToViewRow()) : new ViewRow<T>[0],
             };
         }
     }

--- a/Src/Couchbase/Views/ViewRow.cs
+++ b/Src/Couchbase/Views/ViewRow.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace Couchbase.Views
+﻿namespace Couchbase.Views
 {
     /// <summary>
     /// Represents a single row returned from a View request
@@ -11,19 +9,16 @@ namespace Couchbase.Views
         /// <summary>
         /// The identifier for the row
         /// </summary>
-        [JsonProperty("id")]
         public string Id { get; set; }
 
         /// <summary>
         /// The key emitted by the View Map function
         /// </summary>
-        [JsonProperty("key")]
         public dynamic Key { get; set; }
 
         /// <summary>
         /// The value emitted by the View Map function or if a Reduce view, the value of the Reduce
         /// </summary>
-        [JsonProperty("value")]
         public T Value { get; set; }
 
         /// <summary>
@@ -33,7 +28,28 @@ namespace Couchbase.Views
         /// The geometry object optionally emited from a GEO Spatial View. The structure must be compatible with the GEOJson specification.
         /// </value>
         /// <remarks>This value will be null for all non-Geo Views or if the geometry is not emitted from the Map function.</remarks>
-        [JsonProperty("geometry")]
         public dynamic Geometry { get; set; }
+    }
+
+    internal class ViewRowData<T>
+    {
+        public string id { get; set; }
+
+        public dynamic key { get; set; }
+
+        public T value { get; set; }
+
+        public dynamic geometry { get; set; }
+
+        internal ViewRow<T> ToViewRow()
+        {
+            return new ViewRow<T>
+            {
+                Id = id,
+                Key = key,
+                Value = value,
+                Geometry = geometry,
+            };
+        }
     }
 }


### PR DESCRIPTION
Allows views to work when overriding the JSON serializer (ie with Jil)