### PR TITLE
Fix issue with creating Memcached buckets

### DIFF
--- a/src/Couchbase/Management/Buckets/BucketManager.cs
+++ b/src/Couchbase/Management/Buckets/BucketManager.cs
@@ -95,10 +95,14 @@ namespace Couchbase.Management.Buckets
                 {"name", settings.Name},
                 {"bucketType", settings.BucketType.GetDescription()},
                 {"ramQuotaMB", settings.RamQuotaMB.ToString()},
-                {"replicaIndex", settings.ReplicaIndexes ? "1" : "0"},
-                {"replicaNumber", settings.NumReplicas.ToString()},
                 {"flushEnabled", settings.FlushEnabled ? "1" : "0"}
             };
+
+            if(settings.BucketType == BucketType.Couchbase)
+            {
+                values.Add("replicaNumber", settings.NumReplicas.ToString());
+                values.Add("replicaIndex", settings.ReplicaIndexes ? "1" : "0");
+            }
 
             if (settings.ConflictResolutionType.HasValue)
             {

--- a/tests/Couchbase.IntegrationTests/Management/BucketManagerTests.cs
+++ b/tests/Couchbase.IntegrationTests/Management/BucketManagerTests.cs
@@ -16,7 +16,7 @@ namespace Couchbase.IntegrationTests.Management
         }
 
         [Fact]
-        public async Task CreateAndDropBucket()
+        public async Task CreateAndDropCouchbaseBucket()
         {
             var cluster = await _fixture.GetCluster().ConfigureAwait(false);
 
@@ -25,6 +25,40 @@ namespace Couchbase.IntegrationTests.Management
                 BucketType = BucketType.Couchbase,
                 Name = "bucketmgr_test",
                 NumReplicas = 0,
+                RamQuotaMB = 100
+            }).ConfigureAwait(false);
+
+            await Task.Delay(5000).ConfigureAwait(false);
+
+            await cluster.Buckets.DropBucketAsync("bucketmgr_test").ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CreateAndDropMemcached()
+        {
+            var cluster = await _fixture.GetCluster().ConfigureAwait(false);
+
+            await cluster.Buckets.CreateBucketAsync(new BucketSettings
+            {
+                BucketType = BucketType.Memcached,
+                Name = "bucketmgr_test",
+                RamQuotaMB = 100
+            }).ConfigureAwait(false);
+
+            await Task.Delay(5000).ConfigureAwait(false);
+
+            await cluster.Buckets.DropBucketAsync("bucketmgr_test").ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CreateAndDropEphemeral()
+        {
+            var cluster = await _fixture.GetCluster().ConfigureAwait(false);
+
+            await cluster.Buckets.CreateBucketAsync(new BucketSettings
+            {
+                BucketType = BucketType.Ephemeral,
+                Name = "bucketmgr_test",
                 RamQuotaMB = 100
             }).ConfigureAwait(false);
 


### PR DESCRIPTION
Only Couchbase buckets could be created from the SDK, because numReplicas should not be set when creating Memcached and Ephemeral buckets.