### PR TITLE
Remove the head of the queue when popping

### DIFF
--- a/Src/Couchbase.IntegrationTests/CouchbaseBucket_DataStructure_Tests.cs
+++ b/Src/Couchbase.IntegrationTests/CouchbaseBucket_DataStructure_Tests.cs
@@ -527,10 +527,11 @@ namespace Couchbase.IntegrationTests
             Assert.AreEqual(bob.Name, item.Name);
             CollectionAssert.AreEqual(bob.Items, item.Items);
 
-            // Now there should be two items
+            // Now there should be one item
             queue = await _bucket.GetAsync<List<Poco1>>(key);
             Assert.IsNotNull(queue);
             Assert.AreEqual(1, queue.Value.Count);
+            Assert.AreEqual(mary.Name, queue.Value[0].Name);
         }
 
         [Test]
@@ -637,10 +638,11 @@ namespace Couchbase.IntegrationTests
             Assert.AreEqual(bob.Name, item.Name);
             CollectionAssert.AreEqual(bob.Items, item.Items);
 
-            // Now there should be two items
+            // Now there should be one item
             queue = _bucket.Get<List<Poco1>>(key).Value;
             Assert.IsNotNull(queue);
             Assert.AreEqual(1, queue.Count);
+            Assert.AreEqual(mary.Name, queue[0].Name);
         }
 
         [Test]

--- a/Src/Couchbase/CouchbaseBucket.cs
+++ b/Src/Couchbase/CouchbaseBucket.cs
@@ -7101,7 +7101,7 @@ namespace Couchbase
 
                 var item = getResult.Value.First();
                 var mutateResult = MutateIn<List<T>>(key)
-                    .Remove("[-1]")
+                    .Remove("[0]")
                     .WithCas(getResult.Cas)
                     .WithTimeout(timeout)
                     .Execute();
@@ -7749,7 +7749,7 @@ namespace Couchbase
 
                 var item = getResult.Value.First();
                 var mutateResult = await MutateIn<List<T>>(key)
-                    .Remove("[-1]")
+                    .Remove("[0]")
                     .WithCas(getResult.Cas)
                     .WithTimeout(timeout)
                     .ExecuteAsync()


### PR DESCRIPTION
QueryPop removed the tail of the queue instead of the head.