### PR TITLE
Trapping exception from config serialization

### DIFF
--- a/Src/Couchbase/Core/ClusterController.cs
+++ b/Src/Couchbase/Core/ClusterController.cs
@@ -109,9 +109,21 @@ namespace Couchbase.Core
                     foreach (var provider in _configProviders.OfType<CarrierPublicationProvider>())
                     {
                         Log.Debug("Processing config rev#{0}", config.Rev);
+                        string traceObj = null;
+                        try
+                        {
+                            //will make logs verbose
+                            traceObj = JsonConvert.SerializeObject(config);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error("Unable to serialize config", ex);
+                        }
 
-                        //will make logs verbose
-                        Log.Trace(JsonConvert.SerializeObject(config));
+                        if (traceObj != null)
+                        {
+                            Log.Trace(traceObj);
+                        }
 
                         provider.UpdateConfig(config);
                     }


### PR DESCRIPTION
The Serialization of the config can through an exception due to
'Input string is not in the proper format'.  When the exception
is thrown the CT thread stops and the _configQueue grows without
bound.