### PR TITLE
fix custom circuit breaker config not being injected

### DIFF
--- a/src/Couchbase/ClusterOptions.cs
+++ b/src/Couchbase/ClusterOptions.cs
@@ -353,6 +353,11 @@ namespace Couchbase
                 AddSingletonService(DnsResolver);
             }
 
+            if (CircuitBreakerConfiguration != null)
+            {
+                AddSingletonService(CircuitBreakerConfiguration);
+            }
+
             return new CouchbaseServiceProvider(_services);
         }
 

--- a/tests/Couchbase.UnitTests/ConfigurationTests.cs
+++ b/tests/Couchbase.UnitTests/ConfigurationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Couchbase.Core.CircuitBreakers;
 using Couchbase.Core.DI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -9,6 +10,50 @@ namespace Couchbase.UnitTests
 {
     public class ConfigurationTests
     {
+        #region CircuitBreaker
+
+        [Fact]
+        public void CircuitBreakerConfiguration_DefaultCircuitBreakerConfiguration_LoadsInServiceProvider()
+        {
+            // Arrange
+
+            var config = new ClusterOptions();
+
+            // Act
+            // noop
+
+            // Assert
+
+            var serviceProvider = config.BuildServiceProvider();
+            var actualCircuitBreakerConfiguration = serviceProvider.GetService<CircuitBreakerConfiguration>();
+            Assert.Equal(CircuitBreakerConfiguration.Default, actualCircuitBreakerConfiguration);
+        }
+
+        [Fact]
+        public void CircuitBreakerConfiguration_CustomCircuitBreakerConfiguration_LoadsInServiceProvider()
+        {
+            // Arrange
+
+            var config = new ClusterOptions();
+
+            var expectedCircuitBreakerConfiguration = new CircuitBreakerConfiguration
+            {
+                Enabled = false
+            };
+
+            // Act
+
+            config.CircuitBreakerConfiguration = expectedCircuitBreakerConfiguration;
+
+            // Assert
+
+            var serviceProvider = config.BuildServiceProvider();
+            var actualCircuitBreakerConfiguration = serviceProvider.GetService<CircuitBreakerConfiguration>();
+            Assert.Equal(expectedCircuitBreakerConfiguration, actualCircuitBreakerConfiguration);
+        }
+
+        #endregion
+
         #region Logging
 
         [Fact]


### PR DESCRIPTION
Fixes bug in `3.0` where `CircuitBreakerConfiguration` is not injected into DI and is therefore ignored - this means that the default `CircuitBreakerConfiguration` is always used regardless of configuration passed.