### PR TITLE
register provider as scoped

### DIFF
--- a/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ namespace Couchbase.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(bucketName));
             }
 
-            services.AddSingleton(serviceProvider =>
+            services.AddScoped(serviceProvider =>
             {
                 var generator = serviceProvider.GetRequiredService<NamedBucketProxyGenerator>();
 
@@ -93,7 +93,7 @@ namespace Couchbase.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(bucketName));
             }
 
-            services.TryAddSingleton(serviceProvider =>
+            services.TryAddScoped(serviceProvider =>
             {
                 var generator = serviceProvider.GetRequiredService<NamedBucketProxyGenerator>();
 

--- a/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,8 +40,8 @@ namespace Couchbase.Extensions.DependencyInjection
 
             services.AddSingleton<NamedBucketProxyGenerator>();
             services.TryAddSingleton<ICouchbaseLifetimeService, CouchbaseLifetimeService>();
-            services.TryAddSingleton<IClusterProvider, ClusterProvider>();
-            services.TryAddSingleton<IBucketProvider, BucketProvider>();
+            services.TryAddScoped<IClusterProvider, ClusterProvider>();
+            services.TryAddScoped<IBucketProvider, BucketProvider>();
 
             if (options != null)
             {

--- a/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,6 +40,30 @@ namespace Couchbase.Extensions.DependencyInjection
 
             services.AddSingleton<NamedBucketProxyGenerator>();
             services.TryAddSingleton<ICouchbaseLifetimeService, CouchbaseLifetimeService>();
+            services.TryAddSingleton<IClusterProvider, ClusterProvider>();
+            services.TryAddSingleton<IBucketProvider, BucketProvider>();
+
+            if (options != null)
+            {
+                services.Configure(options);
+            }
+
+            return services;
+        }
+
+        /// <summary>
+        /// Add Couchbase dependencies to the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="options">Optional action to configure the <see cref="ClusterOptions"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddScopedCouchbase(this IServiceCollection services,
+            Action<ClusterOptions> options)
+        {
+            services.AddOptions();
+
+            services.AddSingleton<NamedBucketProxyGenerator>();
+            services.TryAddSingleton<ICouchbaseLifetimeService, CouchbaseLifetimeService>();
             services.TryAddScoped<IClusterProvider, ClusterProvider>();
             services.TryAddScoped<IBucketProvider, BucketProvider>();
 
@@ -67,7 +91,7 @@ namespace Couchbase.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(bucketName));
             }
 
-            services.AddScoped(serviceProvider =>
+            services.TryAddSingleton(serviceProvider =>
             {
                 var generator = serviceProvider.GetRequiredService<NamedBucketProxyGenerator>();
 
@@ -79,13 +103,66 @@ namespace Couchbase.Extensions.DependencyInjection
 
         /// <summary>
         /// Register an interface based on <see cref="INamedBucketProvider"/> which will be injected
-        /// with a specific bucket name if the interface hasn't already been added.
+        /// with a specific bucket name if the interface hasn't already been added, using, AddScoped.
         /// </summary>
         /// <typeparam name="T">Interface inherited from <see cref="INamedBucketProvider"/>.  Must not add any members.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="bucketName">The name of the Couchbase bucket.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection TryAddCouchbaseBucket<T>(this IServiceCollection services, string bucketName)
+            where T : class, INamedBucketProvider
+        {
+            if (bucketName == null)
+            {
+                throw new ArgumentNullException(nameof(bucketName));
+            }
+
+            services.TryAddScoped(serviceProvider =>
+            {
+                var generator = serviceProvider.GetRequiredService<NamedBucketProxyGenerator>();
+
+                return generator.GetProxy<T>(serviceProvider.GetRequiredService<IBucketProvider>(), bucketName);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Register an interface based on <see cref="INamedBucketProvider"/> which will be injected
+        /// with a specific bucket name, using TryAddScoped.
+        /// </summary>
+        /// <typeparam name="T">Interface inherited from <see cref="INamedBucketProvider"/>.  Must not add any members.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="bucketName">The name of the Couchbase bucket.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddScopedCouchbaseBucket<T>(this IServiceCollection services, string bucketName)
+            where T : class, INamedBucketProvider
+        {
+            if (bucketName == null)
+            {
+                throw new ArgumentNullException(nameof(bucketName));
+            }
+
+            services.TryAddScoped(serviceProvider =>
+            {
+                var generator = serviceProvider.GetRequiredService<NamedBucketProxyGenerator>();
+
+                return generator.GetProxy<T>(serviceProvider.GetRequiredService<IBucketProvider>(), bucketName);
+            });
+
+            return services;
+        }
+
+
+        /// <summary>
+        /// Register an interface based on <see cref="INamedBucketProvider"/> which will be injected
+        /// with a specific bucket name if the interface hasn't already been added.
+        /// </summary>
+        /// <typeparam name="T">Interface inherited from <see cref="INamedBucketProvider"/>.  Must not add any members.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="bucketName">The name of the Couchbase bucket.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection TryAddScopedCouchbaseBucket<T>(this IServiceCollection services, string bucketName)
             where T : class, INamedBucketProvider
         {
             if (bucketName == null)


### PR DESCRIPTION
When disposing voluntarily (or not);  all subsequent requests are affected.

Furthermore; if a bucket get's disposed; then the cached reference becomes unsuable. The provider should check if the object in his collection is still valid before returning it (GetOrAdd)