### PR TITLE
NCBC-4244: Raw byte[] sub-document reads over couchbase2

### DIFF
--- a/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
+++ b/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
@@ -322,12 +322,18 @@ namespace Couchbase.FitPerformer
                     // contentAs<byte[]> base64-decodes instead of returning the raw wire bytes. When a
                     // spec reads byte[], supply a passthrough serializer (mirroring Java) via a per-op
                     // transcoder so the raw fragment bytes are returned. Opt-in per-op; does not change
-                    // the SDK default (Queue<byte[]>/CBSE-22994 unaffected). Non-byte[] specs still use
-                    // normal JSON, so mixed-spec lookups behave correctly.
+                    // the SDK default (Queue<byte[]>/CBSE-22994 unaffected). Decorate the cluster's
+                    // *configured* serializer (honoring UseCustomSerializer) rather than hard-coding
+                    // DefaultSerializer, so non-byte[] specs in a mixed-spec lookup keep the cluster's
+                    // serialization semantics.
                     if (request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray))
                     {
+                        var configuredSerializer =
+                            connection.Cluster.ClusterServices.GetService(typeof(Couchbase.Core.IO.Serializers.ITypeSerializer))
+                                as Couchbase.Core.IO.Serializers.ITypeSerializer
+                            ?? new Couchbase.Core.IO.Serializers.DefaultSerializer();
                         options = options.Transcoder(new Couchbase.Core.IO.Transcoders.JsonTranscoder(
-                            new Couchbase.Core.IO.Serializers.RawByteArraySerializer(new Couchbase.Core.IO.Serializers.DefaultSerializer())));
+                            new Couchbase.Core.IO.Serializers.RawByteArraySerializer(configuredSerializer)));
                     }
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);

--- a/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
+++ b/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
@@ -317,24 +317,9 @@ namespace Couchbase.FitPerformer
                 {
                     var request = op.CollectionCommand.LookupIn;
                     var options = OptionsUtil.ConvertLookupInOptions(request.Options);
-                    // contentAs(byte[]) is a raw-passthrough read cross-SDK (see the Java performer /
-                    // DefaultJsonSerializer). .NET's default serializer base64s byte[], so a bare
-                    // contentAs<byte[]> base64-decodes instead of returning the raw wire bytes. When a
-                    // spec reads byte[], supply a passthrough serializer (mirroring Java) via a per-op
-                    // transcoder so the raw fragment bytes are returned. Opt-in per-op; does not change
-                    // the SDK default (Queue<byte[]>/CBSE-22994 unaffected). Decorate the cluster's
-                    // *configured* serializer (honoring UseCustomSerializer) rather than hard-coding
-                    // DefaultSerializer, so non-byte[] specs in a mixed-spec lookup keep the cluster's
-                    // serialization semantics.
-                    if (request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray))
-                    {
-                        var configuredSerializer =
-                            connection.Cluster.ClusterServices.GetService(typeof(Couchbase.Core.IO.Serializers.ITypeSerializer))
-                                as Couchbase.Core.IO.Serializers.ITypeSerializer
-                            ?? new Couchbase.Core.IO.Serializers.DefaultSerializer();
-                        options = options.Transcoder(new Couchbase.Core.IO.Transcoders.JsonTranscoder(
-                            new Couchbase.Core.IO.Serializers.RawByteArraySerializer(configuredSerializer)));
-                    }
+                    var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
+                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                    if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
                     result.Initiated = Timestamp.FromDateTime(DateTime.UtcNow);
@@ -349,6 +334,9 @@ namespace Couchbase.FitPerformer
                 {
                     var request = op.CollectionCommand.LookupInAllReplicas;
                     var options = OptionsUtil.ConvertLookupInAllReplicasOptions(request.Options, _spans);
+                    var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
+                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                    if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
                     result.Initiated = Timestamp.FromDateTime(DateTime.UtcNow);
@@ -374,6 +362,9 @@ namespace Couchbase.FitPerformer
                 {
                     var request = op.CollectionCommand.LookupInAnyReplica;
                     var options = OptionsUtil.ConvertLookupInAnyReplicasOptions(request.Options, _spans);
+                    var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
+                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                    if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
                     result.Initiated = Timestamp.FromDateTime(DateTime.UtcNow);
@@ -387,6 +378,27 @@ namespace Couchbase.FitPerformer
                 default:
                     throw new NotSupportedException("Unknown Collection Command");
             }
+        }
+
+        // contentAs(byte[]) is a raw-passthrough read cross-SDK (see the Java performer /
+        // DefaultJsonSerializer). .NET's default serializer base64s byte[], so a bare
+        // contentAs<byte[]> base64-decodes instead of returning the raw wire bytes. When any spec
+        // reads byte[], supply a passthrough serializer (mirroring Java) via a per-op transcoder so
+        // the raw fragment bytes are returned. Opt-in per-op; does not change the SDK default
+        // (Queue<byte[]>/CBSE-22994 unaffected). Decorate the cluster's *configured* serializer
+        // (honoring UseCustomSerializer) rather than hard-coding DefaultSerializer, so non-byte[]
+        // specs in a mixed-spec lookup keep the cluster's serialization semantics. Shared by the
+        // LookupIn / LookupInAllReplicas / LookupInAnyReplica paths.
+        private static Couchbase.Core.IO.Transcoders.ITypeTranscoder? RawByteArrayTranscoderIfNeeded(
+            bool anyByteArraySpec, ClusterConnection connection)
+        {
+            if (!anyByteArraySpec) return null;
+            var configuredSerializer =
+                connection.Cluster.ClusterServices.GetService(typeof(Couchbase.Core.IO.Serializers.ITypeSerializer))
+                    as Couchbase.Core.IO.Serializers.ITypeSerializer
+                ?? new Couchbase.Core.IO.Serializers.DefaultSerializer();
+            return new Couchbase.Core.IO.Transcoders.JsonTranscoder(
+                new Couchbase.Core.IO.Serializers.RawByteArraySerializer(configuredSerializer));
         }
 
         private static async Task HandleScopeLevelCommand(Grpc.Protocol.Sdk.Command op, ClusterConnection connection, Result result)

--- a/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
+++ b/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
@@ -317,6 +317,18 @@ namespace Couchbase.FitPerformer
                 {
                     var request = op.CollectionCommand.LookupIn;
                     var options = OptionsUtil.ConvertLookupInOptions(request.Options);
+                    // contentAs(byte[]) is a raw-passthrough read cross-SDK (see the Java performer /
+                    // DefaultJsonSerializer). .NET's default serializer base64s byte[], so a bare
+                    // contentAs<byte[]> base64-decodes instead of returning the raw wire bytes. When a
+                    // spec reads byte[], supply a passthrough serializer (mirroring Java) via a per-op
+                    // transcoder so the raw fragment bytes are returned. Opt-in per-op; does not change
+                    // the SDK default (Queue<byte[]>/CBSE-22994 unaffected). Non-byte[] specs still use
+                    // normal JSON, so mixed-spec lookups behave correctly.
+                    if (request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray))
+                    {
+                        options = options.Transcoder(new Couchbase.Core.IO.Transcoders.JsonTranscoder(
+                            new Couchbase.Core.IO.Serializers.RawByteArraySerializer(new Couchbase.Core.IO.Serializers.DefaultSerializer())));
+                    }
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
                     result.Initiated = Timestamp.FromDateTime(DateTime.UtcNow);

--- a/src/Couchbase/Core/IO/Serializers/RawByteArraySerializer.cs
+++ b/src/Couchbase/Core/IO/Serializers/RawByteArraySerializer.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Couchbase.Core.IO.Serializers
+{
+    /// <summary>
+    /// An <see cref="ITypeSerializer"/> decorator that treats <see langword="byte"/>[] as a raw
+    /// pass-through in both directions and delegates every other type to an inner serializer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default serializers (Newtonsoft and System.Text.Json) encode a <see langword="byte"/>[]
+    /// as a Base64 JSON string, so a plain <c>ContentAs&lt;byte[]&gt;()</c> Base64-decodes. That is
+    /// required for round-tripping arbitrary binary through data structures such as
+    /// <c>PersistentQueue&lt;byte[]&gt;</c>. When you instead want the <em>raw</em> encoded bytes of a
+    /// value (for example, the raw JSON of a sub-document fragment), wrap the configured serializer in
+    /// this decorator and supply it via a per-operation transcoder. This matches the behaviour of the
+    /// Java SDK's default serializer, where <c>byte[]</c> is always raw pass-through.
+    /// </para>
+    /// <para>
+    /// Because non-<see langword="byte"/>[] types are delegated to the inner serializer, its JSON
+    /// semantics (converters, naming policy, AOT source generation, etc.) are preserved. This type
+    /// implements only <see cref="ITypeSerializer"/>; it does not forward the extended serializer
+    /// interfaces (projections, streaming), so it is intended for per-operation use (e.g. a raw
+    /// <see langword="byte"/>[] sub-document read) rather than as a cluster-wide serializer.
+    /// </para>
+    /// </remarks>
+    public sealed class RawByteArraySerializer : ITypeSerializer
+    {
+        private readonly ITypeSerializer _inner;
+
+        /// <summary>
+        /// Creates a <see cref="RawByteArraySerializer"/> wrapping the serializer that should handle
+        /// all non-<see langword="byte"/>[] types.
+        /// </summary>
+        /// <param name="inner">The serializer to delegate to for non-<see langword="byte"/>[] types.</param>
+        public RawByteArraySerializer(ITypeSerializer inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        /// <inheritdoc />
+        public T? Deserialize<T>(ReadOnlyMemory<byte> buffer) =>
+            typeof(T) == typeof(byte[]) ? (T)(object)buffer.ToArray() : _inner.Deserialize<T>(buffer);
+
+        /// <inheritdoc />
+        public T? Deserialize<T>(Stream stream)
+        {
+            if (typeof(T) == typeof(byte[]))
+            {
+                using var ms = new MemoryStream();
+                stream.CopyTo(ms);
+                return (T)(object)ms.ToArray();
+            }
+
+            return _inner.Deserialize<T>(stream);
+        }
+
+        /// <inheritdoc />
+        public async ValueTask<T?> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+        {
+            if (typeof(T) == typeof(byte[]))
+            {
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms, 81920, cancellationToken).ConfigureAwait(false);
+                return (T)(object)ms.ToArray();
+            }
+
+            return await _inner.DeserializeAsync<T>(stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void Serialize(Stream stream, object? obj)
+        {
+            if (obj is byte[] bytes)
+            {
+                stream.Write(bytes, 0, bytes.Length);
+                return;
+            }
+
+            _inner.Serialize(stream, obj);
+        }
+
+        /// <inheritdoc />
+        public async ValueTask SerializeAsync(Stream stream, object? obj, CancellationToken cancellationToken = default)
+        {
+            if (obj is byte[] bytes)
+            {
+                await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            await _inner.SerializeAsync(stream, obj, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
+++ b/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
@@ -282,6 +282,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         _stellarCluster.ThrowIfBootStrapFailed();
 
         var opts = options?.AsReadOnly() ?? LookupInOptions.DefaultReadOnly;
+        var transcoder = opts.Transcoder ?? _stellarCluster.TypeTranscoder;
         using var childSpan = TraceSpan(OuterRequestSpans.ServiceSpan.Kv.LookupIn, opts.RequestSpan);
         var request = KeyedRequest<LookupInRequest>(id);
         foreach (var spec in specs)
@@ -302,7 +303,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         };
         stellarRequest.SetMetrics(OuterRequestSpans.ServiceSpan.Kv.Name, OuterRequestSpans.ServiceSpan.Kv.LookupIn, childSpan, _bucketName, _scopeName, Name);
         var response = await _retryHandler.RetryAsync(GrpcCall, stellarRequest).ConfigureAwait(false);
-        return new LookupInResult(response, request, _stellarCluster.TypeTranscoder);
+        return new LookupInResult(response, request, transcoder);
 
         async Task<LookupInResponse> GrpcCall()
         {
@@ -364,7 +365,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         };
         stellarRequest.SetMetrics(OuterRequestSpans.ServiceSpan.Kv.Name, OuterRequestSpans.ServiceSpan.Kv.MutateIn, childSpan, _bucketName, _scopeName, Name);
         var response = await _retryHandler.RetryAsync(GrpcCall, stellarRequest).ConfigureAwait(false);
-        return new MutateInResult(response, request, _stellarCluster.TypeTranscoder);
+        return new MutateInResult(response, request, transcoder);
 
         async Task<MutateInResponse> GrpcCall()
         {

--- a/src/Couchbase/Stellar/Util/ResultTypes.cs
+++ b/src/Couchbase/Stellar/Util/ResultTypes.cs
@@ -96,6 +96,9 @@ namespace Couchbase.Stellar.KeyValue
             var spec = SpecOrInvalid(index);
             if (spec.Status == null || spec.Status.Code == (int)StatusCode.OK)
             {
+                // ContentFlags is 0 by design: protostellar's LookupIn/MutateIn responses carry no per-spec
+                // content flags. Subdoc fragments are JSON and decode via the serializer (flags unused);
+                // whole-doc reads that need flags go through Get/GetResponse, which does carry them. Matches classic.
                 var contentWrapper = new GrpcContentWrapper(Content: spec.Content.Memory, ContentFlags: 0,
                     Transcoder, IsFullDoc: OriginalRequest.Specs[index].Path.Length == 0);
                 return contentWrapper.ContentAs<T>();
@@ -159,6 +162,9 @@ namespace Couchbase.Stellar.KeyValue
         public T? ContentAs<T>(int index)
         {
             var spec = SpecOrInvalid(index);
+            // ContentFlags is 0 by design: protostellar's LookupIn/MutateIn responses carry no per-spec
+            // content flags. Subdoc fragments are JSON and decode via the serializer (flags unused);
+            // whole-doc reads that need flags go through Get/GetResponse, which does carry them. Matches classic.
             var contentWrapper = new GrpcContentWrapper(Content: spec.Content.Memory, ContentFlags: 0, Transcoder: Transcoder, IsFullDoc: false);
             return contentWrapper.ContentAs<T>();
         }

--- a/tests/Couchbase.Stellar.CombinationTests/KeyValue/StellarByteArraySubdocTests.cs
+++ b/tests/Couchbase.Stellar.CombinationTests/KeyValue/StellarByteArraySubdocTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading.Tasks;
+using Couchbase.Core.IO.Transcoders;
+using Couchbase.KeyValue;
+using Couchbase.Stellar.CombinationTests.Fixtures;
+using Xunit;
+
+namespace Couchbase.Stellar.CombinationTests.KeyValue
+{
+    // Regression coverage for CBSE-22994 over couchbase2 / protostellar.
+    // A byte[] stored as a JSON value round-trips as a quoted Base64 string. The sub-document
+    // read path (PersistentQueue<byte[]> and LookupIn(...).ContentAs<byte[]>()) must JSON-decode
+    // that string back to the original bytes. NCBC-4069 had added a byte[] fast-path to
+    // DefaultSerializer that returned the raw fragment instead, silently corrupting the value.
+    [Collection(StellarTestCollection.Name)]
+    public class StellarByteArraySubdocTests
+    {
+        private readonly StellarFixture _fixture;
+
+        public StellarByteArraySubdocTests(StellarFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        private static readonly byte[] Original = { 10, 36, 102, 50, 56, 98, 49, 51 };
+
+        [Fact]
+        public async Task Queue_ByteArray_RoundTrips()
+        {
+            var collection = await _fixture.DefaultCollection();
+            var docId = "cbse22994-queue-" + Guid.NewGuid();
+            var queue = collection.Queue<byte[]>(docId);
+
+            try
+            {
+                await queue.EnqueueAsync(Original);
+
+                var peeked = await queue.PeekAsync();
+                Assert.Equal(Original, peeked);
+
+                var dequeued = await queue.DequeueAsync();
+                Assert.Equal(Original, dequeued);
+            }
+            finally
+            {
+                try { await collection.RemoveAsync(docId); } catch { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task LookupIn_SubDocPath_ContentAsByteArray_RoundTrips()
+        {
+            var collection = await _fixture.DefaultCollection();
+            var docId = "cbse22994-subdoc-" + Guid.NewGuid();
+
+            try
+            {
+                await collection.UpsertAsync(docId, new { data = Original });
+
+                var result = await collection.LookupInAsync(docId, specs => specs.Get("data"));
+                var retrieved = result.ContentAs<byte[]>(0);
+
+                Assert.Equal(Original, retrieved);
+            }
+            finally
+            {
+                try { await collection.RemoveAsync(docId); } catch { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task List_ByteArray_RoundTrips()
+        {
+            var collection = await _fixture.DefaultCollection();
+            var docId = "cbse22994-list-" + Guid.NewGuid();
+            var list = collection.List<byte[]>(docId);
+
+            try
+            {
+                await list.AddAsync(Original);
+
+                byte[]? retrieved = null;
+                await foreach (var item in list)
+                {
+                    retrieved = item;
+                    break;
+                }
+
+                Assert.Equal(Original, retrieved);
+            }
+            finally
+            {
+                try { await collection.RemoveAsync(docId); } catch { /* best effort */ }
+            }
+        }
+
+        // Whole-document byte[] round-trip. The design-correct path is RawBinaryTranscoder:
+        // it encodes with the Binary content flag, and Stellar's GrpcContentWrapper routes a
+        // full-doc read through Transcoder.Decode (the default JsonTranscoder throws for byte[]).
+        [Fact]
+        public async Task FullDoc_ByteArray_RawBinaryTranscoder_RoundTrips()
+        {
+            var collection = await _fixture.DefaultCollection();
+            var docId = "cbse22994-fulldoc-" + Guid.NewGuid();
+            var transcoder = new RawBinaryTranscoder();
+
+            try
+            {
+                await collection.UpsertAsync(docId, Original, options => options.Transcoder(transcoder));
+
+                var result = await collection.GetAsync(docId, options => options.Transcoder(transcoder));
+                var retrieved = result.ContentAs<byte[]>();
+
+                Assert.Equal(Original, retrieved);
+            }
+            finally
+            {
+                try { await collection.RemoveAsync(docId); } catch { /* best effort */ }
+            }
+        }
+
+        // Parity regression: Stellar LookupIn/MutateIn must honor a per-operation Transcoder, like the
+        // classic SDK. Previously these dropped opts.Transcoder and always used the cluster transcoder,
+        // so a whole-doc GetFull read as byte[] with RawBinaryTranscoder threw (JsonTranscoder fallback).
+        [Fact]
+        public async Task LookupIn_GetFull_HonorsPerOpTranscoder()
+        {
+            var collection = await _fixture.DefaultCollection();
+            var docId = "cbse22994-lookup-transcoder-" + Guid.NewGuid();
+            var transcoder = new RawBinaryTranscoder();
+
+            try
+            {
+                await collection.UpsertAsync(docId, Original, options => options.Transcoder(transcoder));
+
+                var result = await collection.LookupInAsync(docId, specs => specs.GetFull(),
+                    new LookupInOptions().Transcoder(transcoder));
+                var retrieved = result.ContentAs<byte[]>(0);
+
+                Assert.Equal(Original, retrieved);
+            }
+            finally
+            {
+                try { await collection.RemoveAsync(docId); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/Core/IO/Serializers/RawByteArraySerializerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Serializers/RawByteArraySerializerTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Text;
+using Couchbase.Core.IO.Serializers;
+using Xunit;
+
+namespace Couchbase.UnitTests.Core.IO.Serializers
+{
+    public class RawByteArraySerializerTests
+    {
+        [Fact]
+        public void Constructor_NullInner_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RawByteArraySerializer(null!));
+        }
+
+        [Fact]
+        public void Deserialize_ByteArray_ReturnsRawBytes_NotBase64Decoded()
+        {
+            // RawByteArraySerializer passes byte[] through raw, unlike the default serializer which
+            // treats a byte[] as a Base64 JSON string. Given the raw JSON bytes of a sub-document
+            // fragment, Deserialize<byte[]> returns those exact bytes -- the cross-SDK
+            // contentAs(byte[]) contract.
+            var serializer = new RawByteArraySerializer(new DefaultSerializer());
+            var raw = Encoding.UTF8.GetBytes("{\"content\":\"initial\"}");
+
+            var result = serializer.Deserialize<byte[]>(new ReadOnlyMemory<byte>(raw));
+
+            Assert.Equal(raw, result);
+        }
+
+        [Fact]
+        public void Serialize_ByteArray_WritesRawBytes()
+        {
+            var serializer = new RawByteArraySerializer(new DefaultSerializer());
+            var original = new byte[] { 10, 36, 102, 50, 56, 98, 49, 51 };
+
+            using var stream = new MemoryStream();
+            serializer.Serialize(stream, original);
+
+            // Raw bytes, not a quoted Base64 string.
+            Assert.Equal(original, stream.ToArray());
+        }
+
+        [Fact]
+        public void Deserialize_NonByteArray_DelegatesToInner()
+        {
+            var serializer = new RawByteArraySerializer(new DefaultSerializer());
+            var json = Encoding.UTF8.GetBytes("\"hello\"");
+
+            var result = serializer.Deserialize<string>(new ReadOnlyMemory<byte>(json));
+
+            Assert.Equal("hello", result);
+        }
+
+        [Fact]
+        public void Serialize_NonByteArray_DelegatesToInner()
+        {
+            var serializer = new RawByteArraySerializer(new DefaultSerializer());
+
+            using var stream = new MemoryStream();
+            serializer.Serialize(stream, "hello");
+
+            Assert.Equal("\"hello\"", Encoding.UTF8.GetString(stream.ToArray()));
+        }
+    }
+}


### PR DESCRIPTION
Motivation
==========
Completing the byte[] sub-document work over couchbase2 (on top of the NCBC-4243 classic fix) surfaced three gaps:

- StellarCollection.LookupInAsync/MutateInAsync silently ignored the per-operation Transcoder and always used the cluster default, unlike the classic SDK (OperationConfigurator honors opts.Transcoder). A custom transcoder passed to LookupIn/MutateIn over couchbase2 was dropped.

- contentAs(byte[]) on a sub-document is a raw-bytes passthrough cross-SDK (the Java SDK's default serializer returns byte[] as-is). .NET's default serializers encode byte[] as a Base64 JSON string -- which Queue<byte[]>/ List<byte[]> (CBSE-22994) rely on -- so a bare ContentAs<byte[]> Base64- decodes, and there is no way to read the raw bytes of a fragment. The FIT test contentAsBytesGetLookup needs those raw bytes.

- The ContentFlags:0 used by the Stellar sub-document results was an undocumented "// TODO".

Modifications
=============
- StellarCollection: honor opts.Transcoder in LookupInAsync (transcoder = opts.Transcoder ?? cluster default) and MutateInAsync (pass the already-computed transcoder into MutateInResult).

- Add RawByteArraySerializer, an ITypeSerializer decorator: byte[] is raw passthrough both ways, other types delegate to an inner serializer (preserving its JSON semantics/converters/AOT). Wrapping the configured serializer via a per-op transcoder yields raw sub-document bytes without changing the SDK default. Per-op use, not cluster-wide.

- Document why Stellar LookupInResult/MutateInResult use ContentFlags:0 (protostellar carries no per-spec content flags; sub-doc fragments are JSON; whole-doc reads that need flags use Get/GetResponse).

- FIT performer (fit/Couchbase.FitPerformer): in the LookupIn path, when a spec reads byte[], supply a RawByteArraySerializer via a per-op transcoder so ContentAs<byte[]> returns the raw fragment bytes.

- Add and expand the Stellar combination tests: Queue<byte[]> / List<byte[]> round-trip, whole-doc byte[] via RawBinaryTranscoder, and a LookupIn per-op transcoder regression, validating the CBSE-22994 fix over couchbase2 / protostellar. These require the couchbase2 gateway (port 18098) and are not run in CI unless that gateway is available.

Results
=======
Unit tests pass (including a new RawByteArraySerializer test). The new and updated Stellar combination byte[] tests pass, and the FIT contentAsBytesGetLookup test now passes over couchbase2 (it failed before this change).

