### PR TITLE
Fix documentation of Expiry

### DIFF
--- a/Src/Couchbase/Document.cs
+++ b/Src/Couchbase/Document.cs
@@ -21,7 +21,7 @@ namespace Couchbase
         public ulong Cas { get; set; }
 
         /// <summary>
-        /// The time-to-live or TTL for the document before it's evicted from disk in milliseconds.
+        /// The time-to-live or TTL for the document before it's evicted from disk in seconds.
         /// </summary>
         /// <remarks>Setting this to zero or less will give the document infinite lifetime</remarks>
         public uint Expiry { get; set; }


### PR DESCRIPTION
The value is in seconds, not milliseconds.
https://developer.couchbase.com/documentation/server/4.1/developer-guide/expiry.html