### PR TITLE
Avoid blocking in async code in request executers

### DIFF
--- a/Src/Couchbase/Core/Buckets/CouchbaseRequestExecuter.cs
+++ b/Src/Couchbase/Core/Buckets/CouchbaseRequestExecuter.cs
@@ -713,7 +713,7 @@ namespace Couchbase.Core.Buckets
         /// <returns>
         /// An <see cref="Task{IOperationResult}" /> object representing the asynchronous operation.
         /// </returns>
-        public override Task<IOperationResult<T>> SendWithRetryAsync<T>(IOperation<T> operation,
+        public override async Task<IOperationResult<T>> SendWithRetryAsync<T>(IOperation<T> operation,
             TaskCompletionSource<IOperationResult<T>> tcs = null,
             CancellationTokenSource cts = null)
         {
@@ -744,9 +744,9 @@ namespace Couchbase.Core.Buckets
                 while ((server = vBucket.LocatePrimary()) == null)
                 {
                     if (attempts++ > 10) { throw new TimeoutException("Could not acquire a server.");}
-                    Thread.Sleep((int)Math.Pow(2, attempts));
+                    await Task.Delay((int)Math.Pow(2, attempts)).ContinueOnAnyContext();
                 }
-                server.SendAsync(operation).ConfigureAwait(false);
+                await server.SendAsync(operation).ContinueOnAnyContext();
             }
             catch (Exception e)
             {
@@ -757,7 +757,7 @@ namespace Couchbase.Core.Buckets
                     Status = ResponseStatus.ClientFailure
                 });
             }
-            return tcs.Task;
+            return await tcs.Task.ContinueOnAnyContext();
         }
 
 
@@ -770,7 +770,7 @@ namespace Couchbase.Core.Buckets
         /// <returns>
         /// An <see cref="Task{IOperationResult}" /> object representing the asynchronous operation.
         /// </returns>
-        public override Task<IOperationResult> SendWithRetryAsync(IOperation operation,
+        public override async Task<IOperationResult> SendWithRetryAsync(IOperation operation,
             TaskCompletionSource<IOperationResult> tcs = null,
             CancellationTokenSource cts = null)
         {
@@ -801,10 +801,10 @@ namespace Couchbase.Core.Buckets
                 while ((server = vBucket.LocatePrimary()) == null)
                 {
                     if (attempts++ > 10) { throw new TimeoutException("Could not acquire a server."); }
-                    Thread.Sleep((int)Math.Pow(2, attempts));
+                    await Task.Delay((int)Math.Pow(2, attempts)).ContinueOnAnyContext();
                 }
                 Log.Debug("Starting send for {0} with {1}", operation.Opaque, server.EndPoint);
-                server.SendAsync(operation).ConfigureAwait(false);
+                await server.SendAsync(operation).ContinueOnAnyContext();
             }
             catch (Exception e)
             {
@@ -815,7 +815,7 @@ namespace Couchbase.Core.Buckets
                     Status = ResponseStatus.ClientFailure
                 });
             }
-            return tcs.Task;
+            return await tcs.Task.ContinueOnAnyContext();
         }
 
         public override ISearchQueryResult SendWithRetry(SearchQuery searchQuery)
@@ -868,10 +868,10 @@ namespace Couchbase.Core.Buckets
                 while ((server = ConfigInfo.GetSearchNode()) == null)
                 {
                     if (attempts++ > 10) { throw new TimeoutException("Could not acquire a server."); }
-                    Thread.Sleep((int)Math.Pow(2, attempts));
+                    await Task.Delay((int)Math.Pow(2, attempts)).ContinueOnAnyContext();
                 }
 
-                searchResult = await server.SendAsync(searchQuery);
+                searchResult = await server.SendAsync(searchQuery).ContinueOnAnyContext();
             }
             catch (Exception e)
             {

--- a/Src/Couchbase/Core/Buckets/MemcachedRequestExecuter.cs
+++ b/Src/Couchbase/Core/Buckets/MemcachedRequestExecuter.cs
@@ -153,7 +153,7 @@ namespace Couchbase.Core.Buckets
         /// <returns>
         /// An <see cref="Task{IOperationResult}" /> object representing the asynchronous operation.
         /// </returns>
-        public override Task<IOperationResult<T>> SendWithRetryAsync<T>(IOperation<T> operation,
+        public override async Task<IOperationResult<T>> SendWithRetryAsync<T>(IOperation<T> operation,
             TaskCompletionSource<IOperationResult<T>> tcs = null,
             CancellationTokenSource cts = null)
         {
@@ -172,9 +172,9 @@ namespace Couchbase.Core.Buckets
                 while ((server = GetServer(operation.Key)) == null)
                 {
                     if (attempts++ > 10) { throw new TimeoutException("Could not acquire a server."); }
-                    Thread.Sleep((int)Math.Pow(2, attempts));
+                    await Task.Delay((int)Math.Pow(2, attempts)).ConfigureAwait(false);
                 }
-                server.SendAsync(operation).ConfigureAwait(false);
+                await server.SendAsync(operation).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -185,7 +185,7 @@ namespace Couchbase.Core.Buckets
                     Status = ResponseStatus.ClientFailure
                 });
             }
-            return tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace Couchbase.Core.Buckets
         /// <returns>
         /// An <see cref="Task{IOperationResult}" /> object representing the asynchronous operation.
         /// </returns>
-        public override Task<IOperationResult> SendWithRetryAsync(IOperation operation,
+        public override async Task<IOperationResult> SendWithRetryAsync(IOperation operation,
             TaskCompletionSource<IOperationResult> tcs = null,
             CancellationTokenSource cts = null)
         {
@@ -216,9 +216,9 @@ namespace Couchbase.Core.Buckets
                 while ((server = GetServer(operation.Key)) == null)
                 {
                     if (attempts++ > 10) { throw new TimeoutException("Could not acquire a server."); }
-                    Thread.Sleep((int)Math.Pow(2, attempts));
+                    await Task.Delay((int)Math.Pow(2, attempts)).ConfigureAwait(false);
                 }
-                server.SendAsync(operation).ConfigureAwait(false);
+                await server.SendAsync(operation).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -229,7 +229,7 @@ namespace Couchbase.Core.Buckets
                     Status = ResponseStatus.ClientFailure
                 });
             }
-            return tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
I've noticed some blocking Tread.Sleep calls being made inside async code.  

In addition `async Task SendAsync(IOperation operation)` was being called without awaiting on results.

That may as well be intentional, however it seems to be a good practice to await on the result in order for exceptions to be handled normally (e.g. unwrapped from `AggregateException`) by an `await` after calling async functions.