### PR TITLE
Don't export fuzziness or prefix_length when values less than 1

### DIFF
--- a/Src/Couchbase.UnitTests/Search/BooleanQueryTests.cs
+++ b/Src/Couchbase.UnitTests/Search/BooleanQueryTests.cs
@@ -61,8 +61,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }
@@ -90,8 +88,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }
@@ -119,8 +115,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }

--- a/Src/Couchbase.UnitTests/Search/ConjunctionQueryTests.cs
+++ b/Src/Couchbase.UnitTests/Search/ConjunctionQueryTests.cs
@@ -42,8 +42,6 @@ namespace Couchbase.UnitTests.Search
                     new
                     {
                         term = "hotel",
-                        prefix_length = 0,
-                        fuzziness = 0,
                         field = "type"
                     }
                 }

--- a/Src/Couchbase.UnitTests/Search/DisjunctionQueryTests.cs
+++ b/Src/Couchbase.UnitTests/Search/DisjunctionQueryTests.cs
@@ -43,8 +43,6 @@ namespace Couchbase.UnitTests.Search
                     new
                     {
                         term = "hotel",
-                        prefix_length = 0,
-                        fuzziness = 0,
                         field = "type"
                     }
                 }

--- a/Src/Couchbase/Search/Queries/Simple/TermQuery.cs
+++ b/Src/Couchbase/Search/Queries/Simple/TermQuery.cs
@@ -59,8 +59,10 @@ namespace Couchbase.Search.Queries.Simple
         {
             var json = base.Export();
             json.Add(new JProperty("term", _term));
-            json.Add(new JProperty("prefix_length", _prefixLength));
-            json.Add(new JProperty("fuzziness", _fuzziness));
+            if(_prefixLength > 0)
+                json.Add(new JProperty("prefix_length", _prefixLength));
+            if(_fuzziness > 0)
+                json.Add(new JProperty("fuzziness", _fuzziness));
 
             if (!string.IsNullOrEmpty(_field))
             {


### PR DESCRIPTION
Currently Couchbase 6.5 does not accept a fuzziness value of 0 while Couchbase 6.0 did.  As it stands the 2.7 SDK cannot make a search for an exact value in FTS.

This stops the code from outputting "fuzziness":0 or "prefix_length":0 allowing the search to succeed.