### PR TITLE
stream output should be gotten before writers are disposed

### DIFF
--- a/Src/Couchbase.UnitTests/Couchbase.UnitTests.csproj
+++ b/Src/Couchbase.UnitTests/Couchbase.UnitTests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <PackageReference Include="NUnit" Version="3.6.1" />

--- a/Src/Couchbase.UnitTests/Serialization/DefaultSerializerTests.cs
+++ b/Src/Couchbase.UnitTests/Serialization/DefaultSerializerTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core.Serialization;
+using Couchbase.IO;
+using Microsoft.IO;
+using NUnit.Framework;
+
+namespace Couchbase.UnitTests.Serialization
+{
+    [TestFixture]
+    public class DefaultSerializerTests
+    {
+        [Test]
+        public void DefaultSerializer_Serializer_WorksWithRecyclableMemoryStream()
+        {
+            RecyclableMemoryStreamManager manager = new RecyclableMemoryStreamManager(2, 4, 4192 * 16);
+            MemoryStreamFactory.SetFactoryFunc(() => manager.GetStream());
+            var serializer = new DefaultSerializer();
+            var output = serializer.Serialize(new {Value = "Foo"});
+        }
+    }
+}

--- a/Src/Couchbase/Core/Serialization/DefaultSerializer.cs
+++ b/Src/Couchbase/Core/Serialization/DefaultSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -177,9 +177,9 @@ namespace Couchbase.Core.Serialization
                     {
                         var serializer = JsonSerializer.Create(SerializerSettings);
                         serializer.Serialize(jr, obj);
+                        return ms.ToArray();
                     }
                 }
-                return ms.ToArray();
             }
         }
 


### PR DESCRIPTION
The stream writer is causing the recyclable memory stream to be disposed prior to the ToArray call being made.