### PR TITLE
Fix error in HttpServerConfig.Initialize when one of the servers is unresponsive

### DIFF
--- a/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpServerConfig.cs
+++ b/Src/Couchbase/Configuration/Server/Providers/Streaming/HttpServerConfig.cs
@@ -87,6 +87,10 @@ namespace Couchbase.Configuration.Server.Providers.Streaming
             {
                 Log.Error(e);
             }
+            catch (HttpRequestException e)
+            {
+                Log.Error(e);
+            }
             catch (Exception e)
             {
                 Log.Error("Bootstrapping failed from {0}: {1}", server, e);


### PR DESCRIPTION
Whenever HttpServerConfig.Initialize encounters a problem with the connection with one of the servers, it should skip that server and try the next one. Because the DownloadString-method only throws HttpRequestExceptions, but the DownloadConfigs-method only handles BootstrapExceptions, this 'skip-and-try-the-next-functionality does not work