### PR TITLE
Move the specific BucketExistsException before the generic CouchBaseE…

### DIFF
--- a/src/Couchbase/Management/Buckets/BucketManager.cs
+++ b/src/Couchbase/Management/Buckets/BucketManager.cs
@@ -75,8 +75,7 @@ namespace Couchbase.Management.Buckets
                 //Throw specific exception if a rate limiting exception is thrown.
                 result.ThrowIfRateLimitingError(body, ctx);
 
-                //Throw any other error cases
-                result.ThrowOnError(ctx);
+
 
                 if (result.StatusCode == HttpStatusCode.BadRequest)
                 {
@@ -86,6 +85,9 @@ namespace Couchbase.Management.Buckets
                         throw new BucketExistsException(settings.Name);
                     }
                 }
+
+                //Throw any other error cases
+                result.ThrowOnError(ctx);
             }
             catch (BucketExistsException)
             {


### PR DESCRIPTION
**Expected Behavior:**
When creating a bucket with a name that already exists, the BucketExistsException should be thrown.

**Actual Result:**
When creating a bucket with a name that already exists, the CouchBaseException is thrown.

**How to reproduce:**
Create a bucket with the same name twice:
`ICluster.IBucketManager.CreateBucketAsync(new BucketSettings{ Name = "NICE_BUCKET"})`