### PR TITLE
BucketCache (non-static API for accessing buckets)

### DIFF
--- a/Src/Couchbase.UnitTests/BucketCacheTests.cs
+++ b/Src/Couchbase.UnitTests/BucketCacheTests.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using Couchbase.Authentication;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests
+{
+    [TestFixture]
+    public class BucketCacheTests
+    {
+        [Test]
+        public void Constructor_When_Configuration_Is_Null_ArgumentNullException_Is_Thrown1()
+        {
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => new BucketCache((ClientConfiguration)null));
+        }
+
+        [Test]
+        public void Constructor_When_Configuration_Is_Null_ArgumentNullException_Is_Thrown2()
+        {
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => new BucketCache(null, Mock.Of<IAuthenticator>()));
+        }
+
+        [Test]
+        public void Constructor_When_Authenticator_Is_Null_ArgumentNullException_Is_Thrown()
+        {
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => new BucketCache(Mock.Of<ClientConfiguration>(), null));
+        }
+
+        [Test]
+        public void Constructor_When_Definition_Is_Null_ArgumentNullException_Is_Thrown()
+        {
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => new BucketCache((ICouchbaseClientDefinition)null));
+        }
+
+        [Test]
+        public void Get_When_BucketName_Is_Null_ArgumentNullException_Is_Thrown()
+        {
+            // Arrange
+            var bucketCache = new BucketCache(() => Mock.Of<ICluster>());
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => bucketCache.Get(null));
+        }
+
+        [Test]
+        public void Get_When_BucketName_Is_Empty_ArgumentException_Is_Thrown()
+        {
+            // Arrange
+            var bucketCache = new BucketCache(() => Mock.Of<ICluster>());
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => bucketCache.Get(""));
+        }
+
+        [Test]
+        public void Get_Calls_OpenBucket_Using_BucketName1()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            // Act
+            bucketCache.Get(bucketName);
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName));
+        }
+
+        [Test]
+        public void Get_Calls_OpenBucket_Using_BucketName2()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            // Act
+            bucketCache.Get(bucketName, null);
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName));
+        }
+
+        [Test]
+        public void Get_Calls_OpenBucket_Using_BucketName_And_Password()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+            var password = "bar";
+
+            // Act
+            bucketCache.Get(bucketName, password);
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName, password));
+        }
+
+        [Test]
+        public void Get_Calls_OpenBucket_Using_Password_From_Configuration()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+            var password = "bar";
+
+            cluster.Configuration.BucketConfigs.Add(bucketName, new BucketConfiguration() { Password = password });
+
+            // Act
+            bucketCache.Get(bucketName);
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName, password));
+        }
+
+        [Test]
+        public void Get_Calls_OpenBucket_Without_Password_If_Configuration_Password_Is_Null()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            cluster.Configuration.BucketConfigs.Add(bucketName, new BucketConfiguration() { Password = null });
+
+            // Act
+            bucketCache.Get(bucketName);
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName));
+        }
+
+        [Test]
+        public void Get_Caches_Buckets()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            // Act
+            var bucket = bucketCache.Get(bucketName);
+
+            // Assert
+
+            Assert.AreSame(bucket, bucketCache.Get(bucketName));
+        }
+
+        [Test]
+        public void Remove_Removes_Bucket_From_Cache()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            var bucket = Mock.Of<IBucket>();
+
+            Mock.Get(cluster)
+                .Setup(_ => _.OpenBucket(bucketName))
+                .Returns(bucket);
+
+            bucketCache.Get(bucketName);
+
+            // Act
+            bucketCache.Remove(bucketName);
+
+            // Assert
+            bucketCache.Get(bucketName);
+
+            Mock.Get(cluster)
+                .Verify(_ => _.OpenBucket(bucketName), Times.Exactly(2));
+        }
+
+        [Test]
+        public void Remove_Disposes_Removed_Bucket()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            var bucket = Mock.Of<IBucket>();
+
+            Mock.Get(cluster)
+                .Setup(_ => _.OpenBucket(bucketName))
+                .Returns(bucket);
+
+            bucketCache.Get(bucketName);
+
+            // Act
+            bucketCache.Remove(bucketName);
+
+            // Assert
+            Mock.Get(bucket)
+                .Verify(_ => _.Dispose());
+        }
+
+        [Test]
+        public void Dispose_Disposes_Cached_Buckets()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            var bucket = Mock.Of<IBucket>();
+
+            Mock.Get(cluster)
+                .Setup(_ => _.OpenBucket(bucketName))
+                .Returns(bucket);
+
+            bucketCache.Get(bucketName);
+
+            // Act
+            bucketCache.Dispose();
+
+            // Assert
+            Mock.Get(bucket)
+                .Verify(_ => _.Dispose());
+        }
+
+        [Test]
+        public void Dispose_Disposes_Cluster()
+        {
+            // Arrange
+            var cluster = GetCluster();
+            var bucketCache = new BucketCache(() => cluster);
+            var bucketName = "foo";
+
+            var bucket = Mock.Of<IBucket>();
+
+            Mock.Get(cluster)
+                .Setup(_ => _.OpenBucket(bucketName))
+                .Returns(bucket);
+
+            bucketCache.Get(bucketName);
+
+            // Act
+            bucketCache.Dispose();
+
+            // Assert
+            Mock.Get(cluster)
+                .Verify(_ => _.Dispose());
+        }
+
+        private ICluster GetCluster()
+        {
+            var cluster = Mock.Of<ICluster>();
+            var clientConfiguration = new ClientConfiguration();
+
+            Mock.Get(cluster)
+                .SetupGet(_ => _.Configuration)
+                .Returns(clientConfiguration);
+
+            clientConfiguration.BucketConfigs = new Dictionary<string, BucketConfiguration>();
+
+            return cluster;
+        }
+    }
+}

--- a/Src/Couchbase/BucketCache.cs
+++ b/Src/Couchbase/BucketCache.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Couchbase.Authentication;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+
+namespace Couchbase
+{
+    /// <summary>
+    /// Provides access to <see cref="IBucket"/> instances.
+    /// </summary>
+    public class BucketCache : IBucketCache, IDisposable
+    {
+        private readonly SemaphoreSlim syncRoot = new SemaphoreSlim(1, 1);
+        private readonly Dictionary<string, IBucket> buckets = new Dictionary<string, IBucket>();
+        private readonly Lazy<ICluster> cluster;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BucketCache"/> class.
+        /// </summary>
+        /// <param name="configuration">The <see cref="ClientConfiguration"/> to use when initialize the internal <see cref="BucketCache"/>.</param>
+        public BucketCache(ClientConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            cluster = new Lazy<ICluster>(() => new Cluster(configuration));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BucketCache"/> class.
+        /// </summary>
+        /// <param name="configuration">The <see cref="ClientConfiguration"/> to use when initialize the internal <see cref="BucketCache"/>.</param>
+        /// <param name="authenticator">The <see cref="IAuthenticator"/> for authenticating against the cluster.
+        /// Use a <see cref="PasswordAuthenticator"/> for RBAC in Couchbase Server 5.0 and greater.</param>
+        public BucketCache(ClientConfiguration configuration, IAuthenticator authenticator)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (authenticator == null)
+            {
+                throw new ArgumentNullException(nameof(authenticator));
+            }
+
+            cluster = new Lazy<ICluster>(() =>
+            {
+                var cluster = new Cluster(configuration);
+                cluster.Authenticate(authenticator);
+
+                return cluster;
+            });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BucketCache"/> class.
+        /// </summary>
+        /// <param name="definition">The configuration definition loaded from a configuration file.</param>
+        public BucketCache(ICouchbaseClientDefinition definition)
+        {
+            if (definition == null)
+            {
+                throw new ArgumentNullException(nameof(definition));
+            }
+
+            var configuration = new ClientConfiguration(definition);
+            configuration.Initialize();
+
+            cluster = new Lazy<ICluster>(() => new Cluster(configuration));
+        }
+
+        // for testing purposes
+        internal BucketCache(Func<ICluster> clusterFactory)
+        {
+            cluster = new Lazy<ICluster>(clusterFactory);
+        }
+
+        /// <summary>
+        /// Opens or gets an <see cref="IBucket"/> instance from the <see cref="ICluster"/> that this <see cref="BucketCache"/> is wrapping.
+        /// The <see cref="IBucket"/> will be cached and subsequent requests for an <see cref="IBucket"/> of the same name will return the
+        /// cached instance.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to open or get.</param>
+        /// <returns>An <see cref="IBucket"/> instance.</returns>
+        public IBucket Get(string bucketName)
+        {
+            return Get(bucketName, null);
+        }
+
+        /// <summary>
+        /// Opens or gets an <see cref="IBucket"/> instance from the <see cref="ICluster"/> that this <see cref="BucketCache"/> is wrapping.
+        /// The <see cref="IBucket"/> will be cached and subsequent requests for an <see cref="IBucket"/> of the same name will return the
+        /// cached instance.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to open or get.</param>
+        /// <param name="password">Bucket password, or null for unsecured buckets.</param>
+        /// <returns>An <see cref="IBucket"/> instance.</returns>
+        public IBucket Get(string bucketName, string password)
+        {
+            if (string.IsNullOrWhiteSpace(bucketName))
+            {
+                if (bucketName == null)
+                {
+                    throw new ArgumentNullException(nameof(bucketName));
+                }
+
+                throw new ArgumentException("The parameter bucketName cannot be empty or whitespace.", nameof(bucketName));
+            }
+
+            if (!buckets.TryGetValue(bucketName, out var bucket))
+            {
+                syncRoot.Wait();
+
+                try
+                {
+                    if (!buckets.ContainsKey(bucketName))
+                    {
+                        bucket = OpenBucket(bucketName, password);
+
+                        buckets.Add(bucketName, bucket);
+                    }
+                }
+                finally
+                {
+                    syncRoot.Release();
+                }
+            }
+
+            return bucket;
+        }
+
+        /// <summary>
+        /// Removes the given bucket from the cached buckets.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to remove.</param>
+        public void Remove(string bucketName)
+        {
+            syncRoot.Wait();
+
+            try
+            {
+                if (buckets.TryGetValue(bucketName, out var bucket))
+                {
+                    buckets.Remove(bucketName);
+
+                    bucket.Dispose();
+                }
+            }
+            finally
+            {
+                syncRoot.Release();
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="BucketCache"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            if (cluster.IsValueCreated)
+            {
+                foreach (var bucket in buckets.Values)
+                {
+                    bucket.Dispose();
+                }
+
+                buckets.Clear();
+
+                cluster.Value.Dispose();
+            }
+        }
+
+        private IBucket OpenBucket(string bucketName, string password)
+        {
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                // try to find a password in configuration
+                if (cluster.Value.Configuration.BucketConfigs.TryGetValue(bucketName, out var bucketConfig) && bucketConfig.Password != null)
+                {
+                    return cluster.Value.OpenBucket(bucketName, bucketConfig.Password);
+                }
+
+                return cluster.Value.OpenBucket(bucketName);
+            }
+
+            return cluster.Value.OpenBucket(bucketName, password);
+        }
+    }
+}

--- a/Src/Couchbase/IBucketCache.cs
+++ b/Src/Couchbase/IBucketCache.cs
@@ -1,0 +1,35 @@
+﻿using Couchbase.Core;
+
+namespace Couchbase
+{
+    /// <summary>
+    /// Provides access to <see cref="IBucket"/> instances.
+    /// </summary>
+    public interface IBucketCache
+    {
+        /// <summary>
+        /// Opens or gets an <see cref="IBucket"/> instance from the <see cref="ICluster"/> that this <see cref="IBucketCache"/> is wrapping.
+        /// The <see cref="IBucket"/> will be cached and subsequent requests for an <see cref="IBucket"/> of the same name will return the
+        /// cached instance.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to open or get.</param>
+        /// <returns>An <see cref="IBucket"/> instance.</returns>
+        IBucket Get(string bucketName);
+
+        /// <summary>
+        /// Opens or gets an <see cref="IBucket"/> instance from the <see cref="ICluster"/> that this <see cref="IBucketCache"/> is wrapping.
+        /// The <see cref="IBucket"/> will be cached and subsequent requests for an <see cref="IBucket"/> of the same name will return the
+        /// cached instance.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to open or get.</param>
+        /// <param name="password">Bucket password, or null for unsecured buckets.</param>
+        /// <returns>An <see cref="IBucket"/> instance.</returns>
+        IBucket Get(string bucketName, string password);
+
+        /// <summary>
+        /// Removes the given bucket from the cached buckets.
+        /// </summary>
+        /// <param name="bucketName">The name of the <see cref="IBucket"/> to remove.</param>
+        void Remove(string bucketName);
+    }
+}


### PR DESCRIPTION
Motivation
----------
BucketCache provides a non-static API for accessing buckets (just like the static API of ClusterHelper), which will be cached for subsequent requests. BucketCache can be used with an IoC container (registered as a singleton instance) which makes the referencing code testable and makes the IoC container responsible for teardown (by implementing IDisposable).

Modifications
-------------
 - add IBucketCache interface
 - add BucketCache implementing IBucketCache
 - add BucketCache unit tests

Result
------
The static API of ClusterHelper is maintained and a non-static API through BucketCache is provided for use with an IoC container.