### PR TITLE
NCBC-4260: Retry LOCKED documents instead of failing immediately

### DIFF
--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -189,13 +189,8 @@ internal class StellarRetryHandler : IRetryOrchestrator
                                 throw new CasMismatchException(context);
                             case StellarRetryStrings.PreconditionLocked:
                             {
-                                // CNG reports a locked document as a PreconditionFailure "LOCKED"
-                                // detail block. Per RFC 77 this is a retryable condition (KV_LOCKED):
-                                // the document is only temporarily locked, so retry with backoff until
-                                // the timeout is exceeded rather than failing immediately. Mirrors the
-                                // FailedPrecondition/LOCKED path below and matches Java's KV_LOCKED
-                                // retry and Go's KVLockedRetryReason. Returns (rather than breaks) so
-                                // the retry loop resumes without falling through to the status switch.
+                                // Retryable per RFC 77 (KV_LOCKED). return (not break) so we retry with
+                                // backoff rather than falling through to the status switch.
                                 context.RetryReasons.Add(RetryReason.KvLocked);
                                 request.Attempts++;
                                 return;
@@ -232,6 +227,8 @@ internal class StellarRetryHandler : IRetryOrchestrator
             case StatusCode.FailedPrecondition:
                 if (detail.Contains(StellarRetryStrings.Locked))
                 {
+                    // Same locked-document condition as the PreconditionFailure/LOCKED path above.
+                    context.RetryReasons.Add(RetryReason.KvLocked);
                     request.Attempts++;
                     break;
                 }

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -189,8 +189,16 @@ internal class StellarRetryHandler : IRetryOrchestrator
                                 throw new CasMismatchException(context);
                             case StellarRetryStrings.PreconditionLocked:
                             {
+                                // CNG reports a locked document as a PreconditionFailure "LOCKED"
+                                // detail block. Per RFC 77 this is a retryable condition (KV_LOCKED):
+                                // the document is only temporarily locked, so retry with backoff until
+                                // the timeout is exceeded rather than failing immediately. Mirrors the
+                                // FailedPrecondition/LOCKED path below and matches Java's KV_LOCKED
+                                // retry and Go's KVLockedRetryReason. Returns (rather than breaks) so
+                                // the retry loop resumes without falling through to the status switch.
                                 context.RetryReasons.Add(RetryReason.KvLocked);
-                                throw new UnambiguousTimeoutException("Document is locked", context);
+                                request.Attempts++;
+                                return;
                             }
                             case StellarRetryStrings.Unlocked:
                                 throw new DocumentNotLockedException();

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -45,6 +45,45 @@ public class StellarRetryHandlerTests
     }
 
     [Fact]
+    public async Task Locked_IsRetried_NotThrownImmediately()
+    {
+        // CNG-5 regression: CNG reports a locked document as a PreconditionFailure "LOCKED"
+        // detail block. It must be retried with backoff, not raised immediately as an
+        // UnambiguousTimeoutException.
+        var preconditionFailure = new Google.Rpc.PreconditionFailure();
+        preconditionFailure.Violations.Add(
+            new Google.Rpc.PreconditionFailure.Types.Violation { Type = StellarRetryStrings.PreconditionLocked });
+        var any = new Any
+        {
+            TypeUrl = StellarRetryStrings.TypeUrlPreconditionFailure,
+            Value = preconditionFailure.ToByteString()
+        };
+
+        var retryMock = new Mock<StellarRetryHandler>();
+        retryMock.Setup(handler => handler.StatusDeserializer(It.IsAny<RpcException>())).Returns(any);
+
+        var request = new StellarRequest { Timeout = TimeSpan.FromSeconds(5) };
+        var callCount = 0;
+
+        Task<GetResponse> GrpcCall()
+        {
+            callCount++;
+            if (callCount < 3)
+            {
+                throw new RpcException(new Status(StatusCode.FailedPrecondition, "LOCKED"));
+            }
+
+            return Task.FromResult(new GetResponse());
+        }
+
+        var result = await retryMock.Object.RetryAsync(GrpcCall, request);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, callCount);
+        Assert.True(request.Attempts > 0, "Expected the LOCKED document to be retried.");
+    }
+
+    [Fact]
     public async Task Throw_CouchbaseException_On_Unknown_Error()
     {
         var retryMock = new StellarRetryHandler();

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -80,7 +80,9 @@ public class StellarRetryHandlerTests
 
         Assert.NotNull(result);
         Assert.Equal(3, callCount);
-        Assert.True(request.Attempts > 0, "Expected the LOCKED document to be retried.");
+        // Exactly one increment per failed call: guards against falling through to the status
+        // switch (which would increment Attempts a second time on a LOCKED detail string).
+        Assert.Equal(2u, request.Attempts);
     }
 
     [Fact]


### PR DESCRIPTION
Motivation
==========
CNG reports a locked document as a PreconditionFailure "LOCKED" detail block. Stellar mapped that block to an immediate UnambiguousTimeoutException("Document is locked") with no retry, so a transiently locked
document failed the operation outright. Per RFC 77 a locked document is a retryable condition; Java retries via KV_LOCKED and Go via KVLockedRetryReason.

Modification
============
In StellarRetryHandler, change the PreconditionFailure LOCKED case to add the KvLocked retry reason, increment Attempts, and return so the retry loop backs off and retries until the timeout is exceeded, mirroring the existing FailedPrecondition/LOCKED path. Uses return (not break) so it does not fall through into the status switch.

Results
=======
17 StellarRetryHandler tests passing, including a new regression test asserting a LOCKED PreconditionFailure is retried (rather than throwing immediately) and then succeeds.