### PR TITLE
Support for controlling how MemoryStreams are created

### DIFF
--- a/Src/Couchbase/Core/Serialization/DefaultSerializer.cs
+++ b/Src/Couchbase/Core/Serialization/DefaultSerializer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Couchbase.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -168,7 +169,7 @@ namespace Couchbase.Core.Serialization
         /// <returns>A <see cref="byte"/> array that is the serialized value of the key.</returns>
         public byte[] Serialize(object obj)
         {
-            using (var ms = new MemoryStream())
+            using (var ms = MemoryStreamFactory.GetMemoryStream())
             {
                 using (var sw = new StreamWriter(ms))
                 {

--- a/Src/Couchbase/Core/Transcoders/BinaryTranscoder.cs
+++ b/Src/Couchbase/Core/Transcoders/BinaryTranscoder.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Couchbase.Core.Serialization;
+using Couchbase.IO;
 using Couchbase.IO.Converters;
 
 namespace Couchbase.Core.Transcoders
@@ -49,7 +50,7 @@ namespace Couchbase.Core.Transcoders
                 return new byte[0];
             }
 
-            using (var ms = new MemoryStream())
+            using (var ms = MemoryStreamFactory.GetMemoryStream())
             {
                 _formatter.Serialize(ms, value);
                 return ms.ToArray();

--- a/Src/Couchbase/IO/Connection.cs
+++ b/Src/Couchbase/IO/Connection.cs
@@ -44,7 +44,7 @@ namespace Couchbase.IO
             {
                 state = new SocketAsyncState
                 {
-                    Data = new MemoryStream(),
+                    Data = MemoryStreamFactory.GetMemoryStream(),
                     Opaque = Converter.ToUInt32(buffer, HeaderIndexFor.Opaque),
                     Buffer = buffer,
                     Completed = callback,
@@ -99,7 +99,7 @@ namespace Couchbase.IO
             //create the state object and set it
             var state = new SocketAsyncState
             {
-                Data = new MemoryStream(),
+                Data = MemoryStreamFactory.GetMemoryStream(),
                 Opaque = Converter.ToUInt32(buffer, HeaderIndexFor.Opaque),
                 Buffer = buffer,
                 SendOffset = _eventArgs.Offset

--- a/Src/Couchbase/IO/MemoryStreamFactory.cs
+++ b/Src/Couchbase/IO/MemoryStreamFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+
+namespace Couchbase.IO
+{
+    /// <summary>
+    /// Creates instances of MemoryStreams for use in writing/ reading bytes to/ from the network.  
+    /// </summary>
+    public static class MemoryStreamFactory
+    {
+        private static Func<MemoryStream> FactoryFunc = () => new MemoryStream();
+        
+        /// <summary>
+        /// Provides a custom MemoryStream creation function that will override the default implementation.
+        /// </summary>
+        /// <param name="factoryFunc"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void SetFactoryFunc(Func<MemoryStream> factoryFunc)
+        {
+            if (factoryFunc == null)
+            {
+                throw new ArgumentNullException(nameof(factoryFunc), "You must provide a non-null factory function");
+            }
+
+            FactoryFunc = factoryFunc;
+        }
+        
+        /// <summary>
+        /// Fetches a MemoryStream. The default implementation retuns a new MemoryStream instance.
+        /// </summary>
+        /// <returns></returns>
+        public static MemoryStream GetMemoryStream()
+        {
+            return FactoryFunc();
+        }
+    }
+}

--- a/Src/Couchbase/IO/Operations/OperationBase.cs
+++ b/Src/Couchbase/IO/Operations/OperationBase.cs
@@ -47,7 +47,7 @@ namespace Couchbase.IO.Operations
             VBucket = vBucket;
             Converter = transcoder.Converter;
             MaxRetries = DefaultRetries;
-            Data = new MemoryStream();
+            Data = MemoryStreamFactory.GetMemoryStream();
             Header = new OperationHeader {Status = ResponseStatus.None};
         }
 
@@ -124,7 +124,7 @@ namespace Couchbase.IO.Operations
             {
                 Data.Dispose();
             }
-            Data = new MemoryStream();
+            Data = MemoryStreamFactory.GetMemoryStream();
             LengthReceived = 0;
 
             Header = new OperationHeader
@@ -145,7 +145,7 @@ namespace Couchbase.IO.Operations
             LengthReceived += msgBytes.Length;
             if (Data == null)
             {
-                Data = new MemoryStream();
+                Data = MemoryStreamFactory.GetMemoryStream();
             }
             Data.Write(msgBytes, 0, msgBytes.Length);
         }

--- a/Src/Couchbase/IO/SslConnection.cs
+++ b/Src/Couchbase/IO/SslConnection.cs
@@ -81,7 +81,7 @@ namespace Couchbase.IO
             {
                 state = new SocketAsyncState
                 {
-                    Data = new MemoryStream(),
+                    Data = MemoryStreamFactory.GetMemoryStream(),
                     Opaque = Converter.ToUInt32(request, HeaderIndexFor.Opaque),
                     Buffer = request,
                     Completed = callback
@@ -184,7 +184,7 @@ namespace Couchbase.IO
 
             var state = new SocketAsyncState
             {
-                Data = new MemoryStream(),
+                Data = MemoryStreamFactory.GetMemoryStream(),
                 Opaque = Converter.ToUInt32(buffer, HeaderIndexFor.Opaque)
             };
 


### PR DESCRIPTION
# Summary
This PR adds the ability to configure how `MemoryStream` instances are created within the Couchbase SDK, while maintaining compatibility with how `MemoryStreams` instances are created.

# Motivation
When profiling our production web servers, I have observed that a large amount of allocated memory can be traced back to the Couchbase SDK and it's use of `MemoryStream`:
![image](https://user-images.githubusercontent.com/1540536/33102635-d052ccd6-cf71-11e7-942a-b74ccf52a674.png)

This change would allow users to plug in their own more memory efficient `MemoryStream` implementations (see [Microsoft.IO.RecyclableMemoryStream](https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream)).

# Changes
- Added the `MemoryStreamFactory` that can use a configured function to create MemoryStream instances
- Default implementation does not differ from current, `new MemoryStream()` is called
- In instances where `new MemoryStream()` was being called, replaced with `MemoryStreamFactory.GetMemoryStream()`
- In instances where `new MemoryStream(byte[])` was being called, no changes were made: MemoryStreams are being used in a read-only capacity.

# Notes
This is my first PR against this project- if my code does not meet your standards or the static factory is not a pattern you wish to encourage, please let me know and I'll do my best to re-work this PR.