### PR TITLE
NCBC-1323: Update appveyor to support VS2017 projects

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,15 +8,10 @@ environment:
     secure: Mpa4faeUiC2uggKSC5ZgiA==
 cache:
 - src\packages -> **\packages.config
-install:
-- ps: nuget install secure-file -ExcludeVersion
-before_build:
-#- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
-- ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
 build_script:
-#- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
-- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
-after_build:
+- ps: nuget install secure-file -ExcludeVersion
+- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
+- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
 - ps: Compress-Archive -Path .\Src\Couchbase\bin\Release\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
 artifacts:
 - path: '*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,23 @@
-version: 2.4.3.{build}
+version: 2.4.8.{build}
 configuration: Release
+image: Visual Studio 2017
 init:
 - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME".TrimStart("v") }
-assembly_info:
-  patch: true
-  file: '**\AssemblyInfo.*'
-  assembly_version: '%APPVEYOR_BUILD_VERSION%'
-  assembly_file_version: '%APPVEYOR_BUILD_VERSION%'
-  assembly_informational_version: '%APPVEYOR_BUILD_VERSION%'
 environment:
   SnkSecret:
     secure: Mpa4faeUiC2uggKSC5ZgiA==
 cache:
 - src\packages -> **\packages.config
 install:
-- ps: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe
 - ps: nuget install secure-file -ExcludeVersion
 before_build:
-- ps: nuget restore .\src\couchbase-net-client.sln
-- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Couchbase.snk
-- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase\Couchbase.snk
-- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase.NetStandard\Couchbase.snk
+#- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
 - ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
 build_script:
-- cmd: msbuild Src\Couchbase\Couchbase.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
-- cmd: msbuild Src\Couchbase.NetStandard\Couchbase.NetStandard.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
+#- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
+- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
 after_build:
-- ps: Copy-Item -Path .\Src\Couchbase\bin\Release -Filter "Couchbase.*" -Destination .\binaries\net45 -Recurse
-- ps: Copy-Item -Path .\Src\Couchbase.NetStandard\bin\Release -Filter "Couchbase.*" -Destination .\binaries\netstandard1.5 -Recurse
-- ps: Compress-Archive -Path .\binaries\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
-- ps: nuget pack .\src\Couchbase\Couchbase.nuspec -Properties "Configuration=Release;Platform=AnyCPU;" -version "$env:APPVEYOR_BUILD_VERSION"
+- ps: Compress-Archive -Path .\Src\Couchbase\bin\Release\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
 artifacts:
 - path: '*.zip'
 - path: '*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,18 @@
-version: 2.4.3.{build}
-configuration: Release
+version: 2.4.8.{build}
+image: Visual Studio 2017
 init:
 - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME".TrimStart("v") }
-assembly_info:
-  patch: true
-  file: '**\AssemblyInfo.*'
-  assembly_version: '%APPVEYOR_BUILD_VERSION%'
-  assembly_file_version: '%APPVEYOR_BUILD_VERSION%'
-  assembly_informational_version: '%APPVEYOR_BUILD_VERSION%'
 environment:
   SnkSecret:
     secure: Mpa4faeUiC2uggKSC5ZgiA==
 cache:
 - src\packages -> **\packages.config
-install:
-- ps: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe
-- ps: nuget install secure-file -ExcludeVersion
-before_build:
-- ps: nuget restore .\src\couchbase-net-client.sln
-- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Couchbase.snk
-- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase\Couchbase.snk
-- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase.NetStandard\Couchbase.snk
-- ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
 build_script:
-- cmd: msbuild Src\Couchbase\Couchbase.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
-- cmd: msbuild Src\Couchbase.NetStandard\Couchbase.NetStandard.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
-after_build:
-- ps: Copy-Item -Path .\Src\Couchbase\bin\Release -Filter "Couchbase.*" -Destination .\binaries\net45 -Recurse
-- ps: Copy-Item -Path .\Src\Couchbase.NetStandard\bin\Release -Filter "Couchbase.*" -Destination .\binaries\netstandard1.5 -Recurse
-- ps: Compress-Archive -Path .\binaries\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
-- ps: nuget pack .\src\Couchbase\Couchbase.nuspec -Properties "Configuration=Release;Platform=AnyCPU;" -version "$env:APPVEYOR_BUILD_VERSION"
+- ps: nuget install secure-file -ExcludeVersion
+- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
+- ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
+- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
+- ps: Compress-Archive -Path .\Src\Couchbase\bin\Release\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
 artifacts:
 - path: '*.zip'
 - path: '*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 2.4.8.{build}
+configuration: Release
 image: Visual Studio 2017
 init:
 - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME".TrimStart("v") }
@@ -7,11 +8,14 @@ environment:
     secure: Mpa4faeUiC2uggKSC5ZgiA==
 cache:
 - src\packages -> **\packages.config
-build_script:
+install:
 - ps: nuget install secure-file -ExcludeVersion
+before_build:
 - ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
 - ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
+build_script:
 - ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
+after_build:
 - ps: Compress-Archive -Path .\Src\Couchbase\bin\Release\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
 artifacts:
 - path: '*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,35 @@
-version: 2.4.8.{build}
+version: 2.4.3.{build}
 configuration: Release
-image: Visual Studio 2017
 init:
 - ps: if ($env:APPVEYOR_REPO_TAG -eq "true") { Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME".TrimStart("v") }
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '%APPVEYOR_BUILD_VERSION%'
+  assembly_file_version: '%APPVEYOR_BUILD_VERSION%'
+  assembly_informational_version: '%APPVEYOR_BUILD_VERSION%'
 environment:
   SnkSecret:
     secure: Mpa4faeUiC2uggKSC5ZgiA==
 cache:
 - src\packages -> **\packages.config
 install:
+- ps: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe
 - ps: nuget install secure-file -ExcludeVersion
 before_build:
-- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Src\Couchbase\Couchbase.snk
+- ps: nuget restore .\src\couchbase-net-client.sln
+- ps: .\secure-file\tools\secure-file.exe -decrypt .\build-utils\Couchbase.snk.enc -secret $env:SnkSecret -out .\Couchbase.snk
+- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase\Couchbase.snk
+- ps: Copy-Item .\Couchbase.snk .\Src\Couchbase.NetStandard\Couchbase.snk
 - ps: (Get-Content .\src\Couchbase\Properties\AssemblyInfo.cs) | Where { $_ -notmatch "InternalsVisibleTo" } | Set-Content .\src\Couchbase\Properties\AssemblyInfo.cs
 build_script:
-- ps: msbuild Src\Couchbase\Couchbase.csproj /p:Configuration=Release /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk /p:version="$env:APPVEYOR_BUILD_VERSION" /t:restore /t:pack /p:PackageOutputPath=..\..\
+- cmd: msbuild Src\Couchbase\Couchbase.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
+- cmd: msbuild Src\Couchbase.NetStandard\Couchbase.NetStandard.csproj /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=Couchbase.snk
 after_build:
-- ps: Compress-Archive -Path .\Src\Couchbase\bin\Release\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
+- ps: Copy-Item -Path .\Src\Couchbase\bin\Release -Filter "Couchbase.*" -Destination .\binaries\net45 -Recurse
+- ps: Copy-Item -Path .\Src\Couchbase.NetStandard\bin\Release -Filter "Couchbase.*" -Destination .\binaries\netstandard1.5 -Recurse
+- ps: Compress-Archive -Path .\binaries\* -CompressionLevel Optimal -DestinationPath .\Couchbase-Net-Client-$env:APPVEYOR_BUILD_VERSION.zip
+- ps: nuget pack .\src\Couchbase\Couchbase.nuspec -Properties "Configuration=Release;Platform=AnyCPU;" -version "$env:APPVEYOR_BUILD_VERSION"
 artifacts:
 - path: '*.zip'
 - path: '*.nupkg'


### PR DESCRIPTION
NCBC-1323: Update appveyor to support VS2017 projects

MOTIVATION
----------
The current appeveyor.yml does not support the new vs 2017 project
structure and should be updated.

MODIFICATIONS
-------------
- update appveyor.yml to support vs 2017 project file

RESULT
------
Appveyor can now succeffully build the new project structure, package
the nuget package.

Change-Id: I546e1e15b7b847a29e4777031d3a10e079989ba7