### PR TITLE
NCBC-4258: Limit grpc message sizes in Stellar

### DIFF
--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -135,7 +135,7 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         {
             LoggerFactory = clusterOptions.Logging,
             HttpHandler = socketsHandler,
-            MaxReceiveMessageSize = null, // gRPC default is 4MB, which is too small for Couchbase documents
+            MaxReceiveMessageSize = 25 * 1024 * 1024, // 25 MiB (26214400 bytes) per RFC 77; accommodates the 20MB max doc plus overhead (gRPC default of 4MB is too small)
         };
 
         GrpcChannel = GrpcChannel.ForAddress(_clusterOptions.ConnectionStringValue!.GetStellarBootstrapUri(), grpcChannelOptions);


### PR DESCRIPTION
Motivation
==========
We should comply with our RFC - this was missing.

Modification
============
RFC only wants the receive message limit, so we just added that to the setup of the GrpcChannel.

Results
=======
Tests all pass, etc...