### PR TITLE
Added scaling up connections to minium after a temporary connection i…

### DIFF
--- a/src/Couchbase/Core/IO/Connections/DefaultConnectionPoolScaleController.cs
+++ b/src/Couchbase/Core/IO/Connections/DefaultConnectionPoolScaleController.cs
@@ -130,7 +130,7 @@ namespace Couchbase.Core.IO.Connections
                 _logger.LogInformation(
                     "Detected connection less than minimum, scaling up connection pool {endpoint}",
                      _redactor.SystemData(connectionPool.EndPoint));
-                await connectionPool.ScaleAsync(1).ConfigureAwait(false);
+                await connectionPool.ScaleAsync(connectionPool.MinimumSize - size).ConfigureAwait(false);
 
                 // Don't do any further checks
                 return;

--- a/src/Couchbase/Core/IO/Connections/DefaultConnectionPoolScaleController.cs
+++ b/src/Couchbase/Core/IO/Connections/DefaultConnectionPoolScaleController.cs
@@ -122,6 +122,20 @@ namespace Couchbase.Core.IO.Connections
                 }
             }
 
+            if (size < connectionPool.MinimumSize)
+            {
+                // We should scale up
+                // We'll reevaluate on the next cycle if we need to scale up more.
+
+                _logger.LogInformation(
+                    "Detected connection less than minimum, scaling up connection pool {endpoint}",
+                     _redactor.SystemData(connectionPool.EndPoint));
+                await connectionPool.ScaleAsync(1).ConfigureAwait(false);
+
+                // Don't do any further checks
+                return;
+            }
+
             if (size < connectionPool.MaximumSize)
             {
                 // See if we should scale up

--- a/tests/Couchbase.UnitTests/Core/IO/Connections/DefaultConnectionPoolScaleControllerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Connections/DefaultConnectionPoolScaleControllerTests.cs
@@ -102,9 +102,9 @@ namespace Couchbase.UnitTests.Core.IO.Connections
         public async Task RunScalingLogic_BelowMinimumSize_ScaleUp()
         {
             // Arrange
-
+            const int minConnectionPoolSize = 2;
             var connectionPool = CreateMockConnectionPool(
-                0, 2, 5, 0,
+                0, minConnectionPoolSize, 5, 0,
                 Enumerable.Range(1, 1).Select(_ => CreateMockConnection(TimeSpan.Zero)));
 
             var controller = new MockController
@@ -119,7 +119,7 @@ namespace Couchbase.UnitTests.Core.IO.Connections
             // Assert
 
             connectionPool.Verify(
-                m => m.ScaleAsync(1),
+                m => m.ScaleAsync(minConnectionPoolSize),
                 Times.Once);
         }
 

--- a/tests/Couchbase.UnitTests/Core/IO/Connections/DefaultConnectionPoolScaleControllerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Connections/DefaultConnectionPoolScaleControllerTests.cs
@@ -98,6 +98,31 @@ namespace Couchbase.UnitTests.Core.IO.Connections
                 Times.Never);
         }
 
+        [Fact]
+        public async Task RunScalingLogic_BelowMinimumSize_ScaleUp()
+        {
+            // Arrange
+
+            var connectionPool = CreateMockConnectionPool(
+                0, 2, 5, 0,
+                Enumerable.Range(1, 1).Select(_ => CreateMockConnection(TimeSpan.Zero)));
+
+            var controller = new MockController
+            {
+                BackPressureThreshold = 4
+            };
+
+            // Act
+
+            await controller.RunScalingLogicPublic(connectionPool.Object);
+
+            // Assert
+
+            connectionPool.Verify(
+                m => m.ScaleAsync(1),
+                Times.Once);
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(5)]


### PR DESCRIPTION
…ssue causing all connections to be cleaned up

Bug 1 (Fixed by this PR):
After a temporary network failure, all the connections are cleaned up. Any pending requests are requeued onto the send queue. As long as the number of queued messages are fewer than the backpressure setting, no new connection attempts are made and the requests will sit in the queue forever. E.g. the await GetClusterMap in the ConfigHandler poll loop will wait forever even after the network failure is resolved.

Bug 2: (Not fixed by this PR)
In the same scenario as above, requests do not time out as expected.


