### PR TITLE
NCBC-4263: fail retryable mid-stream errors as RequestCancelled Motivation

### DIFF
--- a/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
+++ b/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Couchbase.Analytics;
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Retry;
@@ -17,12 +18,17 @@ namespace Couchbase.Stellar.Analytics;
 public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
 {
     private readonly AsyncServerStreamingCall<AnalyticsQueryResponse> _streamingAnalyticsResponse;
+    private readonly IAsyncStreamReader<AnalyticsQueryResponse> _responseStream;
     private readonly ITypeSerializer _serializer;
     private readonly Action<Exception> _onStreamError;
+    private readonly List<T> _tempResults = new();
+    private bool _hasReadHeader;
+    private bool _firstResponseHadRows;
 
     public ProtoAnalyticsResult(AsyncServerStreamingCall<AnalyticsQueryResponse> streamingAnalyticsResponse, ITypeSerializer serializer, Action<Exception> onStreamError)
     {
         _streamingAnalyticsResponse = streamingAnalyticsResponse;
+        _responseStream = _streamingAnalyticsResponse.ResponseStream;
         _serializer = serializer;
         _onStreamError = onStreamError;
     }
@@ -32,18 +38,68 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
         _streamingAnalyticsResponse.Dispose();
     }
 
+    /// <summary>
+    /// Reads the first streamed response. This runs under the retry orchestrator (called from
+    /// StellarAnalyticsClient.GrpcCall inside RetryAsync), so a retryable failure on the first
+    /// response propagates and is retried per RFC 77 — no rows have been delivered yet. There is
+    /// deliberately no try/catch here: only genuinely mid-stream failures (in the enumerator, after
+    /// the first response) are mapped to RequestCanceled via <see cref="_onStreamError"/>.
+    /// </summary>
+    internal async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        if (_hasReadHeader)
+        {
+            return;
+        }
+        _hasReadHeader = true;
+
+        _firstResponseHadRows = await _responseStream.MoveNext(cancellationToken).ConfigureAwait(false);
+        if (_firstResponseHadRows)
+        {
+            SetMetaData(_responseStream.Current);
+            foreach (var protoRow in _responseStream.Current.Rows)
+            {
+                if (cancellationToken.IsCancellationRequested || protoRow == null)
+                {
+                    break;
+                }
+                if (protoRow.IsEmpty)
+                {
+                    continue;
+                }
+                _tempResults.Add(_serializer.Deserialize<T>(protoRow.Memory)!);
+            }
+        }
+    }
+
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
     {
-        var responseStream = _streamingAnalyticsResponse.ResponseStream;
+        // Normally already read inside the retry orchestrator; idempotent, so this is a safety net
+        // for callers that enumerate a result constructed outside GrpcCall.
+        await InitializeAsync(cancellationToken).ConfigureAwait(false);
 
-        // A read failure here is mid-stream; map it (see ThrowMidStreamException).
-        // MoveNext sits in the try because a yield can't live inside a catch.
+        // Rows buffered from the first response (read under the retry orchestrator).
+        foreach (var row in _tempResults)
+        {
+            yield return row;
+        }
+        _tempResults.Clear();
+
+        // If the first read reported end-of-stream there is nothing more to enumerate.
+        if (!_firstResponseHadRows)
+        {
+            yield break;
+        }
+
+        // Subsequent responses are genuinely mid-stream: a failure here cannot be retried (rows may
+        // already have been delivered), so map it (see ThrowMidStreamException). MoveNext sits in the
+        // try because a yield can't live inside a catch.
         while (true)
         {
             bool hasNext;
             try
             {
-                hasNext = await responseStream.MoveNext(cancellationToken).ConfigureAwait(false);
+                hasNext = await _responseStream.MoveNext(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (e is RpcException || StellarRetryHandler.IsTransientTransportException(e))
             {
@@ -53,31 +109,9 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
 
             if (!hasNext) break;
 
-            var responseMetaData = responseStream.Current.MetaData;
-            MetaData = new AnalyticsMetaData
-            {
-                ClientContextId = responseMetaData.ClientContextId,
-                RequestId = responseMetaData.RequestId,
-                Signature = responseMetaData.Signature,
-                Status = AnalyticsStatus.Success
-            };
+            SetMetaData(_responseStream.Current);
 
-            MetaData.Metrics = new AnalyticsMetrics
-            {
-                ElaspedTime = responseMetaData.Metrics.ElapsedTime.ToTimeSpan().ToString(),
-                ExecutionTime = responseMetaData.Metrics.ExecutionTime.ToTimeSpan().ToString(),
-                ResultCount = (uint)responseMetaData.Metrics.ResultCount,
-                ResultSize = (uint)responseMetaData.Metrics.ResultSize,
-                MutationCount = (uint)responseMetaData.Metrics.MutationCount,
-                ErrorCount = (uint)responseMetaData.Metrics.ErrorCount,
-                WarningCount = (uint)responseMetaData.Metrics.WarningCount,
-                SortCount = (uint)responseMetaData.Metrics.SortCount
-            };
-
-            MetaData.Warnings = new List<AnalyticsWarning>(responseMetaData.Warnings.Count);
-            MetaData.Warnings.AddRange(responseMetaData.Warnings.Select(warning => new AnalyticsWarning { Code = (int)warning.Code, Message = warning.Message }));
-
-            foreach (var protoRow in responseStream.Current.Rows)
+            foreach (var protoRow in _responseStream.Current.Rows)
             {
                 if (cancellationToken.IsCancellationRequested || protoRow == null)
                 {
@@ -93,6 +127,33 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
                 yield return analyticsRow!;
             }
         }
+    }
+
+    private void SetMetaData(AnalyticsQueryResponse response)
+    {
+        var responseMetaData = response.MetaData;
+        MetaData = new AnalyticsMetaData
+        {
+            ClientContextId = responseMetaData.ClientContextId,
+            RequestId = responseMetaData.RequestId,
+            Signature = responseMetaData.Signature,
+            Status = AnalyticsStatus.Success
+        };
+
+        MetaData.Metrics = new AnalyticsMetrics
+        {
+            ElaspedTime = responseMetaData.Metrics.ElapsedTime.ToTimeSpan().ToString(),
+            ExecutionTime = responseMetaData.Metrics.ExecutionTime.ToTimeSpan().ToString(),
+            ResultCount = (uint)responseMetaData.Metrics.ResultCount,
+            ResultSize = (uint)responseMetaData.Metrics.ResultSize,
+            MutationCount = (uint)responseMetaData.Metrics.MutationCount,
+            ErrorCount = (uint)responseMetaData.Metrics.ErrorCount,
+            WarningCount = (uint)responseMetaData.Metrics.WarningCount,
+            SortCount = (uint)responseMetaData.Metrics.SortCount
+        };
+
+        MetaData.Warnings = new List<AnalyticsWarning>(responseMetaData.Warnings.Count);
+        MetaData.Warnings.AddRange(responseMetaData.Warnings.Select(warning => new AnalyticsWarning { Code = (int)warning.Code, Message = warning.Message }));
     }
 
     public RetryReason RetryReason { get; }

--- a/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
+++ b/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
@@ -20,17 +20,17 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
     private readonly AsyncServerStreamingCall<AnalyticsQueryResponse> _streamingAnalyticsResponse;
     private readonly IAsyncStreamReader<AnalyticsQueryResponse> _responseStream;
     private readonly ITypeSerializer _serializer;
-    private readonly Action<Exception> _onStreamError;
+    private readonly Func<Exception, Exception> _mapMidStreamError;
     private readonly List<T> _tempResults = new();
     private bool _hasReadHeader;
     private bool _firstResponseHadRows;
 
-    public ProtoAnalyticsResult(AsyncServerStreamingCall<AnalyticsQueryResponse> streamingAnalyticsResponse, ITypeSerializer serializer, Action<Exception> onStreamError)
+    public ProtoAnalyticsResult(AsyncServerStreamingCall<AnalyticsQueryResponse> streamingAnalyticsResponse, ITypeSerializer serializer, Func<Exception, Exception> mapMidStreamError)
     {
         _streamingAnalyticsResponse = streamingAnalyticsResponse;
         _responseStream = _streamingAnalyticsResponse.ResponseStream;
         _serializer = serializer;
-        _onStreamError = onStreamError;
+        _mapMidStreamError = mapMidStreamError;
     }
 
     public void Dispose()
@@ -43,7 +43,7 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
     /// StellarAnalyticsClient.GrpcCall inside RetryAsync), so a retryable failure on the first
     /// response propagates and is retried per RFC 77 — no rows have been delivered yet. There is
     /// deliberately no try/catch here: only genuinely mid-stream failures (in the enumerator, after
-    /// the first response) are mapped to RequestCanceled via <see cref="_onStreamError"/>.
+    /// the first response) are mapped to RequestCanceled via <see cref="_mapMidStreamError"/>.
     /// </summary>
     internal async Task InitializeAsync(CancellationToken cancellationToken)
     {
@@ -92,8 +92,8 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
         }
 
         // Subsequent responses are genuinely mid-stream: a failure here cannot be retried (rows may
-        // already have been delivered), so map it (see ThrowMidStreamException). MoveNext sits in the
-        // try because a yield can't live inside a catch.
+        // already have been delivered), so map it to the exception to throw (see MapMidStreamException).
+        // MoveNext sits in the try because a yield can't live inside a catch.
         while (true)
         {
             bool hasNext;
@@ -103,8 +103,7 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
             }
             catch (Exception e) when (e is RpcException || StellarRetryHandler.IsTransientTransportException(e))
             {
-                _onStreamError(e); // always throws
-                throw; // unreachable, satisfies definite assignment
+                throw _mapMidStreamError(e);
             }
 
             if (!hasNext) break;

--- a/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
+++ b/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
@@ -1,4 +1,5 @@
 #if NETCOREAPP3_1_OR_GREATER
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -6,6 +7,7 @@ using Couchbase.Analytics;
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Retry;
 using Couchbase.Protostellar.Analytics.V1;
+using Couchbase.Stellar.Core.Retry;
 using Grpc.Core;
 
 namespace Couchbase.Stellar.Analytics;
@@ -16,11 +18,13 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
 {
     private readonly AsyncServerStreamingCall<AnalyticsQueryResponse> _streamingAnalyticsResponse;
     private readonly ITypeSerializer _serializer;
+    private readonly Action<Exception> _onStreamError;
 
-    public ProtoAnalyticsResult(AsyncServerStreamingCall<AnalyticsQueryResponse> streamingAnalyticsResponse, ITypeSerializer serializer)
+    public ProtoAnalyticsResult(AsyncServerStreamingCall<AnalyticsQueryResponse> streamingAnalyticsResponse, ITypeSerializer serializer, Action<Exception> onStreamError)
     {
         _streamingAnalyticsResponse = streamingAnalyticsResponse;
         _serializer = serializer;
+        _onStreamError = onStreamError;
     }
 
     public void Dispose()
@@ -31,8 +35,26 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
     {
         var responseStream = _streamingAnalyticsResponse.ResponseStream;
-        while (await responseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+
+        // Analytics results stream lazily to the caller, so a failure while reading is mid-stream and
+        // cannot be retried. Per RFC 77 it is mapped via _onStreamError (retryable → RequestCancelled,
+        // terminal → standard mapping). MoveNext is read inside the try; the yields stay outside it
+        // because C# forbids `yield return` inside a try that has a catch.
+        while (true)
         {
+            bool hasNext;
+            try
+            {
+                hasNext = await responseStream.MoveNext(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is RpcException || StellarRetryHandler.IsTransientTransportException(e))
+            {
+                _onStreamError(e); // always throws
+                throw; // unreachable, satisfies definite assignment
+            }
+
+            if (!hasNext) break;
+
             var responseMetaData = responseStream.Current.MetaData;
             MetaData = new AnalyticsMetaData
             {

--- a/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
+++ b/src/Couchbase/Stellar/Analytics/ProtoAnalyticsResult.cs
@@ -36,10 +36,8 @@ public class ProtoAnalyticsResult<T> : IAnalyticsResult<T>
     {
         var responseStream = _streamingAnalyticsResponse.ResponseStream;
 
-        // Analytics results stream lazily to the caller, so a failure while reading is mid-stream and
-        // cannot be retried. Per RFC 77 it is mapped via _onStreamError (retryable → RequestCancelled,
-        // terminal → standard mapping). MoveNext is read inside the try; the yields stay outside it
-        // because C# forbids `yield return` inside a try that has a catch.
+        // A read failure here is mid-stream; map it (see ThrowMidStreamException).
+        // MoveNext sits in the try because a yield can't live inside a catch.
         while (true)
         {
             bool hasNext;

--- a/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
+++ b/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
@@ -72,7 +72,7 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);
             var response = _analyticsClient.AnalyticsQuery(analyticsRequest, callOptions);
             var result = new ProtoAnalyticsResult<T>(response, _stellarCluster.TypeSerializer,
-                e => _retryHandler.ThrowMidStreamException(e, stellarRequest));
+                e => _retryHandler.MapMidStreamException(e, stellarRequest));
             // Read the first response here, inside the retry orchestrator, so a retryable
             // first-response failure is retried (matching StellarQueryClient). Only genuinely
             // mid-stream failures — after this point — are mapped to RequestCanceled.

--- a/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
+++ b/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
@@ -71,8 +71,13 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
         {
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);
             var response = _analyticsClient.AnalyticsQuery(analyticsRequest, callOptions);
-            return new ProtoAnalyticsResult<T>(response, _stellarCluster.TypeSerializer,
+            var result = new ProtoAnalyticsResult<T>(response, _stellarCluster.TypeSerializer,
                 e => _retryHandler.ThrowMidStreamException(e, stellarRequest));
+            // Read the first response here, inside the retry orchestrator, so a retryable
+            // first-response failure is retried (matching StellarQueryClient). Only genuinely
+            // mid-stream failures — after this point — are mapped to RequestCanceled.
+            await result.InitializeAsync(opts.Token).ConfigureAwait(false);
+            return result;
         }
 
         return await _retryHandler.RetryAsync(GrpcCall, stellarRequest).ConfigureAwait(false);

--- a/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
+++ b/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
@@ -66,8 +66,6 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
             opts.BucketName,
             opts.ScopeName);
 
-        // The Stellar retry orchestrator maps mid-stream errors (RFC 77): retryable → RequestCancelled,
-        // terminal → standard mapping.
         async Task<IAnalyticsResult<T>> GrpcCall()
         {
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);

--- a/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
+++ b/src/Couchbase/Stellar/Analytics/StellarAnalyticsClient.cs
@@ -16,9 +16,9 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
 {
     private readonly StellarCluster _stellarCluster;
     private readonly AnalyticsService.AnalyticsServiceClient _analyticsClient;
-    private readonly IRetryOrchestrator _retryHandler;
+    private readonly StellarRetryHandler _retryHandler;
 
-    public StellarAnalyticsClient(StellarCluster stellarCluster, AnalyticsService.AnalyticsServiceClient analyticsClient, IRetryOrchestrator retryHandler)
+    public StellarAnalyticsClient(StellarCluster stellarCluster, AnalyticsService.AnalyticsServiceClient analyticsClient, StellarRetryHandler retryHandler)
     {
         _stellarCluster = stellarCluster;
         _analyticsClient = analyticsClient;
@@ -66,11 +66,14 @@ internal class StellarAnalyticsClient : AnalyticsService.AnalyticsServiceClient,
             opts.BucketName,
             opts.ScopeName);
 
+        // The Stellar retry orchestrator maps mid-stream errors (RFC 77): retryable → RequestCancelled,
+        // terminal → standard mapping.
         async Task<IAnalyticsResult<T>> GrpcCall()
         {
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);
             var response = _analyticsClient.AnalyticsQuery(analyticsRequest, callOptions);
-            return new ProtoAnalyticsResult<T>(response, _stellarCluster.TypeSerializer);
+            return new ProtoAnalyticsResult<T>(response, _stellarCluster.TypeSerializer,
+                e => _retryHandler.ThrowMidStreamException(e, stellarRequest));
         }
 
         return await _retryHandler.RetryAsync(GrpcCall, stellarRequest).ConfigureAwait(false);

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Core.Exceptions;
@@ -111,8 +112,8 @@ internal class StellarRetryHandler : IRetryOrchestrator
         }
         else
         {
-            // Not something we map — let it propagate.
-            throw e;
+            // Not something we map — let it propagate with its original stack trace preserved.
+            ExceptionDispatchInfo.Capture(e).Throw();
         }
 
         // Retryable: carry the SDK error context. Per RFC 77 we don't nest the raw gRPC

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -90,12 +90,10 @@ internal class StellarRetryHandler : IRetryOrchestrator
     }
 
     /// <summary>
-    /// Maps an <see cref="RpcException"/> raised while reading a streaming result <b>after</b> the
-    /// first response has already been returned to the caller. Per RFC 77 (Streaming → Error
-    /// handling), a mid-stream error cannot be retried because rows may already have been delivered:
-    /// a retryable error is surfaced as <see cref="RequestCanceledException"/>, while a terminal
-    /// error is mapped through the standard <see cref="HandleException"/> handling. This method
-    /// always throws.
+    /// Maps an error raised mid-stream — after the first response was returned — while reading a
+    /// streaming result. Per RFC 77 a mid-stream error cannot be retried (rows may already have been
+    /// delivered): retryable and transport errors become <see cref="RequestCanceledException"/>,
+    /// terminal errors are mapped via <see cref="HandleException"/>. Always throws.
     /// </summary>
     internal void ThrowMidStreamException(Exception e, IRequest request)
     {
@@ -103,27 +101,22 @@ internal class StellarRetryHandler : IRetryOrchestrator
 
         if (e is RpcException rpc && rpc.StatusCode != StatusCode.OK)
         {
-            // Throws a mapped exception for terminal codes; for retryable codes it records a retry
-            // reason on the context and returns (we must not actually retry mid-stream).
+            // Terminal codes throw here; retryable codes record a reason and return.
             HandleException(rpc, request, context);
         }
         else if (IsTransientTransportException(e))
         {
-            // A transport failure (connection reset / broken pipe) that surfaced outside an
-            // RpcException, mirroring RetryAsync's transient-transport catch — retryable.
+            // Transport failure outside an RpcException (e.g. connection reset) — retryable.
             context.RetryReasons.Add(RetryReason.ServiceNotAvailable);
         }
         else
         {
-            // Not a gRPC status error and not a recognised transient transport failure — nothing we
-            // map here; let it propagate unchanged.
+            // Not something we map — let it propagate.
             throw e;
         }
 
-        // Reached only for a retryable error. Per RFC 77 a mid-stream error cannot be retried (rows
-        // may already have been delivered), so fail as RequestCancelled, carrying the SDK error
-        // context (retry reason / server detail). Per RFC 77 we deliberately do NOT nest the raw gRPC
-        // exception as an InnerException (TODO CNG-4: add lastException/lastError to the context).
+        // Retryable: carry the SDK error context. Per RFC 77 we don't nest the raw gRPC
+        // exception (TODO CNG-4: put the cause in lastException/lastError).
         throw new RequestCanceledException(
             "A retryable error occurred mid-stream; the request was cancelled and cannot be retried.")
         {

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -89,6 +89,48 @@ internal class StellarRetryHandler : IRetryOrchestrator
         }
     }
 
+    /// <summary>
+    /// Maps an <see cref="RpcException"/> raised while reading a streaming result <b>after</b> the
+    /// first response has already been returned to the caller. Per RFC 77 (Streaming → Error
+    /// handling), a mid-stream error cannot be retried because rows may already have been delivered:
+    /// a retryable error is surfaced as <see cref="RequestCanceledException"/>, while a terminal
+    /// error is mapped through the standard <see cref="HandleException"/> handling. This method
+    /// always throws.
+    /// </summary>
+    internal void ThrowMidStreamException(Exception e, IRequest request)
+    {
+        var context = new GenericErrorContext();
+
+        if (e is RpcException rpc && rpc.StatusCode != StatusCode.OK)
+        {
+            // Throws a mapped exception for terminal codes; for retryable codes it records a retry
+            // reason on the context and returns (we must not actually retry mid-stream).
+            HandleException(rpc, request, context);
+        }
+        else if (IsTransientTransportException(e))
+        {
+            // A transport failure (connection reset / broken pipe) that surfaced outside an
+            // RpcException, mirroring RetryAsync's transient-transport catch — retryable.
+            context.RetryReasons.Add(RetryReason.ServiceNotAvailable);
+        }
+        else
+        {
+            // Not a gRPC status error and not a recognised transient transport failure — nothing we
+            // map here; let it propagate unchanged.
+            throw e;
+        }
+
+        // Reached only for a retryable error. Per RFC 77 a mid-stream error cannot be retried (rows
+        // may already have been delivered), so fail as RequestCancelled, carrying the SDK error
+        // context (retry reason / server detail). Per RFC 77 we deliberately do NOT nest the raw gRPC
+        // exception as an InnerException (TODO CNG-4: add lastException/lastError to the context).
+        throw new RequestCanceledException(
+            "A retryable error occurred mid-stream; the request was cancelled and cannot be retried.")
+        {
+            Context = context
+        };
+    }
+
     private void HandleException(RpcException protoException, IRequest request, GenericErrorContext context)
     {
         var status = protoException.StatusCode;
@@ -316,7 +358,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
     /// Determines whether an exception (or any exception in its InnerException chain)
     /// represents a transient transport failure that should be retried.
     /// </summary>
-    private static bool IsTransientTransportException(Exception? e)
+    internal static bool IsTransientTransportException(Exception? e)
     {
         while (e is not null)
         {

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.Http;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Core.Exceptions;
@@ -92,18 +91,27 @@ internal class StellarRetryHandler : IRetryOrchestrator
 
     /// <summary>
     /// Maps an error raised mid-stream — after the first response was returned — while reading a
-    /// streaming result. Per RFC 77 a mid-stream error cannot be retried (rows may already have been
-    /// delivered): retryable and transport errors become <see cref="RequestCanceledException"/>,
-    /// terminal errors are mapped via <see cref="HandleException"/>. Always throws.
+    /// streaming result, returning the exception the caller should throw. Per RFC 77 a mid-stream
+    /// error cannot be retried (rows may already have been delivered): retryable and transport errors
+    /// map to <see cref="RequestCanceledException"/>, terminal errors to their mapped SDK exception,
+    /// and anything we don't recognise is returned unchanged for the caller to rethrow.
     /// </summary>
-    internal void ThrowMidStreamException(Exception e, IRequest request)
+    internal Exception MapMidStreamException(Exception e, IRequest request)
     {
         var context = new GenericErrorContext();
 
         if (e is RpcException rpc && rpc.StatusCode != StatusCode.OK)
         {
-            // Terminal codes throw here; retryable codes record a reason and return.
-            HandleException(rpc, request, context);
+            try
+            {
+                // HandleException returns after recording a retry reason for retryable codes, and
+                // throws the mapped SDK exception for terminal ones — capture it to return.
+                HandleException(rpc, request, context);
+            }
+            catch (Exception mapped)
+            {
+                return mapped;
+            }
         }
         else if (IsTransientTransportException(e))
         {
@@ -112,13 +120,13 @@ internal class StellarRetryHandler : IRetryOrchestrator
         }
         else
         {
-            // Not something we map — let it propagate with its original stack trace preserved.
-            ExceptionDispatchInfo.Capture(e).Throw();
+            // Not something we map — return it unchanged for the caller to rethrow.
+            return e;
         }
 
         // Retryable: carry the SDK error context. Per RFC 77 we don't nest the raw gRPC
         // exception (TODO CNG-4: put the cause in lastException/lastError).
-        throw new RequestCanceledException(
+        return new RequestCanceledException(
             "A retryable error occurred mid-stream; the request was cancelled and cannot be retried.")
         {
             Context = context

--- a/src/Couchbase/Stellar/Query/StellarQueryClient.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryClient.cs
@@ -109,8 +109,6 @@ internal class StellarQueryClient : IQueryClient
             opts.BucketName,
             opts.ScopeName);
 
-        // The Stellar retry orchestrator maps mid-stream errors (RFC 77): retryable → RequestCancelled,
-        // terminal → standard mapping.
         async Task<IQueryResult<T>> GrpcCall()
         {
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);

--- a/src/Couchbase/Stellar/Query/StellarQueryClient.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryClient.cs
@@ -115,7 +115,7 @@ internal class StellarQueryClient : IQueryClient
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);
             var asyncResponse = _queryClient.Query(protoRequest, callOptions);
             var streamingResult = new StellarQueryResult<T>(asyncResponse, _typeSerializer,
-                e => _retryHandler.ThrowMidStreamException(e, stellarRequest));
+                e => _retryHandler.MapMidStreamException(e, stellarRequest));
             await streamingResult.InitializeAsync(opts.Token).ConfigureAwait(false);
             return streamingResult;
         }

--- a/src/Couchbase/Stellar/Query/StellarQueryClient.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryClient.cs
@@ -23,9 +23,9 @@ internal class StellarQueryClient : IQueryClient
     private readonly StellarCluster _stellarCluster;
     private readonly QueryService.QueryServiceClient _queryClient;
     private readonly ITypeSerializer _typeSerializer;
-    private readonly IRetryOrchestrator _retryHandler;
+    private readonly StellarRetryHandler _retryHandler;
 
-    internal StellarQueryClient(StellarCluster stellarCluster, QueryService.QueryServiceClient queryClient, ITypeSerializer typeSerializer, IRetryOrchestrator  retryHandler)
+    internal StellarQueryClient(StellarCluster stellarCluster, QueryService.QueryServiceClient queryClient, ITypeSerializer typeSerializer, StellarRetryHandler retryHandler)
     {
         _stellarCluster = stellarCluster;
         _queryClient = queryClient;
@@ -109,11 +109,14 @@ internal class StellarQueryClient : IQueryClient
             opts.BucketName,
             opts.ScopeName);
 
+        // The Stellar retry orchestrator maps mid-stream errors (RFC 77): retryable → RequestCancelled,
+        // terminal → standard mapping.
         async Task<IQueryResult<T>> GrpcCall()
         {
             var callOptions = _stellarCluster.GrpcCallOptions(stellarRequest.RemainingTimeout, opts.Token);
             var asyncResponse = _queryClient.Query(protoRequest, callOptions);
-            var streamingResult = new StellarQueryResult<T>(asyncResponse, _typeSerializer);
+            var streamingResult = new StellarQueryResult<T>(asyncResponse, _typeSerializer,
+                e => _retryHandler.ThrowMidStreamException(e, stellarRequest));
             await streamingResult.InitializeAsync(opts.Token).ConfigureAwait(false);
             return streamingResult;
         }

--- a/src/Couchbase/Stellar/Query/StellarQueryResult.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryResult.cs
@@ -23,17 +23,17 @@ internal class StellarQueryResult<T> : IQueryResult<T>
     private readonly AsyncServerStreamingCall<QueryResponse> _streamingQueryResponse;
     private readonly ITypeSerializer _serializer;
     private readonly IAsyncStreamReader<QueryResponse> _streamReader;
-    private readonly Action<Exception> _onStreamError;
+    private readonly Func<Exception, Exception> _mapMidStreamError;
     private readonly List<T> _tempResults = new();
     private bool _hasReadHeader;
     private volatile bool _disposed;
 
-    public StellarQueryResult(AsyncServerStreamingCall<QueryResponse> streamingQueryResponse, ITypeSerializer serializer, Action<Exception> onStreamError)
+    public StellarQueryResult(AsyncServerStreamingCall<QueryResponse> streamingQueryResponse, ITypeSerializer serializer, Func<Exception, Exception> mapMidStreamError)
     {
         _streamingQueryResponse = streamingQueryResponse;
         _streamReader = _streamingQueryResponse.ResponseStream;
         _serializer = serializer;
-        _onStreamError = onStreamError;
+        _mapMidStreamError = mapMidStreamError;
     }
     public void Dispose()
     {
@@ -100,8 +100,8 @@ internal class StellarQueryResult<T> : IQueryResult<T>
         _tempResults.Clear();
 
         // First response was already read under the retry orchestrator; a failure here is
-        // mid-stream. Map it (see ThrowMidStreamException). MoveNext sits in the try because
-        // a yield can't live inside a catch.
+        // mid-stream. Map it to the exception to throw (see MapMidStreamException). MoveNext sits in
+        // the try because a yield can't live inside a catch.
         while (true)
         {
             bool hasNext;
@@ -111,8 +111,7 @@ internal class StellarQueryResult<T> : IQueryResult<T>
             }
             catch (Exception e) when (e is RpcException || StellarRetryHandler.IsTransientTransportException(e))
             {
-                _onStreamError(e); // always throws
-                throw; // unreachable, satisfies definite assignment
+                throw _mapMidStreamError(e);
             }
 
             if (!hasNext) break;

--- a/src/Couchbase/Stellar/Query/StellarQueryResult.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryResult.cs
@@ -9,6 +9,7 @@ using Couchbase.Core.Retry;
 using Couchbase.Protostellar.Query.V1;
 using Couchbase.Query;
 using Couchbase.Stellar.Core;
+using Couchbase.Stellar.Core.Retry;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Grpc.Core;
@@ -22,15 +23,17 @@ internal class StellarQueryResult<T> : IQueryResult<T>
     private readonly AsyncServerStreamingCall<QueryResponse> _streamingQueryResponse;
     private readonly ITypeSerializer _serializer;
     private readonly IAsyncStreamReader<QueryResponse> _streamReader;
+    private readonly Action<Exception> _onStreamError;
     private readonly List<T> _tempResults = new();
     private bool _hasReadHeader;
     private volatile bool _disposed;
 
-    public StellarQueryResult(AsyncServerStreamingCall<QueryResponse> streamingQueryResponse, ITypeSerializer serializer)
+    public StellarQueryResult(AsyncServerStreamingCall<QueryResponse> streamingQueryResponse, ITypeSerializer serializer, Action<Exception> onStreamError)
     {
         _streamingQueryResponse = streamingQueryResponse;
         _streamReader = _streamingQueryResponse.ResponseStream;
         _serializer = serializer;
+        _onStreamError = onStreamError;
     }
     public void Dispose()
     {
@@ -96,9 +99,26 @@ internal class StellarQueryResult<T> : IQueryResult<T>
         }
         _tempResults.Clear();
 
-        //enumerate the rest of te responses
-        while (await _streamReader.MoveNext(cancellationToken).ConfigureAwait(false))
+        //enumerate the rest of the responses. The first response was already read under the retry
+        //orchestrator (see StellarQueryClient); anything that fails here is mid-stream and cannot be
+        //retried. Per RFC 77 a retryable error is surfaced as RequestCancelled and a terminal error is
+        //mapped normally, both via _onStreamError. (MoveNext is read inside the try; the yields stay
+        //outside it because C# forbids `yield return` inside a try that has a catch.)
+        while (true)
         {
+            bool hasNext;
+            try
+            {
+                hasNext = await _streamReader.MoveNext(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e is RpcException || StellarRetryHandler.IsTransientTransportException(e))
+            {
+                _onStreamError(e); // always throws
+                throw; // unreachable, satisfies definite assignment
+            }
+
+            if (!hasNext) break;
+
             foreach (var queryResponse in _streamReader.Current.Rows)
             {
                 if (queryResponse == null) continue;
@@ -106,27 +126,6 @@ internal class StellarQueryResult<T> : IQueryResult<T>
                 if (deserializedObj == null)
                 {
                     Errors.Add(new Error { Message = "Failed to deserialize item." });
-                }
-                else
-                {
-                    yield return deserializedObj;
-                }
-            }
-        }
-    }
-
-    public async IAsyncEnumerator<T> GetAsyncEnumerator2(CancellationToken cancellationToken = new())
-    {
-        var responseStream = _streamingQueryResponse.ResponseStream;
-        while (await responseStream.MoveNext(cancellationToken).ConfigureAwait(false))
-        {
-            foreach (var queryResponse in responseStream.Current.Rows)
-            {
-                if (queryResponse == null) continue;
-                var deserializedObj = _serializer.Deserialize<T>(queryResponse.Memory);
-                if (deserializedObj == null)
-                {
-                    Errors.Add(new Error { Message = "Failed to deserialize item."});
                 }
                 else
                 {

--- a/src/Couchbase/Stellar/Query/StellarQueryResult.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryResult.cs
@@ -99,11 +99,9 @@ internal class StellarQueryResult<T> : IQueryResult<T>
         }
         _tempResults.Clear();
 
-        //enumerate the rest of the responses. The first response was already read under the retry
-        //orchestrator (see StellarQueryClient); anything that fails here is mid-stream and cannot be
-        //retried. Per RFC 77 a retryable error is surfaced as RequestCancelled and a terminal error is
-        //mapped normally, both via _onStreamError. (MoveNext is read inside the try; the yields stay
-        //outside it because C# forbids `yield return` inside a try that has a catch.)
+        // First response was already read under the retry orchestrator; a failure here is
+        // mid-stream. Map it (see ThrowMidStreamException). MoveNext sits in the try because
+        // a yield can't live inside a catch.
         while (true)
         {
             bool hasNext;

--- a/src/Couchbase/Stellar/Query/StellarQueryResult.cs
+++ b/src/Couchbase/Stellar/Query/StellarQueryResult.cs
@@ -87,10 +87,10 @@ internal class StellarQueryResult<T> : IQueryResult<T>
 
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
     {
-        if (_hasReadHeader)
-        {
-            await InitializeAsync(cancellationToken).ConfigureAwait(false);
-        }
+        // Idempotent (guarded by _hasReadHeader): normally the first response was already read inside
+        // the retry orchestrator via GrpcCall, but call it unconditionally so direct enumeration still
+        // reads the header/first response rather than treating it as mid-stream.
+        await InitializeAsync(cancellationToken).ConfigureAwait(false);
 
         //enumerate the first response
         foreach (var result in _tempResults)

--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -139,7 +139,8 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         };
 
         GrpcChannel = GrpcChannel.ForAddress(_clusterOptions.ConnectionStringValue!.GetStellarBootstrapUri(), grpcChannelOptions);
-        RetryHandler = new StellarRetryHandler();
+        var retryHandler = new StellarRetryHandler();
+        RetryHandler = retryHandler;
 
         _bucketManager = new StellarBucketManager(this);
         _searchIndexManager = new StellarSearchIndexManager(this);
@@ -147,11 +148,11 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         _queryClient = new StellarQueryClient(this,
             new QueryService.QueryServiceClient(GrpcChannel),
             TypeSerializer,
-            RetryHandler);
+            retryHandler);
         _metaData = new Metadata();
         _analyticsClient = new StellarAnalyticsClient(this,
             new AnalyticsService.AnalyticsServiceClient(GrpcChannel),
-            RetryHandler);
+            retryHandler);
         _searchClient = new StellarSearchClient(this);
 
         authenticator.AuthenticateGrpcMetadata(_metaData);

--- a/tests/Couchbase.UnitTests/Stellar/Analytics/StellarAnalyticsClientTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Analytics/StellarAnalyticsClientTests.cs
@@ -1,0 +1,106 @@
+#if NETCOREAPP3_1_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Analytics;
+using Couchbase.Core.Exceptions;
+using Couchbase.Protostellar.Analytics.V1;
+using Couchbase.Stellar.Analytics;
+using Couchbase.Stellar.Core.Retry;
+using Couchbase.UnitTests.Stellar.Utils;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Stellar.Analytics;
+
+public class StellarAnalyticsClientTests
+{
+    private static AsyncServerStreamingCall<AnalyticsQueryResponse> Call(IAsyncStreamReader<AnalyticsQueryResponse> stream) =>
+        new(stream, null!, null!, null!, null!, null!);
+
+    // A streamed response with just enough metadata for ProtoAnalyticsResult to process it.
+    private static AnalyticsQueryResponse ResponseWithMetaData() => new()
+    {
+        MetaData = new AnalyticsQueryResponse.Types.MetaData
+        {
+            Metrics = new AnalyticsQueryResponse.Types.Metrics
+            {
+                ElapsedTime = new Duration(),
+                ExecutionTime = new Duration()
+            }
+        }
+    };
+
+    // NCBC-4263 regression: a retryable error on the FIRST streamed response (before any rows are
+    // delivered) must be retried per RFC 77 — not converted to a non-retryable RequestCanceled.
+    // Before the fix, analytics read the first response outside the retry loop and routed the error
+    // through the mid-stream (never-retry) path. Query already did this correctly.
+    [Fact]
+    public async Task QueryAsync_RetryableFirstResponseError_IsRetried()
+    {
+        var cluster = StellarMocks.CreateClusterFromMocks();
+        var serviceClient = new Mock<AnalyticsService.AnalyticsServiceClient>();
+
+        // First attempt: the first stream read fails with a retryable error.
+        var failingStream = new Mock<IAsyncStreamReader<AnalyticsQueryResponse>>();
+        failingStream
+            .Setup(x => x.MoveNext(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RpcException(new Status(StatusCode.Unavailable, "Service unavailable")));
+
+        // Retry attempt: succeeds (empty stream — no responses).
+        var okStream = new Mock<IAsyncStreamReader<AnalyticsQueryResponse>>();
+        okStream.Setup(x => x.MoveNext(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        serviceClient
+            .SetupSequence(x => x.AnalyticsQuery(It.IsAny<AnalyticsQueryRequest>(), It.IsAny<CallOptions>()))
+            .Returns(Call(failingStream.Object))
+            .Returns(Call(okStream.Object));
+
+        var client = new StellarAnalyticsClient(cluster, serviceClient.Object, new StellarRetryHandler());
+
+        // Before the fix this threw RequestCanceledException; now the first-response error is retried.
+        var result = await client.QueryAsync<dynamic>("SELECT 1;", new AnalyticsOptions());
+
+        Assert.NotNull(result);
+        serviceClient.Verify(
+            x => x.AnalyticsQuery(It.IsAny<AnalyticsQueryRequest>(), It.IsAny<CallOptions>()),
+            Times.Exactly(2)); // proves the first-response error was retried, not surfaced as terminal
+    }
+
+    // The other half: an error that occurs AFTER the first response (genuinely mid-stream) still maps
+    // to RequestCanceled, because rows may already have been delivered and retrying isn't safe.
+    [Fact]
+    public async Task QueryAsync_MidStreamError_ThrowsRequestCanceled()
+    {
+        var cluster = StellarMocks.CreateClusterFromMocks();
+        var serviceClient = new Mock<AnalyticsService.AnalyticsServiceClient>();
+
+        var stream = new Mock<IAsyncStreamReader<AnalyticsQueryResponse>>();
+        stream
+            .SetupSequence(x => x.MoveNext(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true) // first response succeeds (read inside the retry loop)
+            .ThrowsAsync(new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"))); // mid-stream
+        stream.Setup(x => x.Current).Returns(ResponseWithMetaData());
+
+        serviceClient
+            .Setup(x => x.AnalyticsQuery(It.IsAny<AnalyticsQueryRequest>(), It.IsAny<CallOptions>()))
+            .Returns(Call(stream.Object));
+
+        var client = new StellarAnalyticsClient(cluster, serviceClient.Object, new StellarRetryHandler());
+
+        // The first response succeeds, so QueryAsync returns; the mid-stream failure surfaces on enumeration.
+        var result = await client.QueryAsync<dynamic>("SELECT 1;", new AnalyticsOptions());
+
+        await Assert.ThrowsAsync<RequestCanceledException>(async () =>
+        {
+            await foreach (var _ in result.Rows) { }
+        });
+
+        // The mid-stream error is NOT retried.
+        serviceClient.Verify(
+            x => x.AnalyticsQuery(It.IsAny<AnalyticsQueryRequest>(), It.IsAny<CallOptions>()),
+            Times.Once);
+    }
+}
+#endif

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -78,12 +78,7 @@ public class StellarRetryHandlerTests
             async () => await handler.RetryAsync(GrpcCall, request));
     }
 
-    // ──────────────────────────────────────────────────────────
-    //  CNG-16: mid-stream streaming errors (RFC 77 Streaming → Error handling).
-    //  A retryable error that occurs after the first response cannot be retried
-    //  (rows may already have been delivered), so it must surface as
-    //  RequestCancelled; a terminal error keeps its normal mapped type.
-    // ──────────────────────────────────────────────────────────
+    // Mid-stream errors: retryable -> RequestCancelled, terminal -> mapped.
 
     [Fact]
     public void ThrowMidStreamException_RetryableError_ThrowsRequestCancelled()

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -78,6 +78,77 @@ public class StellarRetryHandlerTests
             async () => await handler.RetryAsync(GrpcCall, request));
     }
 
+    // ──────────────────────────────────────────────────────────
+    //  CNG-16: mid-stream streaming errors (RFC 77 Streaming → Error handling).
+    //  A retryable error that occurs after the first response cannot be retried
+    //  (rows may already have been delivered), so it must surface as
+    //  RequestCancelled; a terminal error keeps its normal mapped type.
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ThrowMidStreamException_RetryableError_ThrowsRequestCancelled()
+    {
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+        var e = new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
+
+        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
+            () => handler.ThrowMidStreamException(e, request));
+    }
+
+    [Fact]
+    public void ThrowMidStreamException_TransientTransportError_ThrowsRequestCancelled()
+    {
+        // A mid-stream HTTP/2 transport failure surfaces as RpcException(Internal) with an inner
+        // transport exception; it is retryable, so mid-stream it becomes RequestCancelled.
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+        var inner = new System.Net.Http.HttpRequestException("Connection reset by peer");
+        var e = new RpcExceptionWithInner(new Status(StatusCode.Internal, "Internal error"), inner);
+
+        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
+            () => handler.ThrowMidStreamException(e, request));
+    }
+
+    [Fact]
+    public void ThrowMidStreamException_BareTransportException_ThrowsRequestCancelled()
+    {
+        // A transport failure that surfaces outside an RpcException (a bare HttpRequestException or
+        // IOException, mid-stream) is retryable, so it becomes RequestCancelled.
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+        var e = new System.Net.Http.HttpRequestException("Connection reset by peer");
+
+        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
+            () => handler.ThrowMidStreamException(e, request));
+    }
+
+    [Fact]
+    public void ThrowMidStreamException_TerminalError_ThrowsMappedException()
+    {
+        // A terminal (non-retryable) mid-stream error keeps its mapped type rather than being
+        // converted to RequestCancelled.
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+        var e = new RpcException(new Status(StatusCode.PermissionDenied, "denied"));
+
+        Assert.Throws<Couchbase.AuthenticationFailureException>(
+            () => handler.ThrowMidStreamException(e, request));
+    }
+
+    [Fact]
+    public void ThrowMidStreamException_GenuineInternalError_ThrowsMappedException()
+    {
+        // A genuine server Internal error (no transport inner) is terminal and maps to
+        // InternalServerFailureException, not RequestCancelled.
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+        var e = new RpcException(new Status(StatusCode.Internal, "Internal server error processing request"));
+
+        Assert.Throws<Couchbase.Core.Exceptions.InternalServerFailureException>(
+            () => handler.ThrowMidStreamException(e, request));
+    }
+
     [Fact]
     public async Task NestedIOException_InHttpRequestException_IsRetried()
     {

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -119,21 +119,22 @@ public class StellarRetryHandlerTests
             async () => await handler.RetryAsync(GrpcCall, request));
     }
 
-    // Mid-stream errors: retryable -> RequestCancelled, terminal -> mapped.
+    // Mid-stream errors: retryable -> RequestCancelled, terminal -> mapped. MapMidStreamException
+    // returns the exception the caller should throw (the caller does `throw _mapMidStreamError(e)`).
 
     [Fact]
-    public void ThrowMidStreamException_RetryableError_ThrowsRequestCancelled()
+    public void MapMidStreamException_RetryableError_ReturnsRequestCancelled()
     {
         var handler = new StellarRetryHandler();
         var request = new StellarRequest();
         var e = new RpcException(new Status(StatusCode.Unavailable, "Service unavailable"));
 
-        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
-            () => handler.ThrowMidStreamException(e, request));
+        Assert.IsType<Couchbase.Core.Exceptions.RequestCanceledException>(
+            handler.MapMidStreamException(e, request));
     }
 
     [Fact]
-    public void ThrowMidStreamException_TransientTransportError_ThrowsRequestCancelled()
+    public void MapMidStreamException_TransientTransportError_ReturnsRequestCancelled()
     {
         // A mid-stream HTTP/2 transport failure surfaces as RpcException(Internal) with an inner
         // transport exception; it is retryable, so mid-stream it becomes RequestCancelled.
@@ -142,12 +143,12 @@ public class StellarRetryHandlerTests
         var inner = new System.Net.Http.HttpRequestException("Connection reset by peer");
         var e = new RpcExceptionWithInner(new Status(StatusCode.Internal, "Internal error"), inner);
 
-        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
-            () => handler.ThrowMidStreamException(e, request));
+        Assert.IsType<Couchbase.Core.Exceptions.RequestCanceledException>(
+            handler.MapMidStreamException(e, request));
     }
 
     [Fact]
-    public void ThrowMidStreamException_BareTransportException_ThrowsRequestCancelled()
+    public void MapMidStreamException_BareTransportException_ReturnsRequestCancelled()
     {
         // A transport failure that surfaces outside an RpcException (a bare HttpRequestException or
         // IOException, mid-stream) is retryable, so it becomes RequestCancelled.
@@ -155,12 +156,12 @@ public class StellarRetryHandlerTests
         var request = new StellarRequest();
         var e = new System.Net.Http.HttpRequestException("Connection reset by peer");
 
-        Assert.Throws<Couchbase.Core.Exceptions.RequestCanceledException>(
-            () => handler.ThrowMidStreamException(e, request));
+        Assert.IsType<Couchbase.Core.Exceptions.RequestCanceledException>(
+            handler.MapMidStreamException(e, request));
     }
 
     [Fact]
-    public void ThrowMidStreamException_TerminalError_ThrowsMappedException()
+    public void MapMidStreamException_TerminalError_ReturnsMappedException()
     {
         // A terminal (non-retryable) mid-stream error keeps its mapped type rather than being
         // converted to RequestCancelled.
@@ -168,12 +169,12 @@ public class StellarRetryHandlerTests
         var request = new StellarRequest();
         var e = new RpcException(new Status(StatusCode.PermissionDenied, "denied"));
 
-        Assert.Throws<Couchbase.AuthenticationFailureException>(
-            () => handler.ThrowMidStreamException(e, request));
+        Assert.IsType<Couchbase.AuthenticationFailureException>(
+            handler.MapMidStreamException(e, request));
     }
 
     [Fact]
-    public void ThrowMidStreamException_GenuineInternalError_ThrowsMappedException()
+    public void MapMidStreamException_GenuineInternalError_ReturnsMappedException()
     {
         // A genuine server Internal error (no transport inner) is terminal and maps to
         // InternalServerFailureException, not RequestCancelled.
@@ -181,8 +182,8 @@ public class StellarRetryHandlerTests
         var request = new StellarRequest();
         var e = new RpcException(new Status(StatusCode.Internal, "Internal server error processing request"));
 
-        Assert.Throws<Couchbase.Core.Exceptions.InternalServerFailureException>(
-            () => handler.ThrowMidStreamException(e, request));
+        Assert.IsType<Couchbase.Core.Exceptions.InternalServerFailureException>(
+            handler.MapMidStreamException(e, request));
     }
 
     [Fact]


### PR DESCRIPTION
Motivation
==========
RFC 77 requires a retryable error that occurs mid-stream
(after the first response) to fail as RequestCancelled.
Stellar's query and analytics enumerators instead leaked
mid-stream errors as raw Grpc.Core.RpcException.

Modification
============
Add StellarRetryHandler.ThrowMidStreamException, reusing
HandleException so terminal codes throw their mapped
exception while retryable codes and transient transport
failures become RequestCancelled (carrying the error
context). Route the mid-stream MoveNext loops in
StellarQueryResult and ProtoAnalyticsResult through it.
Search is left as-is: it buffers the whole stream inside
RetryAsync, so retrying its mid-stream errors is safe. That
said, this seems inconsistent so we will explore that in
a separate ticket.

Results
=======
21 StellarRetryHandler tests passing, with new cases for
retryable, transient-transport, and terminal mid-stream
errors. First-response retry behavior is unchanged.