### PR TITLE
Possible deadlock

### DIFF
--- a/src/Couchbase/DnsClientDnsResolver.cs
+++ b/src/Couchbase/DnsClientDnsResolver.cs
@@ -42,7 +42,7 @@ namespace Couchbase
         public async Task<IPAddress?> GetIpAddressAsync(string hostName,
             CancellationToken cancellationToken = default)
         {
-            var addresses = (IEnumerable<IPAddress>) await _dotNetDnsClient.GetHostAddressesAsync(hostName);
+            var addresses = (IEnumerable<IPAddress>) await _dotNetDnsClient.GetHostAddressesAsync(hostName).ConfigureAwait(false);
 
             if (IpAddressMode == IpAddressMode.ForceIpv6)
             {


### PR DESCRIPTION
I'm registering the buckets with an Autofac container, so I'm using `.GetAwaiter().GetResult()` to get the IBucket instance.
This is working in all my projects except one where the second call to Cluster.BucketAsync hangs. I have been unable to reproduce this in a small project, as I am clueless why it is happining in the one project and not the others.
However, I tracked the problem down to a missing `ConfigureAwait(false)`
