### PR TITLE
Fix debug message format

### DIFF
--- a/Src/Couchbase/IO/ConnectionPoolBase.cs
+++ b/Src/Couchbase/IO/ConnectionPoolBase.cs
@@ -174,7 +174,7 @@ namespace Couchbase.IO
         {
             if (SupportsEnhancedAuthentication && !connection.CheckedForEnhancedAuthentication) // only execute this if RBAC is enabled on the cluster
             {
-                Log.Debug("Calling SelectBucket on node {node}.", connection.EndPoint);
+                Log.Debug("Calling SelectBucket on node {0}.", connection.EndPoint);
                 if (string.IsNullOrWhiteSpace(Configuration.BucketName))
                 {
                     const string bucketNameIsEmptyMessage = "BucketName cannot be empty when sending SelectBucket operation";


### PR DESCRIPTION
Fixes the following issue when connecting to a Couchbase 6.6.0 cluster using TLS.

```
[2021-01-20 21:59:42,196] [Warning] [Login] [Couchbase.Configuration.Server.Providers.ConfigProviderBase] System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at Common.Logging.Factory.AbstractLogger.StringFormatFormattedMessage.ToString() in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 164
   at Common.Logging.EntLib.EntLibLogger.PopulateLogEntry(LogEntry log, Object message, Exception ex) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 243
   at Common.Logging.EntLib.EntLibLogger.WriteInternal(LogLevel logLevel, Object message, Exception exception) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 170
   at Common.Logging.Factory.AbstractLogger.DebugFormat(String format, Object[] args) in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 467
   at Couchbase.Logging.CommonLoggingLogger.Debug(String format, Object[] args) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Logging\CommonLoggingLogger.cs:line 34
   at Couchbase.IO.ConnectionPoolBase`1.EnableEnhancedAuthentication(IConnection connection) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPoolBase.cs:line 177
   at Couchbase.IO.ConnectionPool`1.Acquire() in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPool.cs:line 124
   at Couchbase.IO.Services.PooledIOService.Execute[T](IOperation`1 operation) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\Services\PooledIOService.cs:line 130
   at Couchbase.Configuration.Server.Providers.CarrierPublication.CarrierPublicationProvider.GetConfig(String bucketName, String username, String password) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Configuration\Server\Providers\CarrierPublication\CarrierPublicationProvider.cs:line 72
[2021-01-20 21:59:42,202] [Warning] [Login] [Couchbase.Core.ClusterController] System.AggregateException: Could not bootstrap with CCCP. ---> System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at Common.Logging.Factory.AbstractLogger.StringFormatFormattedMessage.ToString() in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 164
   at Common.Logging.EntLib.EntLibLogger.PopulateLogEntry(LogEntry log, Object message, Exception ex) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 243
   at Common.Logging.EntLib.EntLibLogger.WriteInternal(LogLevel logLevel, Object message, Exception exception) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 170
   at Common.Logging.Factory.AbstractLogger.DebugFormat(String format, Object[] args) in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 467
   at Couchbase.Logging.CommonLoggingLogger.Debug(String format, Object[] args) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Logging\CommonLoggingLogger.cs:line 34
   at Couchbase.IO.ConnectionPoolBase`1.EnableEnhancedAuthentication(IConnection connection) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPoolBase.cs:line 177
   at Couchbase.IO.ConnectionPool`1.Acquire() in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPool.cs:line 124
   at Couchbase.IO.Services.PooledIOService.Execute[T](IOperation`1 operation) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\Services\PooledIOService.cs:line 130
   at Couchbase.Configuration.Server.Providers.CarrierPublication.CarrierPublicationProvider.GetConfig(String bucketName, String username, String password) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Configuration\Server\Providers\CarrierPublication\CarrierPublicationProvider.cs:line 72
   --- End of inner exception stack trace ---
   at Couchbase.Configuration.Server.Providers.CarrierPublication.CarrierPublicationProvider.GetConfig(String bucketName, String username, String password) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Configuration\Server\Providers\CarrierPublication\CarrierPublicationProvider.cs:line 166
   at Couchbase.Core.ClusterController.CreateBucketImpl(String bucketName, String password, IAuthenticator authenticator) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Core\ClusterController.cs:line 325
---> (Inner Exception #0) System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.FormatError()
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at Common.Logging.Factory.AbstractLogger.StringFormatFormattedMessage.ToString() in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 164
   at Common.Logging.EntLib.EntLibLogger.PopulateLogEntry(LogEntry log, Object message, Exception ex) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 243
   at Common.Logging.EntLib.EntLibLogger.WriteInternal(LogLevel logLevel, Object message, Exception exception) in c:\_oss\common-logging\src\Common.Logging.EntLib60\Logging\EntLib\EntLibLogger.cs:line 170
   at Common.Logging.Factory.AbstractLogger.DebugFormat(String format, Object[] args) in C:\_oss\common-logging\src\Common.Logging.Portable\Logging\Factory\AbstractLogger.cs:line 467
   at Couchbase.Logging.CommonLoggingLogger.Debug(String format, Object[] args) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Logging\CommonLoggingLogger.cs:line 34
   at Couchbase.IO.ConnectionPoolBase`1.EnableEnhancedAuthentication(IConnection connection) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPoolBase.cs:line 177
   at Couchbase.IO.ConnectionPool`1.Acquire() in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\ConnectionPool.cs:line 124
   at Couchbase.IO.Services.PooledIOService.Execute[T](IOperation`1 operation) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\IO\Services\PooledIOService.cs:line 130
   at Couchbase.Configuration.Server.Providers.CarrierPublication.CarrierPublicationProvider.GetConfig(String bucketName, String username, String password) in C:\Users\frasd\Code\couchbase-net-client\Src\Couchbase\Configuration\Server\Providers\CarrierPublication\CarrierPublicationProvider.cs:line 72<---
```