### PR TITLE
See OperationBase Timedout method:

### DIFF
--- a/Src/Couchbase/MemcachedBucket.cs
+++ b/Src/Couchbase/MemcachedBucket.cs
@@ -2685,7 +2685,7 @@ namespace Couchbase
         /// </returns>
         public IOperationResult<T> Get<T>(string key, TimeSpan timeout)
         {
-            var operation = new Get<T>(key, null, _transcoder, timeout.GetSeconds());
+            var operation = new Get<T>(key, null, _transcoder, timeout.GetMilliseconds());
             return _requestExecuter.SendWithRetry(operation);
         }
 

--- a/Src/Couchbase/Utils/TimeSpanExtensions.cs
+++ b/Src/Couchbase/Utils/TimeSpanExtensions.cs
@@ -49,6 +49,16 @@ namespace Couchbase.Utils
             return (uint) timeSpan.TotalSeconds;
         }
 
+        /// <summary>
+        /// Retrieves the number of milliseconds expressed in a <see cref="TimeSpan"/> as an <see cref="uint"/>.
+        /// </summary>
+        /// <param name="timeSpan">The timespan.</param>
+        /// <returns>An <see cref="uint"/> that is the total number of milliseconds in the <see cref="TimeSpan"/>.</returns>
+        public static uint GetMilliseconds(this TimeSpan timeSpan)
+        {
+            return (uint) timeSpan.TotalMilliseconds;
+        }
+
         private static readonly Regex DurationValueSuffixRegex = new Regex(@"([\d]+)\s?([^\d]+)?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private const string MicrosSuffix = "us";
         private const string MillisSuffix = "ms";


### PR DESCRIPTION
        public bool TimedOut()
        {
            if (_timedOut) return _timedOut;

            var elasped = DateTime.UtcNow.Subtract(CreationTime).TotalMilliseconds;
            if (elasped >= Timeout || (ErrorCode != null && ErrorCode.HasTimedOut(elasped)))
            {
                _timedOut = true;
            }
            return _timedOut;
        }

It compared the elapsed duration in millseconds with the Timeout property - which is set in seconds in the constructor of Get! This is a mismatch which causes wrong OperationTimedout error messages.