### PR TITLE
NCBC-4256: Fix first-run failures in the release workflow (build + pack)

### DIFF
--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -196,12 +196,14 @@ jobs:
         shell: bash
         run: |
           # Reversible round-trip under the same sdk-api/ prefix the real publish
-          # uses, so publish=false exercises the OIDC role's write + public-read ACL
-          # to the docs bucket without publishing real docs.
+          # uses. The real publish is `aws s3 sync --delete`, so exercise every op
+          # it needs -- PutObject, PutObjectAcl, ListBucket, DeleteObject -- so a
+          # green smoke guarantees the real docs publish will work. bash runs with
+          # -eo pipefail, so any denied op fails the step (no best-effort here).
           KEY="sdk-api/_smoke/smoke-${{ github.run_id }}.txt"
           echo "docs-smoke ${{ github.run_id }}" > smoke.txt
-          aws s3 cp smoke.txt "s3://${S3_BUCKET}/${KEY}" --acl public-read
-          curl -fsSI "https://${S3_BUCKET}/${KEY}" > /dev/null
-          echo "✓ docs S3 write/read OK: https://${S3_BUCKET}/${KEY}"
-          aws s3 rm "s3://${S3_BUCKET}/${KEY}" \
-            || echo "⚠ Could not delete smoke object (role may lack s3:DeleteObject) — harmless, remove manually."
+          aws s3 cp smoke.txt "s3://${S3_BUCKET}/${KEY}" --acl public-read   # PutObject + PutObjectAcl
+          curl -fsSI "https://${S3_BUCKET}/${KEY}" > /dev/null               # public-read landed
+          aws s3 ls "s3://${S3_BUCKET}/sdk-api/_smoke/" > /dev/null          # ListBucket (sync diffs the prefix)
+          aws s3 rm "s3://${S3_BUCKET}/${KEY}"                               # DeleteObject (sync --delete)
+          echo "✓ docs S3 access verified (put + public-read acl + list + delete)"

--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -15,6 +15,19 @@ on:
         type: boolean
         required: false
         default: false
+  workflow_call:
+    inputs:
+      version_tag:
+        type: string
+        required: true
+      build_ref:
+        type: string
+        required: false
+        default: ''
+      publish:
+        type: boolean
+        required: false
+        default: false
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -34,9 +47,10 @@ jobs:
         name: Compute version, ref, publish flag
         shell: bash
         env:
-          INPUT_TAG: ${{ github.event.inputs.version_tag }}
-          INPUT_BUILD_REF: ${{ github.event.inputs.build_ref }}
-          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+          # `inputs` is populated for both workflow_dispatch and workflow_call.
+          INPUT_TAG: ${{ inputs.version_tag }}
+          INPUT_BUILD_REF: ${{ inputs.build_ref }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
         run: |
           TAG_INPUT="$INPUT_TAG"
           BUILD_REF_INPUT="$INPUT_BUILD_REF"

--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -144,6 +144,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-inputs, build-docs]
     if: needs.validate-inputs.outputs.publish == 'true'
+    permissions:
+      id-token: write   # required to mint the GitHub OIDC token for AWS
+      contents: read
     env:
       VERSION: ${{ needs.validate-inputs.outputs.version }}
       API_NAME: couchbase-net-client
@@ -161,13 +164,44 @@ jobs:
           mkdir -p site
           unzip -q "./apidocs/$API_NAME-$VERSION.zip" -d site
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::786014483886:role/SDK_GHA
 
       - name: Publish to S3
         run: |
           aws s3 sync ./site/ "s3://$S3_BUCKET/sdk-api/$API_NAME-$VERSION/" --acl public-read --delete
+
+  smoke-docs-s3:
+    name: Smoke test docs S3 access
+    runs-on: ubuntu-latest
+    needs: [validate-inputs]
+    if: needs.validate-inputs.outputs.publish != 'true'
+    permissions:
+      id-token: write   # required to mint the GitHub OIDC token for AWS
+      contents: read
+    env:
+      AWS_REGION: us-west-1
+      S3_BUCKET: docs.couchbase.com
+    steps:
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::786014483886:role/SDK_GHA
+
+      - name: Smoke test docs S3 write access
+        shell: bash
+        run: |
+          # Reversible round-trip under the same sdk-api/ prefix the real publish
+          # uses, so publish=false exercises the OIDC role's write + public-read ACL
+          # to the docs bucket without publishing real docs.
+          KEY="sdk-api/_smoke/smoke-${{ github.run_id }}.txt"
+          echo "docs-smoke ${{ github.run_id }}" > smoke.txt
+          aws s3 cp smoke.txt "s3://${S3_BUCKET}/${KEY}" --acl public-read
+          curl -fsSI "https://${S3_BUCKET}/${KEY}" > /dev/null
+          echo "✓ docs S3 write/read OK: https://${S3_BUCKET}/${KEY}"
+          aws s3 rm "s3://${S3_BUCKET}/${KEY}" \
+            || echo "⚠ Could not delete smoke object (role may lack s3:DeleteObject) — harmless, remove manually."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,3 +430,15 @@ jobs:
             echo "- Packages built:"
             for pkg in ./artifacts/*.nupkg; do echo "  - \`$(basename "$pkg")\`"; done
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Build (and, on a real release, publish) the API docs using the same publish
+  # value this release was invoked with. apidocs.yml stays independently
+  # dispatchable; here it runs automatically as part of the release.
+  publish-docs:
+    name: API Docs
+    needs: [validate-inputs, pack]
+    uses: ./.github/workflows/apidocs.yml
+    with:
+      version_tag: ${{ needs.validate-inputs.outputs.tag }}
+      publish: ${{ needs.validate-inputs.outputs.publish == 'true' }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         run: dotnet restore couchbase-net-client.sln
 
       - name: Build (Release)
-        run: dotnet build couchbase-net-client.sln --configuration Release --no-restore /p:Version=${{ needs.validate-inputs.outputs.version }}
+        run: dotnet build couchbase-net-client.sln --configuration Release /p:Version=${{ needs.validate-inputs.outputs.version }}
 
       - name: Test - Couchbase.UnitTests (net8.0)
         run: dotnet test tests/Couchbase.UnitTests/Couchbase.UnitTests.csproj --configuration Release --framework net8.0 --no-build --logger "trx;LogFileName=unit-tests-net8.0.trx" --results-directory "TestResults"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,8 +437,10 @@ jobs:
   publish-docs:
     name: API Docs
     needs: [validate-inputs, pack]
+    permissions:
+      id-token: write   # apidocs.yml uses OIDC to reach the docs S3 bucket
+      contents: read
     uses: ./.github/workflows/apidocs.yml
     with:
       version_tag: ${{ needs.validate-inputs.outputs.tag }}
       publish: ${{ needs.validate-inputs.outputs.publish == 'true' }}
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
             dotnet pack $proj `
               -c Release `
               --output artifacts `
+              /p:GeneratePackageOnBuild=false `
               /p:ContinuousIntegrationBuild=true `
               /p:Version="$env:VERSION" `
               /p:IncludeSymbols=true `


### PR DESCRIPTION

  The release workflow (added in NCBC-4223) had never actually run; its first
  execution surfaced two build/pack bugs, both fixed here:

  - Build: drop `--no-restore` from the build-and-test step. Solution-level
    `dotnet restore` doesn't generate project.assets.json for the
    Couchbase.Stellar.CodeGen source-generator project, so the `--no-restore`
    build failed with NETSDK1004. This matches build-and-test.yml, which builds
    the same solution without `--no-restore`.

  - Pack: pass `/p:GeneratePackageOnBuild=false` to `dotnet pack`.
    Couchbase.csproj sets GeneratePackageOnBuild=true, which makes `dotnet pack`
    skip the build and fail with NU5026 (net10.0 assembly not found) on a fresh
    runner. The flag restores pack's normal build-then-pack behaviour, matching
    the old Jenkins packProject that built before packing.

  Verified with a publish=false smoke run: build, strong-name signing
  (NETSDK_SIGNKEY), pack, and the AWS OIDC S3 access check all pass.
