### PR TITLE
CouchbaseClientDefinition should use interface for Buckets property

### DIFF
--- a/Src/Couchbase/Configuration/Client/CouchbaseClientDefinition.cs
+++ b/Src/Couchbase/Configuration/Client/CouchbaseClientDefinition.cs
@@ -37,7 +37,7 @@ namespace Couchbase.Configuration.Client
         /// <summary>
         /// Allows specific configurations of Bucket's to be defined, overriding the parent's settings.
         /// </summary>
-        public List<BucketDefinition> Buckets { get; set;  }
+        public List<IBucketDefinition> Buckets { get; set;  }
 
         /// <summary>
         /// Overrides the default and sets the SSL port to use for Key/Value operations using the Binary Memcached protocol.


### PR DESCRIPTION
Motivation
----------
CouchbaseClientDefinition uses BucketDefinition class for Buckets property. If 3rd party uses it's own extended configuration file it's not possible to map element that implements IBucketDefinition.

Modifications
-------------
Changed BucketDefinition to IBucketDefinition for Buckets property.

Results
-------
It's possible to map different configuration element to CouchbaseClientDefinition if it implements IBucketDefinition.