### PR TITLE
Deserialize QueryPlan with DefaultSerializer

### DIFF
--- a/Src/Couchbase/N1QL/QueryClient.cs
+++ b/Src/Couchbase/N1QL/QueryClient.cs
@@ -84,6 +84,7 @@ namespace Couchbase.N1QL
             }
             var query = new QueryRequest(statement);
             query.BaseUri(toPrepare.GetBaseUri());
+            query.DataMapper = new QueryDataMapper();
             return ExecuteQuery<QueryPlan>(query);
         }
 
@@ -108,6 +109,7 @@ namespace Couchbase.N1QL
             }
             var query = new QueryRequest(statement);
             query.BaseUri(toPrepare.GetBaseUri());
+            query.DataMapper = new QueryDataMapper();
             return await ExecuteQueryAsync<QueryPlan>(query, cancellationToken).ContinueOnAnyContext();
         }
 

--- a/Src/Couchbase/N1QL/QueryClient.cs
+++ b/Src/Couchbase/N1QL/QueryClient.cs
@@ -84,7 +84,7 @@ namespace Couchbase.N1QL
             }
             var query = new QueryRequest(statement);
             query.BaseUri(toPrepare.GetBaseUri());
-            query.DataMapper = new QueryDataMapper();
+            query.DataMapper = new QueryPlanDataMapper();
             return ExecuteQuery<QueryPlan>(query);
         }
 
@@ -109,7 +109,7 @@ namespace Couchbase.N1QL
             }
             var query = new QueryRequest(statement);
             query.BaseUri(toPrepare.GetBaseUri());
-            query.DataMapper = new QueryDataMapper();
+            query.DataMapper = new QueryPlanDataMapper();
             return await ExecuteQueryAsync<QueryPlan>(query, cancellationToken).ContinueOnAnyContext();
         }
 

--- a/Src/Couchbase/N1QL/QueryPlanDataMapper.cs
+++ b/Src/Couchbase/N1QL/QueryPlanDataMapper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core.Serialization;
+using Couchbase.Views;
+
+namespace Couchbase.N1QL
+{
+    /// <summary>
+    /// Prepare in QueryClient has a model with a hard reference to Newtonsoft (QueryPlan).
+    /// This class makes sure it gets deserialized with the DefaultSerializer instead of the
+    /// one passed in via the ClientConfiguration.
+    /// </summary>
+    internal class QueryDataMapper : IDataMapper
+    {
+        private readonly ITypeSerializer _serializer;
+
+        public QueryDataMapper()
+        {
+            _serializer = SerializerFactory.GetSerializer()();
+        }
+
+        /// <summary>
+        /// Maps a single row.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="IViewResult{T}"/>'s Type paramater.</typeparam>
+        /// <param name="stream">The <see cref="Stream"/> results of the query.</param>
+        /// <returns>An object deserialized to it's T type.</returns>
+        public T Map<T>(Stream stream) where T : class
+        {
+            return _serializer.Deserialize<T>(stream);
+        }
+    }
+}

--- a/Src/Couchbase/N1QL/QueryPlanDataMapper.cs
+++ b/Src/Couchbase/N1QL/QueryPlanDataMapper.cs
@@ -14,11 +14,11 @@ namespace Couchbase.N1QL
     /// This class makes sure it gets deserialized with the DefaultSerializer instead of the
     /// one passed in via the ClientConfiguration.
     /// </summary>
-    internal class QueryDataMapper : IDataMapper
+    internal class QueryPlanDataMapper : IDataMapper
     {
         private readonly ITypeSerializer _serializer;
 
-        public QueryDataMapper()
+        public QueryPlanDataMapper()
         {
             _serializer = SerializerFactory.GetSerializer()();
         }


### PR DESCRIPTION
QueryPlan won't deserialize properly if the Newtonsoft serializer is not used. This pull request ensures QueryPlan's are always deserialized using the DefaultSerializer.