### PR TITLE
register provider as scope objects - not singleton

### DIFF
--- a/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,8 +40,8 @@ namespace Couchbase.Extensions.DependencyInjection
 
             services.AddSingleton<NamedBucketProxyGenerator>();
             services.TryAddSingleton<ICouchbaseLifetimeService, CouchbaseLifetimeService>();
-            services.TryAddSingleton<IClusterProvider, ClusterProvider>();
-            services.TryAddSingleton<IBucketProvider, BucketProvider>();
+            services.TryAddScoped<IClusterProvider, ClusterProvider>();
+            services.TryAddScoped<IBucketProvider, BucketProvider>();
 
             if (options != null)
             {


### PR DESCRIPTION
If the providers gets disposed, affects all subsequent requests;  

Also;  provider should not "cache" disposable bucket;  or at the very least, remove them from the collection if they are disposed.  Either the bucket should expose an event or a delegate, called when disposing;  giving a chance to the provider to remove the said object from it's collection.

