### PR TITLE
NCBC-4265: Remove Stellar error handling not specified by RFC 77

### DIFF
--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -214,7 +214,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
                                     new ValueInvalidException(); //Prone to change as it's unclear what this Precondition failure maps to.
                             default:
                                 // Unknown precondition (e.g. the removed "CAS") — terminal, not retried.
-                                throw TerminalException(context, status, detail);
+                                throw CreateTerminalException(context, status, detail);
                         }
                     }
                 }
@@ -246,7 +246,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
                 if (detail.Contains(StellarRetryStrings.PathValueOutOfRange)) throw new NumberTooBigException();
                 if (detail.Contains(StellarRetryStrings.ValueTooLarge)) throw new ValueToolargeException(detail);
                 // Unmapped FAILED_PRECONDITION is non-retryable (LOCKED aside) — terminal.
-                throw TerminalException(context, status, detail);
+                throw CreateTerminalException(context, status, detail);
             case StatusCode.PermissionDenied:
             case StatusCode.Unauthenticated:
                 throw new AuthenticationFailureException(context);
@@ -274,12 +274,13 @@ internal class StellarRetryHandler : IRetryOrchestrator
                 throw new InvalidArgumentException(context);
             // RESOURCE_EXHAUSTED (rate-limit only, not in RFC 77) is unmapped — falls through to default.
             default:
-                throw TerminalException(context, status, detail);
+                throw CreateTerminalException(context, status, detail);
         }
     }
 
-    // Non-retryable terminal outcome: record the gRPC status and throw CouchbaseException.
-    private static CouchbaseException TerminalException(GenericErrorContext context, StatusCode status, string detail)
+    // Non-retryable terminal outcome: record the gRPC status and return a CouchbaseException for the
+    // caller to throw.
+    private static CouchbaseException CreateTerminalException(GenericErrorContext context, StatusCode status, string detail)
     {
         context.Fields.Add("status", status);
         return new CouchbaseException(context, detail);

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -191,8 +191,6 @@ internal class StellarRetryHandler : IRetryOrchestrator
 
                         switch (type)
                         {
-                            case StellarRetryStrings.PreconditionCas:
-                                throw new CasMismatchException(context);
                             case StellarRetryStrings.PreconditionLocked:
                             {
                                 // Retryable per RFC 77 (KV_LOCKED). return (not break) so we retry with
@@ -214,6 +212,9 @@ internal class StellarRetryHandler : IRetryOrchestrator
                             case StellarRetryStrings.PreconditionValueOutOfRange:
                                 throw
                                     new ValueInvalidException(); //Prone to change as it's unclear what this Precondition failure maps to.
+                            default:
+                                // Unknown precondition (e.g. the removed "CAS") — terminal, not retried.
+                                throw TerminalException(context, status, detail);
                         }
                     }
                 }
@@ -244,7 +245,8 @@ internal class StellarRetryHandler : IRetryOrchestrator
                 if (detail.Contains(StellarRetryStrings.ValueOutOfRange)) throw new ValueInvalidException();
                 if (detail.Contains(StellarRetryStrings.PathValueOutOfRange)) throw new NumberTooBigException();
                 if (detail.Contains(StellarRetryStrings.ValueTooLarge)) throw new ValueToolargeException(detail);
-                break;
+                // Unmapped FAILED_PRECONDITION is non-retryable (LOCKED aside) — terminal.
+                throw TerminalException(context, status, detail);
             case StatusCode.PermissionDenied:
             case StatusCode.Unauthenticated:
                 throw new AuthenticationFailureException(context);
@@ -270,15 +272,17 @@ internal class StellarRetryHandler : IRetryOrchestrator
                 break;
             case StatusCode.InvalidArgument:
                 throw new InvalidArgumentException(context);
-            case StatusCode.ResourceExhausted:
-                throw new ValueToolargeException(
-                    "Request exceeds maximum message size.");
+            // RESOURCE_EXHAUSTED (rate-limit only, not in RFC 77) is unmapped — falls through to default.
             default:
-            {
-                context.Fields.Add("status", status);
-                throw new CouchbaseException(context, protoException.Status.Detail);
-            }
+                throw TerminalException(context, status, detail);
         }
+    }
+
+    // Non-retryable terminal outcome: record the gRPC status and throw CouchbaseException.
+    private static CouchbaseException TerminalException(GenericErrorContext context, StatusCode status, string detail)
+    {
+        context.Fields.Add("status", status);
+        return new CouchbaseException(context, detail);
     }
 
     internal virtual Any? StatusDeserializer(RpcException ex)

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryStrings.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryStrings.cs
@@ -17,7 +17,6 @@ public static class StellarRetryStrings
     public const string TypeUrlErrorInfo = "type.googleapis.com/google.rpc.ErrorInfo";
     public const string TypeUrlBadRequest = "type.googleapis.com/google.rpc.BadRequest";
 
-    public const string PreconditionCas = "CAS";
     public const string PreconditionLocked = "LOCKED";
     public const string PreconditionPathMismatch = "PATH_MISMATCH";
     public const string PreconditionDocNotJson = "DOC_NOT_JSON";

--- a/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/Core/StellarRetryHandlerTests.cs
@@ -120,6 +120,74 @@ public class StellarRetryHandlerTests
     }
 
     [Fact]
+    public async Task ResourceExhausted_FallsBackToCouchbaseException()
+    {
+        // NCBC-4265: unmapped RESOURCE_EXHAUSTED -> CouchbaseException, not ValueToolarge.
+        var handler = new StellarRetryHandler();
+        var request = new StellarRequest();
+
+        Task<GetResponse> GrpcCall()
+        {
+            throw new RpcException(new Status(StatusCode.ResourceExhausted, "rate limited"));
+        }
+
+        // Exact-type match also proves it is not a ValueToolargeException (a subtype).
+        await Assert.ThrowsAsync<CouchbaseException>(
+            async () => await handler.RetryAsync(GrpcCall, request));
+    }
+
+    [Fact]
+    public async Task UnrecognizedPreconditionType_IsTerminalCouchbaseException_NotRetried()
+    {
+        // NCBC-4265: an unknown precondition type (e.g. the removed "CAS") is terminal, not retried.
+        var preconditionFailure = new Google.Rpc.PreconditionFailure();
+        preconditionFailure.Violations.Add(
+            new Google.Rpc.PreconditionFailure.Types.Violation { Type = "CAS" });
+        var any = new Any
+        {
+            TypeUrl = StellarRetryStrings.TypeUrlPreconditionFailure,
+            Value = preconditionFailure.ToByteString()
+        };
+
+        var retryMock = new Mock<StellarRetryHandler>();
+        retryMock.Setup(handler => handler.StatusDeserializer(It.IsAny<RpcException>())).Returns(any);
+
+        var request = new StellarRequest { Timeout = TimeSpan.FromSeconds(5) };
+        var callCount = 0;
+
+        Task<GetResponse> GrpcCall()
+        {
+            callCount++;
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, "CAS"));
+        }
+
+        await Assert.ThrowsAsync<CouchbaseException>(
+            async () => await retryMock.Object.RetryAsync(GrpcCall, request));
+        Assert.Equal(1, callCount); // thrown on the first attempt, never retried
+    }
+
+    [Fact]
+    public async Task UnmappedFailedPrecondition_NoDetailBlock_IsTerminal_NotRetried()
+    {
+        // NCBC-4265: an unmapped FAILED_PRECONDITION with no detail block is terminal, not retried.
+        var retryMock = new Mock<StellarRetryHandler>();
+        retryMock.Setup(handler => handler.StatusDeserializer(It.IsAny<RpcException>())).Returns((Any?)null);
+
+        var request = new StellarRequest { Timeout = TimeSpan.FromSeconds(5) };
+        var callCount = 0;
+
+        Task<GetResponse> GrpcCall()
+        {
+            callCount++;
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, "SOME_UNKNOWN_PRECONDITION"));
+        }
+
+        await Assert.ThrowsAsync<CouchbaseException>(
+            async () => await retryMock.Object.RetryAsync(GrpcCall, request));
+        Assert.Equal(1, callCount); // thrown on the first attempt, never retried
+    }
+
+    [Fact]
     public async Task NestedIOException_InHttpRequestException_IsRetried()
     {
         // IOException wrapped inside HttpRequestException (the real-world pattern


### PR DESCRIPTION
Motivation
==========
The .NET Stellar retry handler maps two gRPC statuses that RFC 77 does not specify, and that CNG does not emit in the way the mappings assume:

- FAILED_PRECONDITION with a "CAS" precondition violation was mapped to CasMismatchException. CNG never returns this; a CAS mismatch arrives as ABORTED with a CAS_MISMATCH error-info block, which the handler already maps correctly.
- RESOURCE_EXHAUSTED was mapped to ValueToolargeException. CNG only uses this status for rate-limit errors on an API the SDK does not call, so the mapping mislabels an unrelated condition.

Removing the CAS mapping also exposed a latent issue: an unrecognized FAILED_PRECONDITION fell through to the status switch and was retried until the request timed out, even though FAILED_PRECONDITION is non-retryable per its gRPC contract (LOCKED is the sole RFC 77 exception).

Modification
============
- Remove the PreconditionCas -> CasMismatchException case (and the now-unused StellarRetryStrings.PreconditionCas constant).
- Remove the ResourceExhausted -> ValueToolargeException case so it falls through to CouchbaseException. Oversized documents are unaffected: they are caught by a client-side pre-flight size check in StellarCollection before the request is sent, not by this mapping.
- Make unmapped FAILED_PRECONDITION terminal on both paths so it is never retried (LOCKED aside): a default in the structured precondition-failure switch, and a terminal throw on the status-switch detail-string path.
- Route the three terminal, non-retryable outcomes (unknown status, and the two unmapped-precondition paths) through a single TerminalException helper so they behave identically: record the gRPC status in the error context and throw CouchbaseException.

Results
=======
Full unit suite passes. Adds regression tests asserting: RESOURCE_EXHAUSTED falls back to CouchbaseException (exact type, not ValueToolargeException); an unrecognized structured precondition type ("CAS") is a terminal CouchbaseException thrown on the first attempt; and an unmapped FAILED_PRECONDITION with no detail block is likewise terminal and not retried. The existing oversized-document ValueToolargeException tests continue to pass, confirming they do not depend on the removed mapping.