### PR TITLE
Public Constructor of EventingFunctionKeyspace class

### DIFF
--- a/src/Couchbase/Management/Eventing/EventingFunction.cs
+++ b/src/Couchbase/Management/Eventing/EventingFunction.cs
@@ -173,7 +173,7 @@ namespace Couchbase.Management.Eventing
     /// </summary>
     public class EventingFunctionKeyspace
     {
-        internal EventingFunctionKeyspace(string bucketName, string scopeName, string collectionName)
+        public EventingFunctionKeyspace(string bucketName, string scopeName, string collectionName)
         {
             Bucket = bucketName;
             Scope = scopeName;


### PR DESCRIPTION
made the constructor of EventingFunctionKeyspace class so that users (including myself) could create eventing functions programmatically.
this PR was inspired because I was not allowed to create an object of EventingFunctionKeyspace to create an eventing function programmatically.

Currently, this `new EventingFunctionKeyspace { BucketName = "metadata", ScopeName = "_default", CollectionName = "_default" }` is not possible, this PR should fix it.