### PR TITLE
Log messages can be retrieved per bucket instance

### DIFF
--- a/Src/Couchbase.IntegrationTests/Configuration/Client/JsonConfiguration_Tests.cs
+++ b/Src/Couchbase.IntegrationTests/Configuration/Client/JsonConfiguration_Tests.cs
@@ -47,6 +47,23 @@ namespace Couchbase.IntegrationTests.Configuration.Client
 
             Assert.AreEqual(200, config.VBucketRetrySleepTime);
         }
+
+        [Test]
+        public void ClientConfiguration_EnableBucketInstanceLogging_IsFalse()
+        {
+            var config = Utils.TestConfiguration.GetConfiguration("basic");
+
+            Assert.IsFalse(config.EnableBucketInstanceLogging);
+        }
+
+        [Test]
+        public void ClientConfiguration_EnableBucketInstanceLogging_IsTrue()
+        {
+            var config = Utils.TestConfiguration.GetConfiguration("logging");
+
+            Assert.IsTrue(config.EnableBucketInstanceLogging);
+        }
+
     }
 }
 

--- a/Src/Couchbase.IntegrationTests/app.config
+++ b/Src/Couchbase.IntegrationTests/app.config
@@ -6,6 +6,7 @@
       <section name="ssl" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
       <section name="multiplexio" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
       <section name="observeConfig" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="logging" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
     <sectionGroup name="common">
       <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
@@ -54,6 +55,13 @@
       <connectionPool name="custom" type="Couchbase.IO.ConnectionPool`1[Couchbase.IO.MultiplexingConnection], Couchbase.NetClient"></connectionPool>
       <ioService name="multiplexio" type="Couchbase.IO.Services.MultiplexingIOService, Couchbase.NetClient" />
     </multiplexio>
+    <logging enableBucketInstanceLogging="true">
+      <buckets>
+        <add name="default" useEnhancedDurability="false">
+          <connectionPool name="default" />
+        </add>
+      </buckets>
+    </logging>
   </couchbaseClients>
   <common>
     <logging>

--- a/Src/Couchbase.IntegrationTests/config.json
+++ b/Src/Couchbase.IntegrationTests/config.json
@@ -47,6 +47,17 @@
           "useEnhancedDurability": true
         }
       ]
+    },
+
+    "logging": {
+      "enableConfigHeartbeat": false,
+      "enableBucketInstanceLogging" : true, 
+      "buckets": [
+        {
+          "name": "default",
+          "useEnhancedDurability": false
+        }
+      ]
     }
   }
 }

--- a/Src/Couchbase.UnitTests/App.config
+++ b/Src/Couchbase.UnitTests/App.config
@@ -10,7 +10,7 @@
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <couchbaseClients>
-    <couchbase enableConfigHeartBeat="false" ignoreRemoteCertificateNameMismatch="true">
+    <couchbase enableConfigHeartBeat="false" ignoreRemoteCertificateNameMismatch="true" enableBucketInstanceLogging="true">
       <connectionPool name="custom" minSize="5" maxSize="10"></connectionPool>
       <servers>
         <add uri="http://localhost:8091"></add>

--- a/Src/Couchbase.UnitTests/Configuration/Client/ClientConfigurationTests.cs
+++ b/Src/Couchbase.UnitTests/Configuration/Client/ClientConfigurationTests.cs
@@ -204,6 +204,22 @@ namespace Couchbase.UnitTests.Configuration.Client
             Assert.AreEqual(100, config.VBucketRetrySleepTime);
         }
 
+        [Test]
+        public void ClientConfigSection_EnableBucketInstanceLogging_IsFalse()
+        {
+            var config = new ClientConfiguration();
+
+            Assert.IsFalse(config.EnableBucketInstanceLogging);
+        }
+
+        [Test]
+        public void ClientConfigSection_EnableBucketInstanceLogging_IsTrue()
+        {
+            var config = new ClientConfiguration((CouchbaseClientSection)ConfigurationManager.GetSection("couchbaseClients/couchbase"));
+
+            Assert.IsTrue(config.EnableBucketInstanceLogging);
+        }
+
 #endif
     }
 }

--- a/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
+++ b/Src/Couchbase/Configuration/Client/ClientConfiguration.cs
@@ -66,6 +66,7 @@ namespace Couchbase.Configuration.Client
             public static uint ViewRequestTimeout = 75000; //ms
             public static uint SearchRequestTimeout = 75000; //ms
             public static uint VBucketRetrySleepTime = 100; //ms
+            public static bool EnableBucketInstanceLogging = false;
 
             //service point settings
             public static int DefaultConnectionLimit = 5; //connections
@@ -116,6 +117,8 @@ namespace Couchbase.Configuration.Client
             ViewRequestTimeout = (int) Defaults.ViewRequestTimeout; //ms
             SearchRequestTimeout = Defaults.SearchRequestTimeout;
             VBucketRetrySleepTime = Defaults.VBucketRetrySleepTime;
+
+            EnableBucketInstanceLogging = Defaults.EnableBucketInstanceLogging;
 
             //service point settings
             DefaultConnectionLimit = Defaults.DefaultConnectionLimit; //connections
@@ -221,6 +224,7 @@ namespace Couchbase.Configuration.Client
             EnableQueryTiming = definition.EnableQueryTiming;
             SearchRequestTimeout = definition.SearchRequestTimeout;
             VBucketRetrySleepTime = definition.VBucketRetrySleepTime;
+            EnableBucketInstanceLogging = definition.EnableBucketInstanceLogging;
 
             IOErrorCheckInterval = definition.IOErrorCheckInterval;
             IOErrorThreshold = definition.IOErrorThreshold;
@@ -797,6 +801,12 @@ namespace Couchbase.Configuration.Client
                 _operationLifespanChanged = true;
             }
         }
+
+        /// <summary>
+        /// If true, loggers will be created per bucket instance with following key "Couchbase.Core.IBucket.{BucketName}"
+        /// otherwise shared logger for all buckets of given type will be used.
+        /// </summary>
+        public bool EnableBucketInstanceLogging { get; set; }
 
         /// <summary>
         /// Updates the internal bootstrap url with the new list from a server configuration.

--- a/Src/Couchbase/Configuration/Client/CouchbaseClientDefinition.cs
+++ b/Src/Couchbase/Configuration/Client/CouchbaseClientDefinition.cs
@@ -336,6 +336,14 @@ namespace Couchbase.Configuration.Client
         [JsonProperty("vBucketRetrySleepTime")]
         public uint VBucketRetrySleepTime { get; set; }
 
+        /// <summary>
+        /// If true, loggers will be created per bucket instance with following key "Couchbase.Core.IBucket.{BucketName}"
+        /// otherwise shared logger for all buckets of given type will be used.
+        /// </summary>
+        /// <remarks>The default is "disabled" or false</remarks>
+        [JsonProperty("enableBucketInstanceLogging")]
+        public bool EnableBucketInstanceLogging { get; set; }
+
         public CouchbaseClientDefinition()
         {
             UseSsl = ClientConfiguration.Defaults.UseSsl;
@@ -368,6 +376,7 @@ namespace Couchbase.Configuration.Client
             IOErrorCheckInterval = ClientConfiguration.Defaults.IOErrorCheckInterval;
             QueryFailedThreshold = (int)ClientConfiguration.Defaults.QueryFailedThreshold;
             VBucketRetrySleepTime = ClientConfiguration.Defaults.VBucketRetrySleepTime;
+            EnableBucketInstanceLogging = ClientConfiguration.Defaults.EnableBucketInstanceLogging;
         }
 
         #region Additional ICouchbaseClientDefinition Implementations

--- a/Src/Couchbase/Configuration/Client/ICouchbaseClientDefinition.cs
+++ b/Src/Couchbase/Configuration/Client/ICouchbaseClientDefinition.cs
@@ -330,5 +330,11 @@ namespace Couchbase.Configuration.Client
         /// The VBucket retry sleep time.
         /// </value>
         uint VBucketRetrySleepTime { get; set; }
+
+        /// <summary>
+        /// If true, loggers will be created per bucket instance with following key "Couchbase.Core.IBucket.{BucketName}"
+        /// otherwise shared logger for all buckets of given type will be used.
+        /// </summary>
+        bool EnableBucketInstanceLogging { get; set; }
     }
 }

--- a/Src/Couchbase/Configuration/Client/Providers/CouchbaseClientSection.cs
+++ b/Src/Couchbase/Configuration/Client/Providers/CouchbaseClientSection.cs
@@ -518,6 +518,17 @@ namespace Couchbase.Configuration.Client.Providers
 
         }
 
+        /// <summary>
+        /// If true, loggers will be created per bucket instance with following key "Couchbase.Core.IBucket.{BucketName}"
+        /// otherwise shared logger for all buckets of given type will be used.
+        /// </summary>
+        [ConfigurationProperty("enableBucketInstanceLogging", IsRequired = false, DefaultValue = false)]
+        public bool EnableBucketInstanceLogging
+        {
+            get { return (bool) this["enableBucketInstanceLogging"]; }
+            set { this["enableBucketInstanceLogging"] = value; }
+        }
+
         #region Additional ICouchbaseClientDefinition implementations
 
         IEnumerable<Uri> ICouchbaseClientDefinition.Servers

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -43,7 +43,20 @@ namespace Couchbase
     /// <seealso cref="Couchbase.Core.IO.SubDocument.ISubdocInvoker" />
     public sealed class CouchbaseBucket : IBucket, IConfigObserver, IRefCountable, IQueryCacheInvalidator, ISubdocInvoker
     {
-        private static readonly ILog Log = LogManager.GetLogger<CouchbaseBucket>();
+        private ILog Log
+        {
+            get
+            {
+                if (_clusterController.Configuration.EnableBucketInstanceLogging)
+                {
+                    string key = string.Format("{0}.{1}", typeof(IBucket).FullName, Name);
+                    return LogManager.GetLogger(key);
+                }
+
+                return LogManager.GetLogger<CouchbaseBucket>();
+            }
+        }
+
         private readonly IClusterController _clusterController;
         private IConfigInfo _configInfo;
         private volatile bool _disposed;

--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -32,7 +32,20 @@ namespace Couchbase
     /// <seealso cref="Couchbase.IRefCountable" />
     public class MemcachedBucket : IBucket, IConfigObserver, IRefCountable
     {
-        private static readonly ILog Log = LogManager.GetLogger<MemcachedBucket>();
+        private ILog Log
+        {
+            get
+            {
+                if (_clusterController.Configuration.EnableBucketInstanceLogging)
+                {
+                    string key = string.Format("{0}.{1}", typeof(IBucket).FullName, Name);
+                    return LogManager.GetLogger(key);
+                }
+
+                return LogManager.GetLogger<MemcachedBucket>();
+            }
+        }
+
         private readonly IClusterController _clusterController;
         private IConfigInfo _configInfo;
         private volatile bool _disposed;


### PR DESCRIPTION
Motivation
----------
Create separate logger instance for each bucket instance so it's possible to identify and process log messages just for specific buckets.

Modifications
-------------
Created configuration option EnableBucketInstanceLogging that will modify key supplied to LogManager.GetLogger() method in CouchbaseBucket and MemcachedBucket.

Results
-------
It's possible to identify log messages from specific bucket via key `Couchbase.Core.IBucket.<BucketName>`