### PR TITLE
Use correct service type name in query context

### DIFF
--- a/src/Couchbase/Query/QueryClient.cs
+++ b/src/Couchbase/Query/QueryClient.cs
@@ -321,7 +321,7 @@ namespace Couchbase.Query
         {
             var span = _tracer.RequestSpan(operation, options.RequestSpanValue);
             span.SetAttribute(OuterRequestSpans.Attributes.System.Key, OuterRequestSpans.Attributes.System.Value);
-            span.SetAttribute(OuterRequestSpans.Attributes.Service, nameof(OuterRequestSpans.ServiceSpan.N1QLQuery).ToLowerInvariant());
+            span.SetAttribute(OuterRequestSpans.Attributes.Service, OuterRequestSpans.ServiceSpan.N1QLQuery);
             span.SetAttribute(OuterRequestSpans.Attributes.BucketName, options.BucketName!);
             span.SetAttribute(OuterRequestSpans.Attributes.ScopeName, options.ScopeName!);
             span.SetAttribute(OuterRequestSpans.Attributes.Operation, operation);


### PR DESCRIPTION
The N1QL service query was using the nameof operator
which doesn't match in the orphan reporter that is
looking for the value of the property and not the name