### PR TITLE
NCBC-4259 Base Stellar timeout ambiguity on read-only, not idempotent

### DIFF
--- a/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
+++ b/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
@@ -55,7 +55,8 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
 
         var stellarRequest = new StellarRequest
         {
-            Idempotent = true,
+            // A read-only query is safe to retry and unambiguous on timeout; a mutating one is neither.
+            Idempotent = opts.Readonly,
             Token = opts.Token,
             Timeout = opts.Timeout ?? _stellarCluster.ClusterOptions.AnalyticsTimeout
         };

--- a/src/Couchbase/Stellar/Core/Retry/StellarRequest.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRequest.cs
@@ -33,22 +33,14 @@ public class StellarRequest : IRequest
     public uint Attempts { get; set; }
     public bool Idempotent { get; set; }
 
-    private bool? _readOnly;
-
     /// <summary>
-    /// Whether the operation only reads server state (i.e. never mutates data, expiry, or locks).
-    /// This drives ambiguous-vs-unambiguous timeout classification: a read-only op that times out
-    /// definitively did not mutate state (<see cref="Couchbase.Core.Exceptions.UnambiguousTimeoutException"/>),
-    /// whereas a mutating op might have (<see cref="Couchbase.Core.Exceptions.AmbiguousTimeoutException"/>).
-    /// Mirrors the classic SDK, where <c>IRequest.Idempotent</c> is defined as <c>IsReadOnly</c>
-    /// (see OperationBase). Defaults to <see cref="Idempotent"/> when not set explicitly, as the two
-    /// coincide for most operations; KV operations that are idempotent yet mutate state
-    /// (GetAndLock, GetAndTouch, MutateIn) set this to <c>false</c> explicitly.
+    /// Whether the operation only reads server state. Drives timeout ambiguity classification
+    /// (see <see cref="StellarRetryHandler"/>). Defaults to <see cref="Idempotent"/> when not set.
     /// </summary>
-    public bool ReadOnly
+    public bool? ReadOnly
     {
-        get => _readOnly ?? Idempotent;
-        set => _readOnly = value;
+        get => field ?? Idempotent;
+        set;
     }
 
     public List<RetryReason> RetryReasons { get; set; } = new();

--- a/src/Couchbase/Stellar/Core/Retry/StellarRequest.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRequest.cs
@@ -32,6 +32,25 @@ public class StellarRequest : IRequest
 
     public uint Attempts { get; set; }
     public bool Idempotent { get; set; }
+
+    private bool? _readOnly;
+
+    /// <summary>
+    /// Whether the operation only reads server state (i.e. never mutates data, expiry, or locks).
+    /// This drives ambiguous-vs-unambiguous timeout classification: a read-only op that times out
+    /// definitively did not mutate state (<see cref="Couchbase.Core.Exceptions.UnambiguousTimeoutException"/>),
+    /// whereas a mutating op might have (<see cref="Couchbase.Core.Exceptions.AmbiguousTimeoutException"/>).
+    /// Mirrors the classic SDK, where <c>IRequest.Idempotent</c> is defined as <c>IsReadOnly</c>
+    /// (see OperationBase). Defaults to <see cref="Idempotent"/> when not set explicitly, as the two
+    /// coincide for most operations; KV operations that are idempotent yet mutate state
+    /// (GetAndLock, GetAndTouch, MutateIn) set this to <c>false</c> explicitly.
+    /// </summary>
+    public bool ReadOnly
+    {
+        get => _readOnly ?? Idempotent;
+        set => _readOnly = value;
+    }
+
     public List<RetryReason> RetryReasons { get; set; } = new();
     public IRetryStrategy RetryStrategy { get; set; } = new BestEffortRetryStrategy();
     public TimeSpan Timeout { get; set; }

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -44,7 +44,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
             {
                 if (request.Token.IsCancellationRequested)
                 {
-                    if (request.Idempotent)
+                    if (IsReadOnly(request))
                     {
                         throw new UnambiguousTimeoutException("The request timed out.", context);
                     }
@@ -88,6 +88,14 @@ internal class StellarRetryHandler : IRetryOrchestrator
                 request.StopRecording();
         }
     }
+
+    // Ambiguous-vs-unambiguous timeout classification must be based on whether the operation
+    // mutates server state (read-only), not on idempotency. An idempotent-but-mutating op such as
+    // an upsert or MutateIn is safe to retry yet may still have applied on timeout, so it must
+    // surface as AmbiguousTimeoutException. StellarRequest exposes ReadOnly for this; fall back to
+    // Idempotent for any other IRequest implementation.
+    private static bool IsReadOnly(IRequest request) =>
+        request is StellarRequest stellarRequest ? stellarRequest.ReadOnly : request.Idempotent;
 
     private void HandleException(RpcException protoException, IRequest request, GenericErrorContext context)
     {
@@ -240,7 +248,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
             case StatusCode.Cancelled:
                 throw new RequestCanceledException();
             case StatusCode.DeadlineExceeded:
-                if (request.Idempotent) throw new UnambiguousTimeoutException(detail);
+                if (IsReadOnly(request)) throw new UnambiguousTimeoutException(detail);
                 throw new AmbiguousTimeoutException();
             case StatusCode.Internal:
                 if (IsTransientGrpcTransportError(protoException))

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -89,13 +89,11 @@ internal class StellarRetryHandler : IRetryOrchestrator
         }
     }
 
-    // Ambiguous-vs-unambiguous timeout classification must be based on whether the operation
-    // mutates server state (read-only), not on idempotency. An idempotent-but-mutating op such as
-    // an upsert or MutateIn is safe to retry yet may still have applied on timeout, so it must
-    // surface as AmbiguousTimeoutException. StellarRequest exposes ReadOnly for this; fall back to
-    // Idempotent for any other IRequest implementation.
+    // Timeout ambiguity keys on whether the op mutates server state, not on idempotency: an
+    // idempotent-but-mutating op (GetAndLock, MutateIn, ...) is safe to retry yet may have applied
+    // on timeout, so it must surface as Ambiguous. Fall back to Idempotent for non-StellarRequest.
     private static bool IsReadOnly(IRequest request) =>
-        request is StellarRequest stellarRequest ? stellarRequest.ReadOnly : request.Idempotent;
+        (request as StellarRequest)?.ReadOnly ?? request.Idempotent;
 
     private void HandleException(RpcException protoException, IRequest request, GenericErrorContext context)
     {

--- a/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
+++ b/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
@@ -145,6 +145,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
+            ReadOnly = false, // GetAndLock mutates state (acquires a lock)
             Token = opts.Token,
             Timeout = opts.Timeout ?? _stellarCluster.ClusterOptions.KvTimeout
         };
@@ -177,6 +178,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
+            ReadOnly = false, // GetAndTouch mutates state (updates the document expiry)
             Token = opts.Token,
             Timeout = opts.Timeout ?? _stellarCluster.ClusterOptions.KvTimeout
         };
@@ -358,6 +360,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
+            ReadOnly = false, // MutateIn mutates state (applies subdocument mutations)
             Token = opts.Token,
             Timeout = opts.Timeout ?? (opts.DurabilityLevel != Couchbase.KeyValue.DurabilityLevel.None
                 ? _stellarCluster.ClusterOptions.KvDurabilityTimeout

--- a/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
+++ b/src/Couchbase/Stellar/KeyValue/StellarCollection.cs
@@ -145,7 +145,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
-            ReadOnly = false, // GetAndLock mutates state (acquires a lock)
+            ReadOnly = false, // acquires a lock
             Token = opts.Token,
             Timeout = opts.Timeout ?? _stellarCluster.ClusterOptions.KvTimeout
         };
@@ -178,7 +178,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
-            ReadOnly = false, // GetAndTouch mutates state (updates the document expiry)
+            ReadOnly = false, // updates the document expiry
             Token = opts.Token,
             Timeout = opts.Timeout ?? _stellarCluster.ClusterOptions.KvTimeout
         };
@@ -360,7 +360,7 @@ internal class StellarCollection : ICouchbaseCollection, IBinaryCollection
         var stellarRequest = new StellarRequest
         {
             Idempotent = true,
-            ReadOnly = false, // MutateIn mutates state (applies subdocument mutations)
+            ReadOnly = false, // applies subdocument mutations
             Token = opts.Token,
             Timeout = opts.Timeout ?? (opts.DurabilityLevel != Couchbase.KeyValue.DurabilityLevel.None
                 ? _stellarCluster.ClusterOptions.KvDurabilityTimeout

--- a/src/Couchbase/Stellar/Query/StellarQueryClient.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryClient.cs
@@ -98,7 +98,8 @@ internal class StellarQueryClient : IQueryClient
 
         var stellarRequest = new StellarRequest
         {
-            Idempotent = true,
+            // A read-only query is safe to retry and unambiguous on timeout; a mutating one is neither.
+            Idempotent = opts.ReadOnly ?? false,
             Token = opts.Token,
             Timeout = opts.TimeOut ?? _stellarCluster.ClusterOptions.QueryTimeout
         };

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -249,6 +249,56 @@ public class StellarRetryHandlerTests
     }
 
     [Fact]
+    public async Task Timeout_ThrowsAmbiguousTimeout_ForIdempotentButMutating_AfterRetries()
+    {
+        // CNG-2 regression: timeout ambiguity must key on read-only status, not idempotency.
+        // An op such as GetAndLock/GetAndTouch/MutateIn is idempotent (safe to retry) yet mutates
+        // server state, so on timeout it must surface as Ambiguous — it may have applied.
+        var fakeTime = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        fakeTime.SetUtcNow(DateTimeOffset.UtcNow);
+
+        var handler = new StellarRetryHandler(fakeTime);
+        var request = new StellarRequest(fakeTime)
+        {
+            Timeout = TimeSpan.FromMilliseconds(5000),
+            Idempotent = true,
+            ReadOnly = false
+        };
+
+        Task<GetResponse> GrpcCall()
+        {
+            if (request.RemainingTimeout is { } remaining && remaining <= TimeSpan.Zero)
+            {
+                throw new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline exceeded"));
+            }
+
+            throw new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
+        }
+
+        var retryTask = Task.Run(() => handler.RetryAsync(GrpcCall, request));
+
+        while (!retryTask.IsCompleted)
+        {
+            fakeTime.Advance(TimeSpan.FromMilliseconds(500));
+            await Task.Delay(1);
+        }
+
+        await Assert.ThrowsAsync<Couchbase.Core.Exceptions.AmbiguousTimeoutException>(
+            () => retryTask);
+    }
+
+    [Fact]
+    public void ReadOnly_DefaultsToIdempotent_WhenNotSet()
+    {
+        Assert.True(new StellarRequest { Idempotent = true }.ReadOnly);
+        Assert.False(new StellarRequest { Idempotent = false }.ReadOnly);
+
+        // Explicit override wins over the Idempotent default.
+        Assert.False(new StellarRequest { Idempotent = true, ReadOnly = false }.ReadOnly);
+        Assert.True(new StellarRequest { Idempotent = false, ReadOnly = true }.ReadOnly);
+    }
+
+    [Fact]
     public async Task Timeout_RetriesSucceed_WithinDeadline()
     {
         // Simulate: First 2 calls fail with Unavailable, 3rd succeeds.

--- a/tests/Couchbase.UnitTests/Stellar/Query/StellarQueryClientTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Query/StellarQueryClientTests.cs
@@ -34,5 +34,28 @@ public class StellarQueryClientTests
 
         await result.GetAsyncEnumerator().MoveNextAsync();
     }
+
+    // CNG-2 regression: query idempotency (and thus timeout ambiguity) must track the ReadOnly option.
+    // A mutating query that times out may have applied, so it must surface as Ambiguous; a read-only
+    // one definitively did not, so it is Unambiguous.
+    [Theory]
+    [InlineData(true, typeof(Couchbase.Core.Exceptions.UnambiguousTimeoutException))]
+    [InlineData(false, typeof(Couchbase.Core.Exceptions.AmbiguousTimeoutException))]
+    public async Task QueryAsync_TimeoutAmbiguity_TracksReadOnlyOption(bool readOnly, System.Type expected)
+    {
+        var cluster = StellarMocks.CreateClusterFromMocks();
+        var queryServiceClient = new Mock<QueryService.QueryServiceClient>();
+        queryServiceClient
+            .Setup(x => x.Query(It.IsAny<QueryRequest>(), It.IsAny<CallOptions>()))
+            .Throws(new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline exceeded")));
+
+        var queryClient = new StellarQueryClient(cluster, queryServiceClient.Object,
+            SystemTextJsonSerializer.Create(), new StellarRetryHandler());
+
+        var ex = await Assert.ThrowsAnyAsync<System.Exception>(
+            () => queryClient.QueryAsync<dynamic>("SELECT 1;", new QueryOptions().Readonly(readOnly)));
+
+        Assert.IsType(expected, ex);
+    }
 }
 #endif


### PR DESCRIPTION
Motivation
==========
RFC 77 requires ambiguous-vs-unambiguous timeout
classification to be based on read-only status, not idempotency: an idempotent-but-mutating op (e.g.
GetAndLock, GetAndTouch, MutateIn) is safe to retry yet may still have applied on timeout, so it must
surface as AmbiguousTimeoutException. Stellar keyed the decision on StellarRequest.Idempotent, matching neither the RFC nor the classic SDK (where
IRequest.Idempotent is defined as IsReadOnly).

Modification
============
Add a ReadOnly property to StellarRequest that
defaults to Idempotent (echoing the classic coupling) so existing call sites keep their behavior, and set ReadOnly=false explicitly on the three KV operations that are idempotent yet mutate: GetAndLock,
GetAndTouch, MutateIn. Switch the two timeout
decisions in StellarRetryHandler (token cancellation and DEADLINE_EXCEEDED) from Idempotent to a ReadOnly check via an IsReadOnly helper that falls back to
Idempotent for non-StellarRequest inputs.

Results
=======
18 StellarRetryHandler tests passing, including a new regression test that a timed-out idempotent-but-
mutating op raises AmbiguousTimeoutException and a test of the ReadOnly/Idempotent default coupling.
Retry-strategy behavior is unchanged (Idempotent is untouched).