### PR TITLE
Remove --no-restore on workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm64, windows-latest, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-latest]
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet restore couchbase-net-client.sln
 
       - name: Build (Release)
-        run: dotnet build couchbase-net-client.sln --configuration Release --no-restore
+        run: dotnet build couchbase-net-client.sln --configuration Release
 
       - name: Test - Couchbase.UnitTests
         run: dotnet test tests/Couchbase.UnitTests/Couchbase.UnitTests.csproj --configuration Release --no-build --logger "trx;LogFileName=unit-tests.trx" --results-directory "TestResults"


### PR DESCRIPTION
We're getting build failures due to `error NETSDK1004: Assets file '[...]Couchbase.Stellar.CodeGen/obj/project.assets.json' not found. Run a NuGet package restore to generate this file. [[...]Couchbase.Stellar.CodeGen/Couchbase.Stellar.CodeGen.csproj::TargetFramework=net8.0]` for both .NET 8 and 10.

Removing the --no-restore might auto-run it for this project, else we might have to add an additional step.