### PR TITLE
NCBC-XXXX: Fix expiration bugs in CouchbaseBucket Increment and IncrementAsync

### DIFF
--- a/Src/Couchbase.UnitTests/CouchbaseBucketTests/CouchbaseBucketTests.cs
+++ b/Src/Couchbase.UnitTests/CouchbaseBucketTests/CouchbaseBucketTests.cs
@@ -9,7 +9,6 @@ using Couchbase.Configuration.Server.Providers;
 using Couchbase.Configuration.Server.Serialization;
 using Couchbase.Core;
 using Couchbase.Core.Buckets;
-using Couchbase.Core.Serialization;
 using Couchbase.Core.Transcoders;
 using Couchbase.IO;
 using Couchbase.IO.Converters;
@@ -21,8 +20,11 @@ using Moq;
 namespace Couchbase.UnitTests
 {
     [TestFixture]
-    public class CouchbaseBucketTests
+    public partial class CouchbaseBucketTests
     {
+        private readonly IByteConverter _converter = new DefaultConverter();
+        private readonly ITypeTranscoder _transcoder = new DefaultTranscoder();
+
         [Test]
         public void GetAndLockAsync_Does_Not_Throw_StackOverFlowException()
         {

--- a/Src/Couchbase.UnitTests/CouchbaseBucketTests/IncrementAsyncTests.cs
+++ b/Src/Couchbase.UnitTests/CouchbaseBucketTests/IncrementAsyncTests.cs
@@ -1,0 +1,329 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core.Buckets;
+using Couchbase.IO.Operations;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests
+{
+    public partial class CouchbaseBucketTests
+    {
+        [TestFixture]
+        public class IncrementAsyncTests : CouchbaseBucketTests
+        {
+            [Test]
+            public async Task IncrementAsync_With_Key_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key");
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(1, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_Timeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(1, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(10, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_Delta_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(10, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaInitial_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, 4);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaInitialExpirationTime_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, 4, TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaInitialExpiration_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, 4, 10);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaInitialExpirationTimeTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, 4, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(20, operation.Timeout);
+            }
+
+            [Test]
+            public async Task IncrementAsync_With_DeltaInitialExpirationTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetryAsync(It.IsAny<Increment>(), null, null))
+                    .Callback((IOperation<ulong> op, TaskCompletionSource<IOperationResult<ulong>> tcs, CancellationTokenSource ccs) => operation = (Increment)op)
+                    .ReturnsAsync((IOperationResult<ulong>)null);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    await bucket.IncrementAsync("key", 2, 4, 10, TimeSpan.FromSeconds(20));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(20, operation.Timeout);
+            }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2014 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion
+

--- a/Src/Couchbase.UnitTests/CouchbaseBucketTests/IncrementTests.cs
+++ b/Src/Couchbase.UnitTests/CouchbaseBucketTests/IncrementTests.cs
@@ -1,0 +1,318 @@
+﻿using System;
+using Couchbase.Core.Buckets;
+using Couchbase.IO.Operations;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests
+{
+    public partial class CouchbaseBucketTests
+    {
+        [TestFixture]
+        public class IncrementTests : CouchbaseBucketTests
+        {
+            [Test]
+            public void Increment_With_Key_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key");
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(1, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_Timeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(1, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(10, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_Delta_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(1, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(10, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaInitial_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, 4);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(0, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaInitialExpirationTime_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, 4, TimeSpan.FromSeconds(10));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaInitialExpiration_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, 4, 10);
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(42, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaInitialExpirationTimeTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, 4, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(20, operation.Timeout);
+            }
+
+            [Test]
+            public void Increment_With_DeltaInitialExpirationTimeout_ExecutesCorrectOperation()
+            {
+                // Arrange
+
+                Increment operation = null;
+
+                var mockRequestExecuter = new Mock<IRequestExecuter>();
+                mockRequestExecuter
+                    .Setup(m => m.SendWithRetry(It.IsAny<Increment>()))
+                    .Callback((IOperation<ulong> op) => operation = (Increment)op);
+
+                // Act
+
+                using (var bucket = new CouchbaseBucket(mockRequestExecuter.Object, _converter, _transcoder))
+                {
+                    bucket.Name = "bucket";
+
+                    bucket.Increment("key", 2, 4, 10, TimeSpan.FromSeconds(20));
+                }
+
+                // Assert
+
+                Assert.NotNull(operation);
+                Assert.AreEqual(2, operation.Delta);
+                Assert.AreEqual(4, operation.Initial);
+                Assert.AreEqual("bucket", operation.BucketName);
+                Assert.AreEqual(10, operation.Expires);
+                Assert.AreEqual(20, operation.Timeout);
+            }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2014 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion
+

--- a/Src/Couchbase/IO/Operations/Increment.cs
+++ b/Src/Couchbase/IO/Operations/Increment.cs
@@ -5,22 +5,23 @@ namespace Couchbase.IO.Operations
 {
     internal class Increment : MutationOperationBase<ulong>
     {
-        private readonly ulong _delta;
-        private readonly ulong _initial;
-
         public Increment(string key, ulong initial, ulong delta, IVBucket vBucket, ITypeTranscoder transcoder, uint timeout)
             : base(key, vBucket, transcoder, timeout)
         {
-            _delta = delta;
-            _initial = initial;
+            Delta = delta;
+            Initial = initial;
         }
 
         private Increment(string key, ulong initial, ulong delta, IVBucket vBucket, ITypeTranscoder transcoder, uint opaque, uint timeout)
             : base(key, initial, vBucket, transcoder, opaque, timeout)
         {
-            _delta = delta;
-            _initial = initial;
+            Delta = delta;
+            Initial = initial;
         }
+
+        public ulong Delta { get; }
+
+        public ulong Initial { get; }
 
         public override OperationCode OperationCode
         {
@@ -30,8 +31,8 @@ namespace Couchbase.IO.Operations
         public override byte[] CreateExtras()
         {
             var extras = new byte[20];
-            Converter.FromUInt64(_delta, extras, 0);
-            Converter.FromUInt64(_initial, extras, 8);
+            Converter.FromUInt64(Delta, extras, 0);
+            Converter.FromUInt64(Initial, extras, 8);
             Converter.FromUInt32(Expires, extras, 16);
             return extras;
         }
@@ -43,7 +44,7 @@ namespace Couchbase.IO.Operations
 
         public override IOperation Clone()
         {
-            var cloned = new Increment(Key, _initial, _delta, VBucket, Transcoder, Opaque, Timeout)
+            var cloned = new Increment(Key, Initial, Delta, VBucket, Transcoder, Opaque, Timeout)
             {
                 Attempts = Attempts,
                 Cas = Cas,


### PR DESCRIPTION
MOTIVATION
----------
Some of the Increment and IncrementAsync overloads set the timeout as the expiration. Another overload set an incorrect timeout that would cause TimeSpan.FromMinutes(5) to become 00:00:00.0000300. This would then cause the expire time of the document to become zero (infinity) instead of 5 minutes.

MODIFICATIONS
-------------
- Set GlobalTimeout for unit testing.
- Made some of the fields in Increment public readonly instead of a private field for unit testing.
- Refactored some of the code to make it more clear what is passed to the other overloads.
- Created separate files for testing the Increment and IncrementAsync methods.

RESULT
------
The Increment and IncrementAsync method will set the correct expiration.