### PR TITLE
Pull TermQuery fix forward from 2.7 SDK

### DIFF
--- a/src/Couchbase/Search/Queries/Simple/TermQuery.cs
+++ b/src/Couchbase/Search/Queries/Simple/TermQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace Couchbase.Search.Queries.Simple
@@ -59,9 +59,14 @@ namespace Couchbase.Search.Queries.Simple
         {
             var json = base.Export();
             json.Add(new JProperty("term", _term));
-            json.Add(new JProperty("prefix_length", _prefixLength));
-            json.Add(new JProperty("fuzziness", _fuzziness));
-
+            if (_prefixLength > 0)
+            {
+                json.Add(new JProperty("prefix_length", _prefixLength));
+            }
+            if (_fuzziness > 0)
+            {
+                json.Add(new JProperty("fuzziness", _fuzziness));
+            }
             if (!string.IsNullOrEmpty(_field))
             {
                 json.Add(new JProperty("field", _field));

--- a/tests/Couchbase.UnitTests/Search/BooleanQueryTests.cs
+++ b/tests/Couchbase.UnitTests/Search/BooleanQueryTests.cs
@@ -60,8 +60,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }
@@ -89,8 +87,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }
@@ -118,8 +114,6 @@ namespace Couchbase.UnitTests.Search
                         new
                         {
                             term = "hotel",
-                            prefix_length = 0,
-                            fuzziness = 0,
                             field = "type"
                         }
                     }

--- a/tests/Couchbase.UnitTests/Search/ConjunctionQueryTests.cs
+++ b/tests/Couchbase.UnitTests/Search/ConjunctionQueryTests.cs
@@ -40,8 +40,6 @@ namespace Couchbase.UnitTests.Search
                     new
                     {
                         term = "hotel",
-                        prefix_length = 0,
-                        fuzziness = 0,
                         field = "type"
                     }
                 }

--- a/tests/Couchbase.UnitTests/Search/DisjunctionQueryTests.cs
+++ b/tests/Couchbase.UnitTests/Search/DisjunctionQueryTests.cs
@@ -41,8 +41,6 @@ namespace Couchbase.UnitTests.Search
                     new
                     {
                         term = "hotel",
-                        prefix_length = 0,
-                        fuzziness = 0,
                         field = "type"
                     }
                 }


### PR DESCRIPTION
Changed TermQuery to no longer export "fuzziness"
or "prefix_length" in JSON sent to server when values
are 0.
This fixes an issue in Couchbase 6.5 Server FTS code
which fails when values of 0 are provided for
"fuzziness" or "prefix_length".  See
https://github.com/couchbase/couchbase-net-client/commit/62756837d7a029ce0b762e3edef29c4600b7b6a4
which fixed this issue in the 2.7 SDK.