### PR TITLE
Update CouchbaseList.Remove to update list on the server

### DIFF
--- a/Src/Couchbase.UnitTests/Collections/CouchbaseListTests.cs
+++ b/Src/Couchbase.UnitTests/Collections/CouchbaseListTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Couchbase.Collections;
 using Couchbase.Core;
 using Moq;
@@ -10,11 +11,29 @@ namespace Couchbase.UnitTests.Collections
     [TestFixture]
     public class CouchbaseListTests
     {
+        private const string BucketKey = "TestCollection";
+
         public class Poco
         {
             public string Key { get; set; }
 
             public string Name { get; set; }
+        }
+
+        public static class MockHelper
+        {
+            public static Mock<IBucket> CreateBucket(params Poco[] items)
+            {                
+                var result = new Mock<IOperationResult<List<Poco>>>();
+                result.SetupGet(x => x.Success).Returns(true);
+                result.SetupGet(x => x.Value).Returns(items.ToList());
+
+                var bucket = new Mock<IBucket>();
+                bucket.Setup(x => x.Exists(BucketKey)).Returns(true);
+                bucket.Setup(x => x.Get<List<Poco>>(BucketKey)).Returns(result.Object);
+
+                return bucket;
+            }
         }
 
         [Test]
@@ -25,18 +44,109 @@ namespace Couchbase.UnitTests.Collections
             builder.Setup(x => x.ArrayAppend(It.IsAny<Poco>(), It.IsAny<bool>())).Returns(builder.Object);
             builder.Setup(x => x.Execute()).Returns(new DocumentFragment<List<Poco>>(builder.Object) {Success = true});
 
-            var bucket = new Mock<IBucket>();
-            bucket.Setup(x => x.Insert(It.IsAny<Document<List<Poco>>>())).
-                Returns(new DocumentResult<List<Poco>>(new OperationResult<List<Poco>>
-            {
-                Success = true
-            }));
-            bucket.Setup(x => x.MutateIn<List<Poco>>(It.IsAny<string>())).Returns(builder.Object);
+            var bucket = MockHelper.CreateBucket();
+            bucket.Setup(x => x.MutateIn<List<Poco>>(BucketKey)).Returns(builder.Object);
 
-            var collection = new CouchbaseList<Poco>(bucket.Object, "Thecollection");
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            var poco = new Poco() { Key = "Poco", Name = "Poco #1" };
 
             //act/assert
-            Assert.DoesNotThrow(()=> collection.Add(new Poco { Key = "poco1", Name = "Poco-pica" }));
+            Assert.DoesNotThrow(()=> collection.Add(poco));
+
+            builder.Verify(x => x.ArrayAppend(poco, true), Times.Once());
+            builder.Verify(x => x.Execute(), Times.Once());
+        }
+
+        [Test]
+        public void Test_Insert()
+        {
+            //arrange
+            var builder = new Mock<IMutateInBuilder<List<Poco>>>();
+            builder.Setup(x => x.ArrayInsert("[0]", It.IsAny<Poco>(), It.IsAny<bool>())).Returns(builder.Object);
+            builder.Setup(x => x.Execute()).Returns(new DocumentFragment<List<Poco>>(builder.Object) { Success = true });
+
+            var bucket = MockHelper.CreateBucket(new Poco() { Key = "Poco-1", Name = "Poco #1" });
+            bucket.Setup(x => x.MutateIn<List<Poco>>(BucketKey)).Returns(builder.Object);
+
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            var poco = new Poco() { Key = "Poco-2", Name = "Poco #2" };
+
+            //act/assert
+            Assert.DoesNotThrow(() => collection.Insert(0, poco));
+
+            builder.Verify(x => x.ArrayInsert("[0]", poco, true), Times.Once());
+            builder.Verify(x => x.Execute(), Times.Once());
+        }
+
+        [Test]
+        public void Test_RemoveAt()
+        {
+            //arrange
+            var builder = new Mock<IMutateInBuilder<List<Poco>>>();
+            builder.Setup(x => x.Remove("[0]")).Returns(builder.Object);
+            builder.Setup(x => x.Execute()).Returns(new DocumentFragment<List<Poco>>(builder.Object) { Success = true });
+
+            var bucket = MockHelper.CreateBucket(new Poco());
+            bucket.Setup(x => x.MutateIn<List<Poco>>(BucketKey)).Returns(builder.Object);
+
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            //act/assert
+            Assert.DoesNotThrow(() => collection.RemoveAt(0));
+
+            builder.Verify(x => x.Remove("[0]"), Times.Once());
+            builder.Verify(x => x.Execute(), Times.Once());
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Test_Contains(bool expected) 
+        {
+            //arrange
+            var item = new Poco();
+            var items = new List<Poco>();
+
+            if(expected) 
+            {
+                items.Add(item);
+            }
+
+            var bucket = MockHelper.CreateBucket(items.ToArray());
+
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            //act
+            var actual = collection.Contains(item);
+
+            //assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Test_IndexOf(bool contains)
+        {
+            //arrange
+            var item = new Poco();
+            var items = new List<Poco>();
+
+            if(contains)
+            {
+                items.Add(item);
+            }
+
+            var bucket = MockHelper.CreateBucket(items.ToArray());
+
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            //act
+            var expected = contains ? 0 : -1;
+            var actual = collection.IndexOf(item);
+
+            //assert
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/Src/Couchbase.UnitTests/Collections/CouchbaseListTests.cs
+++ b/Src/Couchbase.UnitTests/Collections/CouchbaseListTests.cs
@@ -81,6 +81,28 @@ namespace Couchbase.UnitTests.Collections
         }
 
         [Test]
+        public void Test_Remove()
+        {
+            //arrange
+            var poco = new Poco() { Key = "Poco", Name = "Poco #1" };
+
+            var builder = new Mock<IMutateInBuilder<List<Poco>>>();
+            builder.Setup(x => x.Remove("[0]")).Returns(builder.Object);
+            builder.Setup(x => x.Execute()).Returns(new DocumentFragment<List<Poco>>(builder.Object) { Success = true });
+
+            var bucket = MockHelper.CreateBucket(poco);
+            bucket.Setup(x => x.MutateIn<List<Poco>>(BucketKey)).Returns(builder.Object);
+
+            var collection = new CouchbaseList<Poco>(bucket.Object, BucketKey);
+
+            //act/assert
+            Assert.DoesNotThrow(() => collection.Remove(poco));
+
+            builder.Verify(x => x.Remove("[0]"), Times.Once());
+            builder.Verify(x => x.Execute(), Times.Once());
+        }
+
+        [Test]
         public void Test_RemoveAt()
         {
             //arrange

--- a/Src/Couchbase/Collections/CouchbaseList.cs
+++ b/Src/Couchbase/Collections/CouchbaseList.cs
@@ -163,7 +163,7 @@ namespace Couchbase.Collections
             // ReSharper disable once InconsistentlySynchronizedField
             var get = Bucket.Get<List<T>>(Key);
 
-            if(!get.Success) 
+            if (!get.Success) 
             {
                 if(get.Exception != null) 
                 {

--- a/Src/Couchbase/Collections/CouchbaseList.cs
+++ b/Src/Couchbase/Collections/CouchbaseList.cs
@@ -52,20 +52,7 @@ namespace Couchbase.Collections
         /// <exception cref="System.NotImplementedException"></exception>
         public bool Contains(T item)
         {
-            var get = Bucket.Get<List<T>>(Key);
-
-            if (!get.Success)
-            {
-                if (get.Exception != null)
-                {
-                    throw get.Exception;
-                }
-                throw new InvalidOperationException(get.Status.ToString());
-            }
-
-            var items = get.Value;
-
-            return items.Contains(item);
+            return GetItems().Contains(item);
         }
 
         /// <summary>
@@ -78,20 +65,7 @@ namespace Couchbase.Collections
         /// <exception cref="System.NotImplementedException"></exception>
         public bool Remove(T item)
         {
-            var get = Bucket.Get<List<T>>(Key);
-
-            if (!get.Success)
-            {
-                if (get.Exception != null)
-                {
-                    throw get.Exception;
-                }
-                throw new InvalidOperationException(get.Status.ToString());
-            }
-
-            var items = get.Value;
-
-            return items.Remove(item);
+            return GetItems().Remove(item);            
         }
 
         /// <summary>
@@ -109,20 +83,7 @@ namespace Couchbase.Collections
         /// <exception cref="System.NotImplementedException"></exception>
         public int IndexOf(T item)
         {
-            var get = Bucket.Get<List<T>>(Key);
-
-            if (!get.Success)
-            {
-                if (get.Exception != null)
-                {
-                    throw get.Exception;
-                }
-                throw new InvalidOperationException(get.Status.ToString());
-            }
-
-            var items = get.Value;
-
-            return items.IndexOf(item);
+            return GetItems().IndexOf(item);
         }
 
         /// <summary>
@@ -197,21 +158,26 @@ namespace Couchbase.Collections
             if (index < 0) throw new IndexOutOfRangeException();
             if (index > Count) throw new IndexOutOfRangeException();
 
+            var items = GetItems();
+
+            return items[index];
+        }
+
+        private List<T> GetItems() 
+        {
             // ReSharper disable once InconsistentlySynchronizedField
             var get = Bucket.Get<List<T>>(Key);
 
-            if (!get.Success)
+            if(!get.Success) 
             {
-                if (get.Exception != null)
+                if(get.Exception != null) 
                 {
                     throw get.Exception;
                 }
                 throw new InvalidOperationException(get.Status.ToString());
             }
 
-            var items = get.Value;
-
-            return items[index];
+            return get.Value;
         }
     }
 }

--- a/Src/Couchbase/Collections/CouchbaseList.cs
+++ b/Src/Couchbase/Collections/CouchbaseList.cs
@@ -65,7 +65,16 @@ namespace Couchbase.Collections
         /// <exception cref="System.NotImplementedException"></exception>
         public bool Remove(T item)
         {
-            return GetItems().Remove(item);            
+            var index = GetItems().IndexOf(item);
+            var removed = false;
+            
+            if(index >= 0)
+            {
+                RemoveAt(index, false);
+                removed = true;
+            }
+
+            return removed;
         }
 
         /// <summary>
@@ -117,21 +126,7 @@ namespace Couchbase.Collections
         /// <exception cref="System.IndexOutOfRangeException"></exception>
         public void RemoveAt(int index)
         {
-            if (index < 0) throw new IndexOutOfRangeException();
-            if (index > Count) throw new IndexOutOfRangeException();
-
-            var remove = Bucket.MutateIn<List<T>>(Key).
-                Remove("[" + index + "]").
-                Execute();
-
-            if (!remove.Success)
-            {
-                if (remove.Exception != null)
-                {
-                    throw remove.Exception;
-                }
-                throw new InvalidOperationException(remove.Status.ToString());
-            }
+            RemoveAt(index, true);
         }
 
         /// <summary>
@@ -178,6 +173,28 @@ namespace Couchbase.Collections
             }
 
             return get.Value;
+        }
+
+        private void RemoveAt(int index, bool validate)
+        {
+            if(validate)
+            {
+                if(index < 0) throw new IndexOutOfRangeException();
+                if(index > Count) throw new IndexOutOfRangeException();
+            }
+
+            var remove = Bucket.MutateIn<List<T>>(Key).
+                Remove("[" + index + "]").
+                Execute();
+
+            if(!remove.Success)
+            {
+                if(remove.Exception != null)
+                {
+                    throw remove.Exception;
+                }
+                throw new InvalidOperationException(remove.Status.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates the `Remove` method of `CouchbaseList` so that it removes the item from the list on the server. 

Changes in this PR:
- Expanded tests for `CouchbaseList<T>`
- Abstract item retrieval in `CouchbaseList<T>` into `GetItems`
- Update `Remove` to fetch items from the server, find the index of the item to be removed and then use `IBucket.Remove(string path)` to remove it by index.

~PS. I cannot currently login to Gerrit to sign the CLA, after clicking sign-in and authorizing with GitHub I get a screen which just says "Not Found".~ The link from the bot below worked :+1: