### PR TITLE
Honor connectionTimeout configuration setting when initializing streaming provider

### DIFF
--- a/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpServerConfig.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpServerConfig.cs
@@ -37,6 +37,7 @@ namespace Couchbase.Configuration.Server.Providers.Streaming
             _bucketName = bucketName;
 
             _httpClient = new CouchbaseHttpClient(bucketName, password);
+            _httpClient.Timeout = TimeSpan.FromMilliseconds(clientConfig.BucketConfigs[bucketName].PoolConfiguration.ConnectTimeout);
         }
 
         public string BucketName


### PR DESCRIPTION
Motivation
----------
I'm new to couchbase. Our dev server crashed and was having a hard time figuring out why initially opening a bucket took 20+ seconds to time out even though I had set the connectionTimeout to 1 second. Stepped through the code and discovered that one of the providers was not setting a timeout when downloading config files from the server.

When connecting to a non responsive server (e.g. cluster.OpenBucket("my-bucket") ), the Streaming Provider does not honor the connectionTimeout property from the config. The Carrier Publication provider correctly honors the configuration. My thoughts are that all providers should honor the bucket config. This hack worked for me, but I do not know enough about the client to know if there is a better way to go about it.

Modifications
-------------
Override the Streaming Provider's HttpClient's Timeout property from the bucket's pool configuration.

Results
-------
Opening a bucket now honors the connectionTimeout bucket pool configuration property.