### PR TITLE
NCBC-4261: Use the staged txn.aux.uf user flags when committing

### DIFF
--- a/src/Couchbase/Client/Transactions/AttemptContext.cs
+++ b/src/Couchbase/Client/Transactions/AttemptContext.cs
@@ -1561,7 +1561,7 @@ namespace Couchbase.Client.Transactions
 
                     await _testHooks.BeforeDocCommitted(this, sm.Doc.Id).CAF();
                     var (updatedCas, mutationToken) = await _docs
-                        .UnstageInsertOrReplace(sm.Doc.Collection, sm.Doc.Id, cas, content, insertMode, sm.Flags ?? new Flags(), sm.Expiry).CAF();
+                        .UnstageInsertOrReplace(sm.Doc.Collection, sm.Doc.Id, cas, content, insertMode, sm.Flags ?? Flags.JsonCommonFlags, sm.Expiry).CAF();
                     Logger.LogInformation(
                         "Unstaged mutation successfully on {redactedId}, attempt={attemptId}, insertMode={insertMode}, ambiguityResolutionMode={ambiguityResolutionMode}, preCas={cas}, postCas={updatedCas}",
                         Redactor.UserData(sm.Doc.FullyQualifiedId),

--- a/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
+++ b/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
@@ -9,6 +9,7 @@ using Couchbase.Client.Transactions.Components;
 using Couchbase.Client.Transactions.DataAccess;
 using Couchbase.Client.Transactions.DataModel;
 using Couchbase.Client.Transactions.Error;
+using Couchbase.Client.Transactions.Internal;
 using Couchbase.Client.Transactions.Internal.Test;
 using Couchbase.Client.Transactions.LogUtil;
 using Couchbase.Client.Transactions.Support;
@@ -230,11 +231,14 @@ namespace Couchbase.Client.Transactions.Cleanup
             var coll = op.DocumentCollection;
             if (op.IsDeleted)
             {
+                // InsertAsync has no flags option; the persisted flags are whatever the transcoder's
+                // GetFormat returns. Pin them to the staged flags (txn.aux.uf) — we did not stage
+                // this doc, so re-deriving from the transcoder would not preserve the user's flags.
                 await coll.InsertAsync(op.Id, content,
                     options =>
                     {
                         options.Durability(durabilityLevel)
-                            .Transcoder(op.StagedContent?.Transcoder);
+                            .Transcoder(new FixedFlagsTranscoder(op.StagedContent!.Transcoder, op.StagedContent.Flags));
                         if (op.Expiry.HasValue) options.Expiry(op.Expiry.Value.RemainingTtl());
                     }).CAF();
             }
@@ -246,7 +250,9 @@ namespace Couchbase.Client.Transactions.Cleanup
                 {
                     opts.Durability(durabilityLevel)
                         .Transcoder(op.StagedContent?.Transcoder)
-                        .Flags(op.StagedContent!.Transcoder.GetFormat(content))
+                        // Use the flags recorded at staging time (txn.aux.uf), not flags
+                        // re-derived from this cleaner's transcoder — we did not stage this doc.
+                        .Flags(op.StagedContent!.Flags)
                         .Timeout(_keyValueTimeout)
                         .Cas(op.Cas)
                         .PreserveTtl(coll.Scope.Bucket.SupportsCollections);

--- a/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
+++ b/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Couchbase.Core;
@@ -177,10 +176,13 @@ namespace Couchbase.Client.Transactions.DataAccess
             // if bucket doesn't support ReplaceBodyWithXattr (and ReviveDocument)
             if (insertMode)
             {
+                // InsertAsync has no flags option; the persisted flags are whatever the transcoder's
+                // GetFormat returns. Pin them to the staged flags so the committed doc keeps them.
+                ITypeTranscoder insertTranscoder = isBinary
+                    ? new RawBinaryTranscoder()
+                    : _jsonUserDataTranscoder;
                 var opts = new InsertOptions().Defaults(_durability, _keyValueTimeout)
-                    .Transcoder(isBinary
-                        ? new RawBinaryTranscoder()
-                        : _jsonUserDataTranscoder);
+                    .Transcoder(new FixedFlagsTranscoder(insertTranscoder, flags));
                 if (expiry.HasValue)
                 {
                     opts.Expiry(expiry.Value.RemainingTtl());
@@ -289,6 +291,12 @@ namespace Couchbase.Client.Transactions.DataAccess
             var docMeta = lookupInResult.ContentAs<DocumentMetadata>(docMetaIndex);
             int dataIdx = stagedDataIndex; // just need a default
 
+            // Deserialize the transaction xattr once; reused below for the staged user-flags
+            // (txn.aux.uf) and stored on the result.
+            var txnXattrs = lookupInResult.Exists(txnIndex)
+                ? lookupInResult.ContentAs<TransactionXattrs>(txnIndex)
+                : null;
+
             // Determine the appropriate transcoder for wrapping the document content.
             // This is separate from the lookup transcoder used above.
             // Note: We use separate transcoders for staged vs unstaged content because:
@@ -340,8 +348,12 @@ namespace Couchbase.Client.Transactions.DataAccess
                 ? new LookupInContentAsWrapper(lookupInResult, fullDocIndex.Value, unstagedContentTranscoder)
                 : null;
 
+            // Staged content carries the user flags recorded in txn.aux.uf when it was staged,
+            // NOT the live document body's flags. This matters when committing content we didn't
+            // stage (lost-transaction cleanup) or when resolving ambiguity from a re-read doc.
             var stagedContent = lookupInResult.Exists(dataIdx)
-                ? new LookupInContentAsWrapper(lookupInResult, dataIdx, stagedContentTranscoder)
+                ? new LookupInContentAsWrapper(lookupInResult, dataIdx, stagedContentTranscoder,
+                    flagsOverride: ParseStagedUserFlags(txnXattrs))
                 : null;
 
             var result = new DocumentLookupResult(docId,
@@ -351,12 +363,27 @@ namespace Couchbase.Client.Transactions.DataAccess
                 docMeta,
                 collection);
 
-            if (lookupInResult.Exists(txnIndex))
-            {
-                result.TransactionXattrs = lookupInResult.ContentAs<TransactionXattrs>(txnIndex);
-            }
+            result.TransactionXattrs = txnXattrs;
 
             return result;
+        }
+
+        /// <summary>
+        /// Reconstruct the user flags recorded in <c>txn.aux.uf</c> at staging time. Falls back to
+        /// JSON common flags when the field is absent (e.g. staged by an older/other SDK that did
+        /// not record it — such content was always JSON), mirroring Java's
+        /// <c>stagedUserFlags().orElse(CodecFlags.JSON_COMMON_FLAGS)</c>.
+        /// </summary>
+        internal static Flags ParseStagedUserFlags(TransactionXattrs? txnXattrs)
+        {
+            if (txnXattrs?.AuxiliaryData is { ValueKind: JsonValueKind.Object } aux
+                && aux.TryGetProperty("uf", out var ufElement)
+                && ufElement.TryGetUInt32(out var uf))
+            {
+                return Flags.FromUInt32(uf);
+            }
+
+            return Flags.JsonCommonFlags;
         }
 
         private MutateInOptions GetMutateInOptions(StoreSemantics storeSemantics, ICouchbaseCollection collection) =>
@@ -414,11 +441,8 @@ namespace Couchbase.Client.Transactions.DataAccess
                         specs.Add(MutateInSpec.Upsert(TransactionFields.StagedData, rawJsonElement,
                             createPath: true, isXattr: true));
                     }
-                    // convert flags to a uint
-                    Span<byte> span = stackalloc byte[4];
-                    content.Flags.Write(span);
-                    var flagCompact = BinaryPrimitives.ReadUInt32LittleEndian(span);
-                    // now add it
+                    // record the user flags (reconstructed on read by Flags.FromUInt32)
+                    var flagCompact = content.Flags.ToUInt32();
                     specs.Add(MutateInSpec.Upsert(TransactionFields.UserFlags, flagCompact,
                         createPath: true, isXattr: true));
                     break;

--- a/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
+++ b/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
@@ -353,7 +353,7 @@ namespace Couchbase.Client.Transactions.DataAccess
             // stage (lost-transaction cleanup) or when resolving ambiguity from a re-read doc.
             var stagedContent = lookupInResult.Exists(dataIdx)
                 ? new LookupInContentAsWrapper(lookupInResult, dataIdx, stagedContentTranscoder,
-                    flagsOverride: ParseStagedUserFlags(txnXattrs))
+                    flagsOverride: ParseStagedUserFlags(txnXattrs, isBinaryStaged))
                 : null;
 
             var result = new DocumentLookupResult(docId,
@@ -372,18 +372,34 @@ namespace Couchbase.Client.Transactions.DataAccess
         /// Reconstruct the user flags recorded in <c>txn.aux.uf</c> at staging time. Falls back to
         /// JSON common flags when the field is absent (e.g. staged by an older/other SDK that did
         /// not record it — such content was always JSON), mirroring Java's
-        /// <c>stagedUserFlags().orElse(CodecFlags.JSON_COMMON_FLAGS)</c>.
+        /// <c>stagedUserFlags().orElse(CodecFlags.JSON_COMMON_FLAGS)</c>. When the staged content
+        /// is binary the fallback is binary common flags instead.
+        /// <para>
+        /// <paramref name="isBinaryStaged"/> (i.e. the content is staged at <c>txn.bin</c>) is
+        /// authoritative and overrides a <c>uf</c> that disagrees. Committing binary content with
+        /// JSON flags is not cosmetic: reading it back through the default JsonTranscoder throws
+        /// ("JsonTranscoder does not support byte arrays"), so we never let a bad <c>uf</c> produce
+        /// an unreadable document. This is also the backstop for a <c>uf</c> written by .NET
+        /// 3.8.0-3.9.4, which encoded the value byte-reversed (little-endian) — see
+        /// <see cref="Flags.ToUInt32"/>. We deliberately do not try to detect that byte order:
+        /// the value carries no version marker, any such rule is guesswork, and the only
+        /// non-benign case (binary) is covered deterministically here.
+        /// </para>
         /// </summary>
-        internal static Flags ParseStagedUserFlags(TransactionXattrs? txnXattrs)
+        internal static Flags ParseStagedUserFlags(TransactionXattrs? txnXattrs, bool isBinaryStaged)
         {
             if (txnXattrs?.AuxiliaryData is { ValueKind: JsonValueKind.Object } aux
                 && aux.TryGetProperty("uf", out var ufElement)
                 && ufElement.TryGetUInt32(out var uf))
             {
-                return Flags.FromUInt32(uf);
+                var stagedFlags = Flags.FromUInt32(uf);
+                if (!isBinaryStaged || stagedFlags.DataFormat == DataFormat.Binary)
+                {
+                    return stagedFlags;
+                }
             }
 
-            return Flags.JsonCommonFlags;
+            return isBinaryStaged ? Flags.BinaryCommonFlags : Flags.JsonCommonFlags;
         }
 
         private MutateInOptions GetMutateInOptions(StoreSemantics storeSemantics, ICouchbaseCollection collection) =>

--- a/src/Couchbase/Client/Transactions/Internal/FixedFlagsTranscoder.cs
+++ b/src/Couchbase/Client/Transactions/Internal/FixedFlagsTranscoder.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System;
+using System.IO;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+
+namespace Couchbase.Client.Transactions.Internal
+{
+    /// <summary>
+    /// A transcoder decorator that pins the flags written to the document, delegating the actual
+    /// byte encoding/decoding to an inner transcoder.
+    /// <para>
+    /// On a .NET mutation the persisted flags are always <c>Transcoder.GetFormat(content)</c>
+    /// (see <c>OperationBase&lt;T&gt;.WriteExtras</c>) — there is no per-operation flags override,
+    /// which is why <c>InsertOptions</c> exposes none. When committing content we did not stage
+    /// (lost-transaction cleanup) or via the legacy insert path, we must persist the user flags
+    /// recorded at staging time (<c>txn.aux.uf</c>) rather than flags re-derived from the content.
+    /// This wrapper makes <see cref="GetFormat{T}"/> report those staged flags so they land on the
+    /// document, while <see cref="Encode{T}"/>/<see cref="Decode{T}"/> behave exactly as the inner
+    /// transcoder. It is the .NET analogue of Java passing <c>stagedUserFlags</c> straight to the
+    /// insert request.
+    /// </para>
+    /// </summary>
+    internal sealed class FixedFlagsTranscoder : ITypeTranscoder
+    {
+        private readonly ITypeTranscoder _inner;
+        private readonly Flags _flags;
+
+        public FixedFlagsTranscoder(ITypeTranscoder inner, Flags flags)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _flags = flags;
+        }
+
+        /// <summary>Always reports the fixed (staged) flags, ignoring the content's runtime type.</summary>
+        public Flags GetFormat<T>(T value) => _flags;
+
+        public void Encode<T>(Stream stream, T value, Flags flags, OpCode opcode) =>
+            _inner.Encode(stream, value, flags, opcode);
+
+        public T? Decode<T>(ReadOnlyMemory<byte> buffer, Flags flags, OpCode opcode) =>
+            _inner.Decode<T>(buffer, flags, opcode);
+
+        public ITypeSerializer? Serializer
+        {
+            get => _inner.Serializer;
+            set => _inner.Serializer = value;
+        }
+    }
+}

--- a/src/Couchbase/Client/Transactions/Internal/IContentAsWrapper.cs
+++ b/src/Couchbase/Client/Transactions/Internal/IContentAsWrapper.cs
@@ -93,16 +93,18 @@ namespace Couchbase.Client.Transactions.Internal
 
         public bool IsBinary { get; init; }
 
-        public LookupInContentAsWrapper(ILookupInResult lookupInResult, int specIndex, ITypeTranscoder? transcoder = null)
+        public LookupInContentAsWrapper(ILookupInResult lookupInResult, int specIndex, ITypeTranscoder? transcoder = null, Flags? flagsOverride = null)
         {
             _lookupInResult = lookupInResult;
             if (lookupInResult is not ILookupInResultInternal res)
             {
                 throw new InvalidArgumentException("lookupInResult is not a LookupInResult");
             }
-            // NOTE: this Flags isn't necessarily what we want to use for the flags if this specIndex
-            // becomes the document body.
-            Flags = res.Flags;
+            // res.Flags is the flags of the top-level (live) document body. That is correct for
+            // pre-transaction (unstaged) content, but wrong for staged content: the staged user
+            // flags are recorded separately in txn.aux.uf. Callers wrapping staged content pass
+            // flagsOverride so this wrapper carries the flags the content was actually staged with.
+            Flags = flagsOverride ?? res.Flags;
             _specIndex = specIndex;
             IsBinary = (res.Specs[specIndex].PathFlags & SubdocPathFlags.BinaryValue) != 0;
             Transcoder = transcoder ?? new JsonTranscoder();

--- a/src/Couchbase/Core/IO/Operations/Flags.cs
+++ b/src/Couchbase/Core/IO/Operations/Flags.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using Couchbase.Core.IO.Converters;
 
@@ -14,6 +15,19 @@ namespace Couchbase.Core.IO.Operations
         public TypeCode TypeCode { get; set; }
 
         internal const int Size = 4; // we explicitly serialize into 4 bytes
+
+        /// <summary>
+        /// The canonical common flags for JSON content (a JSON object). Used as a fallback
+        /// when a persisted flags value is unavailable (e.g. a staged transaction mutation
+        /// written by an older/other SDK that did not record <c>txn.aux.uf</c>). Mirrors what
+        /// <see cref="Transcoders.JsonTranscoder.GetFormat{T}"/> emits for an object body.
+        /// </summary>
+        internal static Flags JsonCommonFlags => new()
+        {
+            DataFormat = DataFormat.Json,
+            Compression = Compression.None,
+            TypeCode = TypeCode.Object
+        };
 
         /// <summary>
         /// Read flags from a buffer. The buffer must be at least 4 bytes long.
@@ -49,6 +63,33 @@ namespace Couchbase.Core.IO.Operations
             buffer[0] = unchecked((byte)(((int) DataFormat & 0xf) | ((int) Compression & 0xe0)));  // DataFormat is lower 4 bits, compression higher 3 bits
             buffer[1] = 0;
             ByteConverter.FromUInt16((ushort)TypeCode, buffer.Slice(2));
+        }
+
+        /// <summary>
+        /// Encode these flags as the 32-bit "user flags" integer used to persist them in a document
+        /// xattr (e.g. the transaction <c>txn.aux.uf</c> staged user-flags field). Uses network byte
+        /// order (big-endian) so the common-flags/format nibble lands in the top byte, matching the
+        /// Common Flags SDK RFC and the other SDKs — i.e. <c>(ToUInt32() >> 24) &amp; 0xF</c> is the
+        /// document format. <see cref="Write"/> already emits that byte first, so a big-endian read
+        /// places it in the most-significant byte.
+        /// </summary>
+        internal readonly uint ToUInt32()
+        {
+            Span<byte> span = stackalloc byte[Size];
+            Write(span);
+            return BinaryPrimitives.ReadUInt32BigEndian(span);
+        }
+
+        /// <summary>
+        /// The exact inverse of <see cref="ToUInt32"/>: reconstruct flags from a persisted network
+        /// byte order (big-endian) 32-bit user-flags value. Round-trips byte-for-byte with
+        /// <see cref="ToUInt32"/>.
+        /// </summary>
+        internal static Flags FromUInt32(uint value)
+        {
+            Span<byte> span = stackalloc byte[Size];
+            BinaryPrimitives.WriteUInt32BigEndian(span, value);
+            return Read(span);
         }
 
         private static void ThrowArgumentException()

--- a/src/Couchbase/Core/IO/Operations/Flags.cs
+++ b/src/Couchbase/Core/IO/Operations/Flags.cs
@@ -20,11 +20,26 @@ namespace Couchbase.Core.IO.Operations
         /// The canonical common flags for JSON content (a JSON object). Used as a fallback
         /// when a persisted flags value is unavailable (e.g. a staged transaction mutation
         /// written by an older/other SDK that did not record <c>txn.aux.uf</c>). Mirrors what
-        /// <see cref="Transcoders.JsonTranscoder.GetFormat{T}"/> emits for an object body.
+        /// <see cref="Couchbase.Core.IO.Transcoders.JsonTranscoder.GetFormat{T}"/> emits for
+        /// an object body.
         /// </summary>
         internal static Flags JsonCommonFlags => new()
         {
             DataFormat = DataFormat.Json,
+            Compression = Compression.None,
+            TypeCode = TypeCode.Object
+        };
+
+        /// <summary>
+        /// The canonical common flags for raw binary content. The binary counterpart of
+        /// <see cref="JsonCommonFlags"/>, used as the fallback when we know the content is
+        /// binary but have no usable persisted flags value. Mirrors what
+        /// <see cref="Couchbase.Core.IO.Transcoders.RawBinaryTranscoder.GetFormat{T}"/> emits
+        /// for a <c>byte[]</c>.
+        /// </summary>
+        internal static Flags BinaryCommonFlags => new()
+        {
+            DataFormat = DataFormat.Binary,
             Compression = Compression.None,
             TypeCode = TypeCode.Object
         };

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/FlagsTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/FlagsTests.cs
@@ -76,5 +76,60 @@ namespace Couchbase.UnitTests.Core.IO.Operations
         }
 
         #endregion
+
+        #region ToUInt32 / FromUInt32
+
+        [Theory]
+        [InlineData(DataFormat.Json, TypeCode.Object)]
+        [InlineData(DataFormat.Json, TypeCode.String)]
+        [InlineData(DataFormat.Binary, TypeCode.Object)]
+        [InlineData(DataFormat.Private, TypeCode.String)]
+        [InlineData(DataFormat.String, TypeCode.String)]
+        public void ToUInt32_FromUInt32_RoundTrips(DataFormat dataFormat, TypeCode typeCode)
+        {
+            // Arrange
+
+            var flags = new Flags
+            {
+                DataFormat = dataFormat,
+                Compression = Couchbase.Core.IO.Operations.Compression.None,
+                TypeCode = typeCode
+            };
+
+            // Act
+
+            var roundTripped = Flags.FromUInt32(flags.ToUInt32());
+
+            // Assert
+
+            Assert.Equal(flags.DataFormat, roundTripped.DataFormat);
+            Assert.Equal(flags.Compression, roundTripped.Compression);
+            Assert.Equal(flags.TypeCode, roundTripped.TypeCode);
+        }
+
+        [Fact]
+        public void ToUInt32_UsesNetworkByteOrder_CommonFlagsInTopByte()
+        {
+            // JSON + Object writes bytes [0x02, 0x00, 0x00, 0x01]; read big-endian => 0x02000001.
+            // The common-flags/format nibble must be in the top byte so cross-SDK readers get it
+            // via (uf >> 24) & 0xF — matching Java's CodecFlags (format << 24).
+            var flags = Flags.JsonCommonFlags;
+
+            Assert.Equal(0x02000001u, flags.ToUInt32());
+            Assert.Equal((uint)DataFormat.Json, flags.ToUInt32() >> 24);
+            Assert.Equal(DataFormat.Json, Flags.FromUInt32(0x02000001u).DataFormat);
+        }
+
+        [Fact]
+        public void JsonCommonFlags_IsJsonObject()
+        {
+            var flags = Flags.JsonCommonFlags;
+
+            Assert.Equal(DataFormat.Json, flags.DataFormat);
+            Assert.Equal(Couchbase.Core.IO.Operations.Compression.None, flags.Compression);
+            Assert.Equal(TypeCode.Object, flags.TypeCode);
+        }
+
+        #endregion
     }
 }

--- a/tests/Couchbase.UnitTests/Transactions/FixedFlagsTranscoderTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/FixedFlagsTranscoderTests.cs
@@ -1,0 +1,82 @@
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Couchbase.Client.Transactions.Internal;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+using Xunit;
+
+namespace Couchbase.UnitTests.Transactions;
+
+/// <summary>
+/// NCBC-4261: FixedFlagsTranscoder pins the flags written to a document (used on the raw-insert
+/// commit paths, which have no flags option) while delegating byte encoding/decoding to the inner
+/// transcoder.
+/// </summary>
+public class FixedFlagsTranscoderTests
+{
+    private static JsonTranscoder InnerJson() => new(SystemTextJsonSerializer.Create());
+
+    [Fact]
+    public void GetFormat_AlwaysReturnsFixedFlags_IgnoringContentType()
+    {
+        // Inner would report Json for an object and Binary for a byte[]; the decorator must not.
+        var fixedFlags = new Flags { DataFormat = DataFormat.Binary, TypeCode = System.TypeCode.String };
+        var transcoder = new FixedFlagsTranscoder(InnerJson(), fixedFlags);
+
+        var forObject = transcoder.GetFormat(new { a = 1 });
+        var forBytes = transcoder.GetFormat(new byte[] { 1, 2, 3 });
+
+        Assert.Equal(DataFormat.Binary, forObject.DataFormat);
+        Assert.Equal(System.TypeCode.String, forObject.TypeCode);
+        Assert.Equal(DataFormat.Binary, forBytes.DataFormat);
+        Assert.Equal(System.TypeCode.String, forBytes.TypeCode);
+    }
+
+    [Fact]
+    public void Encode_DelegatesToInner()
+    {
+        var inner = InnerJson();
+        var content = new { key = "value" };
+        var flags = new Flags { DataFormat = DataFormat.Json, TypeCode = System.TypeCode.Object };
+        var transcoder = new FixedFlagsTranscoder(inner, Flags.JsonCommonFlags);
+
+        using var innerStream = new MemoryStream();
+        inner.Encode(innerStream, content, flags, OpCode.Set);
+
+        using var decoratedStream = new MemoryStream();
+        transcoder.Encode(decoratedStream, content, flags, OpCode.Set);
+
+        Assert.Equal(innerStream.ToArray(), decoratedStream.ToArray());
+    }
+
+    [Fact]
+    public void Decode_DelegatesToInner_RoundTrips()
+    {
+        var inner = InnerJson();
+        var flags = new Flags { DataFormat = DataFormat.Json, TypeCode = System.TypeCode.Object };
+        var transcoder = new FixedFlagsTranscoder(inner, Flags.JsonCommonFlags);
+
+        using var stream = new MemoryStream();
+        inner.Encode(stream, new { number = 42 }, flags, OpCode.Set);
+
+        var decoded = transcoder.Decode<Dictionary<string, int>>(stream.ToArray(), flags, OpCode.Get);
+
+        Assert.NotNull(decoded);
+        Assert.Equal(42, decoded!["number"]);
+    }
+
+    [Fact]
+    public void Serializer_DelegatesToInner()
+    {
+        var inner = InnerJson();
+        var transcoder = new FixedFlagsTranscoder(inner, Flags.JsonCommonFlags);
+
+        Assert.Same(inner.Serializer, transcoder.Serializer);
+
+        var newSerializer = SystemTextJsonSerializer.Create();
+        transcoder.Serializer = newSerializer;
+        Assert.Same(newSerializer, inner.Serializer);
+    }
+}

--- a/tests/Couchbase.UnitTests/Transactions/StagedUserFlagsTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/StagedUserFlagsTests.cs
@@ -1,0 +1,178 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Couchbase.Client.Transactions.DataAccess;
+using Couchbase.Client.Transactions.DataModel;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+using Couchbase.KeyValue;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Transactions;
+
+/// <summary>
+/// NCBC-4261: on commit we must use the user flags recorded in txn.aux.uf at staging time,
+/// not the live document body's flags. These cover the parse/fallback helper and that the
+/// staged content wrapper surfaces the staged flags end-to-end through LookupDocumentAsync.
+/// </summary>
+public class StagedUserFlagsTests
+{
+    private static readonly ReadOnlyMemory<byte> JsonBytes =
+        Encoding.UTF8.GetBytes("""{"key":"value"}""");
+    private static readonly ReadOnlyMemory<byte> BinaryBytes = new byte[] { 0x01, 0x02, 0x03 };
+
+    private static TransactionXattrs XattrsWithAux(string? auxJson) => new()
+    {
+        AuxiliaryData = auxJson is null
+            ? null
+            : JsonDocument.Parse(auxJson).RootElement.Clone()
+    };
+
+    // Builds an aux JSON object carrying the user flags for the given format, computed via ToUInt32
+    // so the test stays correct regardless of the (network byte order) encoding.
+    private static string AuxWithUf(DataFormat dataFormat, TypeCode typeCode = TypeCode.Object) =>
+        $$"""{"uf":{{new Flags { DataFormat = dataFormat, TypeCode = typeCode }.ToUInt32()}}}""";
+
+    #region ParseStagedUserFlags
+
+    [Fact]
+    public void ParseStagedUserFlags_JsonUf_ReturnsStagedFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(AuxWithUf(DataFormat.Json)));
+
+        Assert.Equal(DataFormat.Json, flags.DataFormat);
+        Assert.Equal(TypeCode.Object, flags.TypeCode);
+    }
+
+    [Fact]
+    public void ParseStagedUserFlags_BinaryUf_ReturnsBinaryFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(AuxWithUf(DataFormat.Binary)));
+
+        Assert.Equal(DataFormat.Binary, flags.DataFormat);
+    }
+
+    [Fact]
+    public void ParseStagedUserFlags_NoAux_FallsBackToJsonCommonFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(null));
+
+        Assert.Equal(DataFormat.Json, flags.DataFormat);
+        Assert.Equal(TypeCode.Object, flags.TypeCode);
+    }
+
+    [Fact]
+    public void ParseStagedUserFlags_AuxWithoutUf_FallsBackToJsonCommonFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux("""{"docexpiry":123}"""));
+
+        Assert.Equal(DataFormat.Json, flags.DataFormat);
+    }
+
+    [Fact]
+    public void ParseStagedUserFlags_NullXattrs_FallsBackToJsonCommonFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(null);
+
+        Assert.Equal(DataFormat.Json, flags.DataFormat);
+    }
+
+    #endregion
+
+    #region End-to-end via LookupDocumentAsync
+
+    private static Mock<ILookupInResultInternal> BuildLookupResult(Flags bodyFlags, TransactionXattrs txnXattrs)
+    {
+        var specs = new List<LookupInSpec>
+        {
+            new() { Bytes = JsonBytes },   // 0 txn xattrs
+            new() { Bytes = JsonBytes },   // 1 $document meta
+            new() { Bytes = JsonBytes },   // 2 staged JSON data
+            new() { Bytes = BinaryBytes }, // 3 staged binary data
+            new() { Bytes = JsonBytes },   // 4 full document body
+        };
+
+        var mock = new Mock<ILookupInResultInternal>();
+        mock.Setup(r => r.Specs).Returns(specs);
+        mock.Setup(r => r.Flags).Returns(bodyFlags);
+        mock.Setup(r => r.ContentAs<TransactionXattrs>(0)).Returns(txnXattrs);
+        mock.Setup(r => r.Exists(0)).Returns(true);
+        mock.Setup(r => r.Exists(2)).Returns(true);   // JSON staged
+        mock.Setup(r => r.Exists(3)).Returns(false);
+        mock.Setup(r => r.Exists(4)).Returns(true);
+        mock.Setup(r => r.IsDeleted).Returns(false);
+        mock.Setup(r => r.Cas).Returns(0UL);
+        return mock;
+    }
+
+    private static ICouchbaseCollection BuildCollection(Mock<ILookupInResultInternal> lookupResult)
+    {
+        var mockBucket = new Mock<IBucket>();
+        mockBucket.Setup(b => b.Name).Returns("b");
+        var mockScope = new Mock<IScope>();
+        mockScope.Setup(s => s.Name).Returns("s");
+        mockScope.Setup(s => s.Bucket).Returns(mockBucket.Object);
+        var mockCollection = new Mock<ICouchbaseCollection>();
+        mockCollection.Setup(c => c.Name).Returns("c");
+        mockCollection.Setup(c => c.Scope).Returns(mockScope.Object);
+        mockCollection
+            .Setup(c => c.LookupInAsync(
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<LookupInSpec>>(),
+                It.IsAny<LookupInOptions?>()))
+            .ReturnsAsync(lookupResult.Object);
+        return mockCollection.Object;
+    }
+
+    [Fact]
+    public async Task StagedContent_UsesUf_NotBodyFlags()
+    {
+        // Body flags deliberately differ from the staged uf to prove the source.
+        var bodyFlags = new Flags { DataFormat = DataFormat.String };
+        var mock = BuildLookupResult(bodyFlags, XattrsWithAux(AuxWithUf(DataFormat.Json)));
+
+        var result = await DocumentRepository.LookupDocumentAsync(
+            BuildCollection(mock), "doc-id", keyValueTimeout: null,
+            defaultJsonTranscoder: new JsonTranscoder(SystemTextJsonSerializer.Create()));
+
+        Assert.NotNull(result.StagedContent);
+        Assert.Equal(DataFormat.Json, result.StagedContent!.Flags.DataFormat);
+        Assert.Equal(TypeCode.Object, result.StagedContent.Flags.TypeCode);
+    }
+
+    [Fact]
+    public async Task UnstagedContent_StillUsesBodyFlags()
+    {
+        var bodyFlags = new Flags { DataFormat = DataFormat.Json, TypeCode = TypeCode.String };
+        var mock = BuildLookupResult(bodyFlags, XattrsWithAux(AuxWithUf(DataFormat.Json)));
+
+        var result = await DocumentRepository.LookupDocumentAsync(
+            BuildCollection(mock), "doc-id", keyValueTimeout: null,
+            defaultJsonTranscoder: new JsonTranscoder(SystemTextJsonSerializer.Create()));
+
+        Assert.NotNull(result.UnstagedContent);
+        // Unstaged (pre-transaction) content keeps the live body flags, not the staged uf.
+        Assert.Equal(TypeCode.String, result.UnstagedContent!.Flags.TypeCode);
+    }
+
+    [Fact]
+    public async Task StagedContent_NoUf_FallsBackToJson()
+    {
+        var bodyFlags = new Flags { DataFormat = DataFormat.String };
+        var mock = BuildLookupResult(bodyFlags, XattrsWithAux(null));
+
+        var result = await DocumentRepository.LookupDocumentAsync(
+            BuildCollection(mock), "doc-id", keyValueTimeout: null,
+            defaultJsonTranscoder: new JsonTranscoder(SystemTextJsonSerializer.Create()));
+
+        Assert.NotNull(result.StagedContent);
+        Assert.Equal(DataFormat.Json, result.StagedContent!.Flags.DataFormat);
+    }
+
+    #endregion
+}

--- a/tests/Couchbase.UnitTests/Transactions/StagedUserFlagsTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/StagedUserFlagsTests.cs
@@ -26,12 +26,17 @@ public class StagedUserFlagsTests
         Encoding.UTF8.GetBytes("""{"key":"value"}""");
     private static readonly ReadOnlyMemory<byte> BinaryBytes = new byte[] { 0x01, 0x02, 0x03 };
 
-    private static TransactionXattrs XattrsWithAux(string? auxJson) => new()
+    private static TransactionXattrs XattrsWithAux(string? auxJson)
     {
-        AuxiliaryData = auxJson is null
-            ? null
-            : JsonDocument.Parse(auxJson).RootElement.Clone()
-    };
+        if (auxJson is null)
+        {
+            return new TransactionXattrs { AuxiliaryData = null };
+        }
+
+        // Clone() detaches the element from the document, so the document can be disposed here.
+        using var doc = JsonDocument.Parse(auxJson);
+        return new TransactionXattrs { AuxiliaryData = doc.RootElement.Clone() };
+    }
 
     // Builds an aux JSON object carrying the user flags for the given format, computed via ToUInt32
     // so the test stays correct regardless of the (network byte order) encoding.
@@ -43,7 +48,8 @@ public class StagedUserFlagsTests
     [Fact]
     public void ParseStagedUserFlags_JsonUf_ReturnsStagedFlags()
     {
-        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(AuxWithUf(DataFormat.Json)));
+        var flags = DocumentRepository.ParseStagedUserFlags(
+            XattrsWithAux(AuxWithUf(DataFormat.Json)), isBinaryStaged: false);
 
         Assert.Equal(DataFormat.Json, flags.DataFormat);
         Assert.Equal(TypeCode.Object, flags.TypeCode);
@@ -52,7 +58,8 @@ public class StagedUserFlagsTests
     [Fact]
     public void ParseStagedUserFlags_BinaryUf_ReturnsBinaryFlags()
     {
-        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(AuxWithUf(DataFormat.Binary)));
+        var flags = DocumentRepository.ParseStagedUserFlags(
+            XattrsWithAux(AuxWithUf(DataFormat.Binary)), isBinaryStaged: true);
 
         Assert.Equal(DataFormat.Binary, flags.DataFormat);
     }
@@ -60,7 +67,7 @@ public class StagedUserFlagsTests
     [Fact]
     public void ParseStagedUserFlags_NoAux_FallsBackToJsonCommonFlags()
     {
-        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(null));
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(null), isBinaryStaged: false);
 
         Assert.Equal(DataFormat.Json, flags.DataFormat);
         Assert.Equal(TypeCode.Object, flags.TypeCode);
@@ -69,7 +76,8 @@ public class StagedUserFlagsTests
     [Fact]
     public void ParseStagedUserFlags_AuxWithoutUf_FallsBackToJsonCommonFlags()
     {
-        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux("""{"docexpiry":123}"""));
+        var flags = DocumentRepository.ParseStagedUserFlags(
+            XattrsWithAux("""{"docexpiry":123}"""), isBinaryStaged: false);
 
         Assert.Equal(DataFormat.Json, flags.DataFormat);
     }
@@ -77,16 +85,59 @@ public class StagedUserFlagsTests
     [Fact]
     public void ParseStagedUserFlags_NullXattrs_FallsBackToJsonCommonFlags()
     {
-        var flags = DocumentRepository.ParseStagedUserFlags(null);
+        var flags = DocumentRepository.ParseStagedUserFlags(null, isBinaryStaged: false);
 
         Assert.Equal(DataFormat.Json, flags.DataFormat);
     }
 
     #endregion
 
+    #region txn.bin overrides a disagreeing uf
+
+    // Content staged at txn.bin is binary, full stop. A uf that says otherwise cannot be trusted:
+    // committing binary content with JSON flags makes ContentAs<byte[]> throw on read. This is what
+    // covers a uf written byte-reversed by .NET 3.8.0-3.9.4, which we do not otherwise detect.
+    [Theory]
+    [InlineData(DataFormat.Json)]
+    [InlineData(DataFormat.String)]
+    [InlineData(DataFormat.Private)]
+    [InlineData(DataFormat.Reserved)]
+    public void ParseStagedUserFlags_BinaryStaged_NonBinaryUf_FallsBackToBinaryCommonFlags(DataFormat ufFormat)
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(
+            XattrsWithAux(AuxWithUf(ufFormat)), isBinaryStaged: true);
+
+        Assert.Equal(DataFormat.Binary, flags.DataFormat);
+        Assert.Equal(TypeCode.Object, flags.TypeCode);
+    }
+
+    [Fact]
+    public void ParseStagedUserFlags_BinaryStaged_NoUf_FallsBackToBinaryCommonFlags()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(XattrsWithAux(null), isBinaryStaged: true);
+
+        Assert.Equal(DataFormat.Binary, flags.DataFormat);
+        Assert.Equal(TypeCode.Object, flags.TypeCode);
+    }
+
+    // The override is one-way: it must not touch non-binary staged content, so a legitimate
+    // non-JSON uf (e.g. a raw string) still comes through untouched.
+    [Fact]
+    public void ParseStagedUserFlags_NotBinaryStaged_StringUf_IsUnchanged()
+    {
+        var flags = DocumentRepository.ParseStagedUserFlags(
+            XattrsWithAux(AuxWithUf(DataFormat.String, TypeCode.String)), isBinaryStaged: false);
+
+        Assert.Equal(DataFormat.String, flags.DataFormat);
+        Assert.Equal(TypeCode.String, flags.TypeCode);
+    }
+
+    #endregion
+
     #region End-to-end via LookupDocumentAsync
 
-    private static Mock<ILookupInResultInternal> BuildLookupResult(Flags bodyFlags, TransactionXattrs txnXattrs)
+    private static Mock<ILookupInResultInternal> BuildLookupResult(Flags bodyFlags, TransactionXattrs txnXattrs,
+        bool binaryStaged = false)
     {
         var specs = new List<LookupInSpec>
         {
@@ -102,8 +153,8 @@ public class StagedUserFlagsTests
         mock.Setup(r => r.Flags).Returns(bodyFlags);
         mock.Setup(r => r.ContentAs<TransactionXattrs>(0)).Returns(txnXattrs);
         mock.Setup(r => r.Exists(0)).Returns(true);
-        mock.Setup(r => r.Exists(2)).Returns(true);   // JSON staged
-        mock.Setup(r => r.Exists(3)).Returns(false);
+        mock.Setup(r => r.Exists(2)).Returns(!binaryStaged); // txn.stgd
+        mock.Setup(r => r.Exists(3)).Returns(binaryStaged);  // txn.bin
         mock.Setup(r => r.Exists(4)).Returns(true);
         mock.Setup(r => r.IsDeleted).Returns(false);
         mock.Setup(r => r.Cas).Returns(0UL);
@@ -172,6 +223,22 @@ public class StagedUserFlagsTests
 
         Assert.NotNull(result.StagedContent);
         Assert.Equal(DataFormat.Json, result.StagedContent!.Flags.DataFormat);
+    }
+
+    [Fact]
+    public async Task StagedContent_BinaryStaged_JsonUf_StillCommitsAsBinary()
+    {
+        // Staged at txn.bin, but with a uf claiming JSON — as a byte-reversed pre-3.10 .NET uf
+        // decodes. txn.bin wins, or the committed doc would be unreadable as byte[].
+        var bodyFlags = new Flags { DataFormat = DataFormat.Json };
+        var mock = BuildLookupResult(bodyFlags, XattrsWithAux(AuxWithUf(DataFormat.Json)), binaryStaged: true);
+
+        var result = await DocumentRepository.LookupDocumentAsync(
+            BuildCollection(mock), "doc-id", keyValueTimeout: null,
+            defaultJsonTranscoder: new JsonTranscoder(SystemTextJsonSerializer.Create()));
+
+        Assert.NotNull(result.StagedContent);
+        Assert.Equal(DataFormat.Binary, result.StagedContent!.Flags.DataFormat);
     }
 
     #endregion


### PR DESCRIPTION
Motivation
==========
Transactions record the user's content flags at
txn.aux.uf when staging, but that field was never read back. On commit the flags came from the in-memory
StagedMutation or were re-derived from the transcoder, so committing content we didn't stage (lost-transaction cleanup) or re-reading during ambiguity resolution could persist the wrong flags.

Modification
============
Parse txn.aux.uf on lookup and carry it as the staged content wrapper's flags, so both the ambiguity path and the Cleaner inherit the correct staged flags:
- Flags: add symmetric ToUInt32/FromUInt32 helpers and a shared JsonCommonFlags fallback.
- DocumentRepository.LookupDocumentAsync: parse txn.aux.uf into the staged wrapper's flags; keep the live body flags for unstaged (pre-transaction) content.
- LookupInContentAsWrapper: accept an optional flags override, used only for staged content.
- AttemptContext: fall back to JsonCommonFlags (not new Flags(), which is DataFormat.Reserved) when no staged flags are present.
- Cleaner: use the staged flags on the replace path.
- FixedFlagsTranscoder: pin the persisted flags on the raw-insert paths (cleaner tombstone-revive and the legacy no-ReplaceBodyWithXattr insert), since InsertAsync has no flags option.

Results
=======
154 transactions unit tests pass, plus the full
transactions FIT suite (one unrelated, known flake).