### PR TITLE
NCBC-4269: Implement WaitUntilReady for Stellar

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,8 @@ jobs:
   build-and-test:
     name: Build and Unit Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # The suite runs in ~5 minutes; without a cap, a hung test host sits on the 6h default.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -36,8 +38,11 @@ jobs:
       - name: Build (Release)
         run: dotnet build couchbase-net-client.sln --configuration Release
 
+      # --blame-hang turns an intermittent hung test host into a fast red plus a dump, instead of a job
+      # that sits until the timeout with no diagnostics. The suite finishes in well under a minute per
+      # TFM, so 5min of no test activity means it is stuck.
       - name: Test - Couchbase.UnitTests
-        run: dotnet test tests/Couchbase.UnitTests/Couchbase.UnitTests.csproj --configuration Release --no-build --logger "trx;LogFileName=unit-tests.trx" --results-directory "TestResults"
+        run: dotnet test tests/Couchbase.UnitTests/Couchbase.UnitTests.csproj --configuration Release --no-build --logger "trx;LogFileName=unit-tests.trx" --results-directory "TestResults" --blame-hang --blame-hang-timeout 5min --blame-hang-dump-type full
 
       - name: Upload Test Results
         if: always()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.33.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
+    <PackageVersion Include="Grpc.HealthCheck" Version="2.71.0" />
     <PackageVersion Include="Google.Api.CommonProtos" Version="2.17.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Couchbase/Couchbase.csproj
+++ b/src/Couchbase/Couchbase.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.ClientFactory" />
+    <PackageReference Include="Grpc.HealthCheck" />
     <PackageReference Include="Google.Api.CommonProtos" />
     <PackageReference Include="DnsClient" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
+++ b/src/Couchbase/Stellar/Core/Retry/StellarRetryHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Core.Exceptions;
@@ -30,7 +31,16 @@ internal class StellarRetryHandler : IRetryOrchestrator
     internal StellarRetryHandler(TimeProvider timeProvider)
     {
         _timeProvider = timeProvider;
+        Delay = _timeProvider.Delay;
     }
+
+    /// <summary>
+    /// The backoff wait between retry attempts, as a delegate so tests can substitute it — the same seam
+    /// <see cref="Couchbase.Core.Retry.RetryOrchestrator"/> exposes. Tests advance an injected
+    /// <see cref="TimeProvider"/> by the backoff and return synchronously, which keeps the timeout budget
+    /// honest without leaving a real timer for the test to wait on.
+    /// </summary>
+    internal Func<TimeSpan, CancellationToken, Task> Delay { get; set; }
 
     public async Task<T> RetryAsync<T>(Func<Task<T>> send, IRequest request) where T : IServiceResult
     {
@@ -61,7 +71,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
                     if (e.StatusCode != StatusCode.OK)
                     {
                         HandleException(e, request, context);
-                        await backoff.Delay(request).ConfigureAwait(false);
+                        await Delay(backoff.CalculateBackoff(request), request.Token).ConfigureAwait(false);
                     }
                 }
                 catch (Exception e) when (IsTransientTransportException(e))
@@ -71,7 +81,7 @@ internal class StellarRetryHandler : IRetryOrchestrator
                     // Treat these like Unavailable and retry.
                     context.RetryReasons.Add(RetryReason.ServiceNotAvailable);
                     request.Attempts++;
-                    await backoff.Delay(request).ConfigureAwait(false);
+                    await Delay(backoff.CalculateBackoff(request), request.Token).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Couchbase/Stellar/StellarBucket.cs
+++ b/src/Couchbase/Stellar/StellarBucket.cs
@@ -133,8 +133,10 @@ internal class StellarBucket : IBucket
     public Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument, string viewName, ViewOptions? options = null) =>
         throw ThrowHelper.ThrowFeatureNotAvailableException("View Queries", "Protostellar");
 
+    // Per RFC 77, bucket and cluster WaitUntilReady are identical in couchbase2 (the health check
+    // is cluster-wide, not per-bucket), so delegate to the cluster implementation.
     public Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null) =>
-        throw ThrowHelper.ThrowFeatureNotAvailableException("WaitUntilReady", "Protostellar");
+        _stellarCluster.WaitUntilReadyAsync(timeout, options);
 
     private void CheckIfDisposed()
     {

--- a/src/Couchbase/Stellar/StellarBucket.cs
+++ b/src/Couchbase/Stellar/StellarBucket.cs
@@ -134,8 +134,11 @@ internal class StellarBucket : IBucket
         throw ThrowHelper.ThrowFeatureNotAvailableException("View Queries", "Protostellar");
 
     // Per RFC 77, the couchbase2 health check is cluster-wide, not per-bucket.
-    public Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null) =>
-        _stellarCluster.WaitUntilReadyAsync(timeout, options);
+    public Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null)
+    {
+        CheckIfDisposed();
+        return _stellarCluster.WaitUntilReadyAsync(timeout, options);
+    }
 
     private void CheckIfDisposed()
     {

--- a/src/Couchbase/Stellar/StellarBucket.cs
+++ b/src/Couchbase/Stellar/StellarBucket.cs
@@ -133,8 +133,7 @@ internal class StellarBucket : IBucket
     public Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument, string viewName, ViewOptions? options = null) =>
         throw ThrowHelper.ThrowFeatureNotAvailableException("View Queries", "Protostellar");
 
-    // Per RFC 77, bucket and cluster WaitUntilReady are identical in couchbase2 (the health check
-    // is cluster-wide, not per-bucket), so delegate to the cluster implementation.
+    // Per RFC 77, the couchbase2 health check is cluster-wide, not per-bucket.
     public Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null) =>
         _stellarCluster.WaitUntilReadyAsync(timeout, options);
 

--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -77,8 +77,13 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
     private readonly SocketsHttpHandler? _socketsHandler;
 
     // Drives the WaitUntilReady timeout budget. Injectable so tests can run the health-check
-    // retry loop on a FakeTimeProvider instead of the wall clock.
+    // retry loop on a FakeTimeProvider instead of the wall clock. The initializer is what the
+    // public ClusterOptions constructor below gets; the internal constructor overwrites it.
     private readonly TimeProvider _timeProvider = TimeProvider.System;
+
+    // The trace span name for WaitUntilReady. Not in OuterRequestSpans: it names no service and is
+    // not an operation span.
+    private const string WaitUntilReadySpanName = "wait_until_ready";
 
     internal Health.HealthClient HealthClient { get; set; }
 
@@ -376,7 +381,11 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         var opts = options ?? new WaitUntilReadyOptions();
         var userToken = opts.CancellationTokenValue;
 
-        using var traceSpan = RequestTracer.RequestSpan("wait_until_ready", null);
+        // A caller token that has already fired aborts before any health check, matching the
+        // loop-top check in the classic Cluster.WaitUntilReadyAsync.
+        userToken.ThrowIfCancellationRequested();
+
+        using var traceSpan = TraceSpan(WaitUntilReadySpanName, null);
 
         // Keep the timeout in its own source rather than using cts.CancelAfter: it lets the catch
         // below identify a timeout exactly instead of inferring it, and it routes the timer through
@@ -394,6 +403,14 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
             Span = traceSpan,
         };
 
+        // The last non-SERVING status seen, if any. The fabricated RpcException that drives the retry
+        // is swallowed by the retry loop, so without this a server stuck in NOT_SERVING is reported as
+        // a bare timeout with no hint of why. (RFC 77 defers the full lastException to CNG-4.)
+        HealthCheckResponse.Types.ServingStatus? lastStatus = null;
+        string TimeoutMessage() => lastStatus is null
+            ? $"Timed out after {timeout}."
+            : $"Timed out after {timeout}. The last health check reported serving status {lastStatus}.";
+
         try
         {
             await RetryHandler.RetryAsync(async () =>
@@ -410,6 +427,11 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
 
                 if (response.Status != HealthCheckResponse.Types.ServingStatus.Serving)
                 {
+                    lastStatus = response.Status;
+                    _logger.LogDebug(
+                        "WaitUntilReady: couchbase2 health check reported serving status {status} after {attempts} attempt(s); retrying.",
+                        response.Status, request.Attempts + 1);
+
                     throw new RpcException(new Status(StatusCode.Unavailable,
                         $"couchbase2 server reported serving status {response.Status}"));
                 }
@@ -417,11 +439,38 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
                 return WaitUntilReadyResult.Instance;
             }, request).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !userToken.IsCancellationRequested)
+        catch (Exception e) when (userToken.IsCancellationRequested && IsCancellationOutcome(e))
         {
-            throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
+            // Classic parity (Cluster/BucketBase.WaitUntilReadyAsync): when the caller's own token is
+            // what fired, rethrow as OperationCanceledException — normal .NET cancellation semantics —
+            // and let it win over a timeout raised in the same moment. Left alone, the same user action
+            // would surface as a timeout (the retry loop's cancelled-token check) or as
+            // RequestCanceledException (gRPC CANCELLED), depending on where the token landed.
+            throw new OperationCanceledException(
+                "WaitUntilReady was canceled by the CancellationToken supplied in the options.", e, userToken);
+        }
+        catch (UnambiguousTimeoutException e)
+        {
+            // The timeout is spotted in three places — the gRPC deadline, the retry loop's cancelled-token
+            // check, and timeoutCts below — each with its own wording. Normalize the message so callers see
+            // one, carrying the retry context forward.
+            var timedOut = new UnambiguousTimeoutException(TimeoutMessage(), e) { Context = e.Context };
+            timedOut.RetryReasons.AddRange(e.RetryReasons);
+            throw timedOut;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw new UnambiguousTimeoutException(TimeoutMessage());
         }
     }
+
+    /// <summary>
+    /// Whether <paramref name="e"/> is one of the outcomes the retry loop or gRPC produce for a
+    /// cancelled token, as opposed to a genuine failure that happened to race the cancellation.
+    /// </summary>
+    private static bool IsCancellationOutcome(Exception e) =>
+        e is OperationCanceledException or RequestCanceledException
+            or UnambiguousTimeoutException or AmbiguousTimeoutException;
 
     private sealed class WaitUntilReadyResult : IServiceResult
     {

--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -76,6 +76,10 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
     // owns its transport.
     private readonly SocketsHttpHandler? _socketsHandler;
 
+    // Drives the WaitUntilReady timeout budget. Injectable so tests can run the health-check
+    // retry loop on a FakeTimeProvider instead of the wall clock.
+    private readonly TimeProvider _timeProvider = TimeProvider.System;
+
     internal Health.HealthClient HealthClient { get; set; }
 
 
@@ -85,8 +89,10 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         Metadata metaData, IRequestTracer requestTracer, GrpcChannel grpcChannel,
         ITypeSerializer typeSerializer, IRetryOrchestrator retryHandler, ClusterOptions clusterOptions,
         IOperationCompressor operationCompressor,
-        CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.None)
+        CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.None,
+        TimeProvider? timeProvider = null)
     {
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _bucketManager = bucketManager;
         _searchIndexManager = searchIndexManager;
         _queryClient = queryClient;
@@ -372,13 +378,15 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
 
         using var traceSpan = RequestTracer.RequestSpan("wait_until_ready", null);
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(userToken);
-        if (timeout != Timeout.InfiniteTimeSpan)
-        {
-            cts.CancelAfter(timeout);
-        }
+        // Keep the timeout in its own source rather than using cts.CancelAfter: it lets the catch
+        // below identify a timeout exactly instead of inferring it, and it routes the timer through
+        // the injected TimeProvider so tests can drive the budget without the wall clock.
+        using var timeoutCts = timeout != Timeout.InfiniteTimeSpan
+            ? _timeProvider.CreateCancellationTokenSource(timeout)
+            : new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(userToken, timeoutCts.Token);
 
-        var request = new StellarRequest
+        var request = new StellarRequest(_timeProvider)
         {
             Idempotent = true,
             Timeout = timeout,
@@ -409,7 +417,7 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
                 return WaitUntilReadyResult.Instance;
             }, request).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested && !userToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !userToken.IsCancellationRequested)
         {
             throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
         }

--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -41,6 +41,7 @@ using Couchbase.Stellar.Search;
 using Couchbase.Stellar.Util;
 using Couchbase.Utils;
 using Grpc.Core;
+using Grpc.Health.V1;
 using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -75,6 +76,10 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
     // owns its transport.
     private readonly SocketsHttpHandler? _socketsHandler;
 
+    // Standard gRPC health-check client used by WaitUntilReady (NCBC-4269 / RFC 77 CNG-1).
+    // Settable so unit tests can inject a mock.
+    internal Health.HealthClient HealthClient { get; set; }
+
 
     internal StellarCluster(IBucketManager bucketManager, ISearchIndexManager searchIndexManager,
         IQueryIndexManager queryIndexManager, IQueryClient queryClient,
@@ -94,6 +99,7 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         _metaData = metaData;
         RequestTracer = requestTracer;
         GrpcChannel = grpcChannel;
+        HealthClient = new Health.HealthClient(grpcChannel);
         TypeSerializer = typeSerializer;
         TypeTranscoder = _clusterOptions.Transcoder ?? new JsonTranscoder(TypeSerializer);
         OperationCompressor = operationCompressor;
@@ -141,6 +147,7 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         GrpcChannel = GrpcChannel.ForAddress(_clusterOptions.ConnectionStringValue!.GetStellarBootstrapUri(), grpcChannelOptions);
         var retryHandler = new StellarRetryHandler();
         RetryHandler = retryHandler;
+        HealthClient = new Health.HealthClient(GrpcChannel);
 
         _bucketManager = new StellarBucketManager(this);
         _searchIndexManager = new StellarSearchIndexManager(this);
@@ -353,8 +360,89 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         return await _searchClient.QueryAsync(indexName, query, options).ConfigureAwait(false);
     }
 
-    public Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null)=>
-        throw ThrowHelper.ThrowFeatureNotAvailableException("WaitUntilReady", "Protostellar");
+    public async Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null)
+    {
+        CheckIfDisposed();
+
+        // Mirror the classic cluster contract: a non-positive timeout has already elapsed. Guarding
+        // here also prevents an unbounded retry loop — a zero/negative Timeout makes RemainingTimeout
+        // null (no gRPC deadline), so without this the health-check loop would spin forever.
+        // Timeout.InfiniteTimeSpan is the documented "wait forever" sentinel and is allowed through.
+        if (timeout <= TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+        {
+            throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
+        }
+
+        var opts = options ?? new WaitUntilReadyOptions();
+        var userToken = opts.CancellationTokenValue;
+
+        // RFC 77 (couchbase2 WaitUntilReady): ping the standard gRPC health-check RPC until the
+        // server reports SERVING or the timeout is exceeded. The ServiceTypes and DesiredState
+        // options are silently ignored (the health check exposes no per-service or cluster-state
+        // granularity), no Authorization header is sent, and no metrics are emitted.
+        using var traceSpan = RequestTracer.RequestSpan("wait_until_ready", null);
+
+        // Bound the whole operation, not just each attempt: the per-attempt gRPC deadline caps a
+        // single Check, while this token caps the retry/backoff loop and makes a backoff sleep
+        // interruptible. Linked to the caller's token so their cancellation is honored too.
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(userToken);
+        if (timeout != Timeout.InfiniteTimeSpan)
+        {
+            cts.CancelAfter(timeout);
+        }
+
+        var request = new StellarRequest
+        {
+            // A health check is read-only: safe to retry, and unambiguous on timeout.
+            Idempotent = true,
+            Timeout = timeout,
+            Token = cts.Token,
+            Span = traceSpan,
+        };
+
+        try
+        {
+            await RetryHandler.RetryAsync(async () =>
+            {
+                // No Authorization header per RFC (the server does not inspect it). The per-attempt
+                // deadline is the remaining WaitUntilReady budget, so once it is exhausted the call
+                // fails DEADLINE_EXCEEDED and is mapped to an UnambiguousTimeoutException. Only the
+                // caller's token cancels the in-flight call (the timeout is enforced by the deadline),
+                // so a timeout deterministically surfaces as UnambiguousTimeoutException rather than
+                // racing the linked token into a RequestCanceledException.
+                var callOptions = new CallOptions(
+                    headers: new Metadata(),
+                    deadline: request.RemainingTimeout.FromNow(),
+                    cancellationToken: userToken);
+
+                var response = await HealthClient.CheckAsync(new HealthCheckRequest(), callOptions);
+
+                if (response.Status != HealthCheckResponse.Types.ServingStatus.Serving)
+                {
+                    // Not SERVING: retry per RFC (SERVICE_NOT_AVAILABLE). Signalled as UNAVAILABLE so the
+                    // standard retry path handles it and records the serving status as the last error.
+                    throw new RpcException(new Status(StatusCode.Unavailable,
+                        $"couchbase2 server reported serving status {response.Status}"));
+                }
+
+                return WaitUntilReadyResult.Instance;
+            }, request).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !userToken.IsCancellationRequested)
+        {
+            // The overall timeout elapsed during a retry backoff (the caller did not cancel):
+            // surface it as a timeout, consistent with the per-attempt deadline path.
+            throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
+        }
+    }
+
+    // WaitUntilReady has no service payload; this satisfies the IServiceResult constraint on
+    // StellarRetryHandler.RetryAsync so the health check reuses the standard retry rules.
+    private sealed class WaitUntilReadyResult : IServiceResult
+    {
+        public static readonly WaitUntilReadyResult Instance = new();
+        public RetryReason RetryReason => RetryReason.NoRetry;
+    }
 
     public CallOptions GrpcCallOptions() => new (headers: _metaData);
 

--- a/src/Couchbase/Stellar/StellarCluster.cs
+++ b/src/Couchbase/Stellar/StellarCluster.cs
@@ -76,8 +76,6 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
     // owns its transport.
     private readonly SocketsHttpHandler? _socketsHandler;
 
-    // Standard gRPC health-check client used by WaitUntilReady (NCBC-4269 / RFC 77 CNG-1).
-    // Settable so unit tests can inject a mock.
     internal Health.HealthClient HealthClient { get; set; }
 
 
@@ -364,10 +362,6 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
     {
         CheckIfDisposed();
 
-        // Mirror the classic cluster contract: a non-positive timeout has already elapsed. Guarding
-        // here also prevents an unbounded retry loop — a zero/negative Timeout makes RemainingTimeout
-        // null (no gRPC deadline), so without this the health-check loop would spin forever.
-        // Timeout.InfiniteTimeSpan is the documented "wait forever" sentinel and is allowed through.
         if (timeout <= TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
         {
             throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
@@ -376,15 +370,8 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         var opts = options ?? new WaitUntilReadyOptions();
         var userToken = opts.CancellationTokenValue;
 
-        // RFC 77 (couchbase2 WaitUntilReady): ping the standard gRPC health-check RPC until the
-        // server reports SERVING or the timeout is exceeded. The ServiceTypes and DesiredState
-        // options are silently ignored (the health check exposes no per-service or cluster-state
-        // granularity), no Authorization header is sent, and no metrics are emitted.
         using var traceSpan = RequestTracer.RequestSpan("wait_until_ready", null);
 
-        // Bound the whole operation, not just each attempt: the per-attempt gRPC deadline caps a
-        // single Check, while this token caps the retry/backoff loop and makes a backoff sleep
-        // interruptible. Linked to the caller's token so their cancellation is honored too.
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(userToken);
         if (timeout != Timeout.InfiniteTimeSpan)
         {
@@ -393,7 +380,6 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
 
         var request = new StellarRequest
         {
-            // A health check is read-only: safe to retry, and unambiguous on timeout.
             Idempotent = true,
             Timeout = timeout,
             Token = cts.Token,
@@ -404,12 +390,9 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         {
             await RetryHandler.RetryAsync(async () =>
             {
-                // No Authorization header per RFC (the server does not inspect it). The per-attempt
-                // deadline is the remaining WaitUntilReady budget, so once it is exhausted the call
-                // fails DEADLINE_EXCEEDED and is mapped to an UnambiguousTimeoutException. Only the
-                // caller's token cancels the in-flight call (the timeout is enforced by the deadline),
-                // so a timeout deterministically surfaces as UnambiguousTimeoutException rather than
-                // racing the linked token into a RequestCanceledException.
+                // Pass the caller's token, not cts.Token: the timeout must surface via the gRPC
+                // deadline as UnambiguousTimeoutException, not race the linked token into a
+                // RequestCanceledException.
                 var callOptions = new CallOptions(
                     headers: new Metadata(),
                     deadline: request.RemainingTimeout.FromNow(),
@@ -419,8 +402,6 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
 
                 if (response.Status != HealthCheckResponse.Types.ServingStatus.Serving)
                 {
-                    // Not SERVING: retry per RFC (SERVICE_NOT_AVAILABLE). Signalled as UNAVAILABLE so the
-                    // standard retry path handles it and records the serving status as the last error.
                     throw new RpcException(new Status(StatusCode.Unavailable,
                         $"couchbase2 server reported serving status {response.Status}"));
                 }
@@ -430,14 +411,10 @@ internal class StellarCluster : ICluster, IBootstrappable, IClusterExtended
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested && !userToken.IsCancellationRequested)
         {
-            // The overall timeout elapsed during a retry backoff (the caller did not cancel):
-            // surface it as a timeout, consistent with the per-attempt deadline path.
             throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
         }
     }
 
-    // WaitUntilReady has no service payload; this satisfies the IServiceResult constraint on
-    // StellarRetryHandler.RetryAsync so the health check reuses the standard retry rules.
     private sealed class WaitUntilReadyResult : IServiceResult
     {
         public static readonly WaitUntilReadyResult Instance = new();

--- a/tests/Couchbase.UnitTests/Stellar/BucketTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/BucketTests.cs
@@ -54,10 +54,13 @@ public class BucketTests
     }
 
     [Fact]
-    public async Task Throw_FeatureNotAvailableException_WaitUntileReadyAsync()
+    public async Task WaitUntilReadyAsync_ZeroTimeout_ThrowsUnambiguousTimeout()
     {
+        // NCBC-4269 / RFC 77 CNG-1: bucket WaitUntilReady now delegates to the cluster health check
+        // (no longer FeatureNotAvailable). A non-positive timeout has already elapsed. Delegation and
+        // the serving/retry paths are covered in StellarWaitUntilReadyTests.
         var bucket = await CreateBucket();
-        await Assert.ThrowsAsync<FeatureNotAvailableException>(async () => await bucket.WaitUntilReadyAsync(TimeSpan.Zero));
+        await Assert.ThrowsAsync<UnambiguousTimeoutException>(async () => await bucket.WaitUntilReadyAsync(TimeSpan.Zero));
     }
 
     private async Task<IBucket> CreateBucket()

--- a/tests/Couchbase.UnitTests/Stellar/ClusterTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/ClusterTests.cs
@@ -60,10 +60,13 @@ public class ClusterTests
 
 
       [Fact]
-      public async Task Throw_FeatureNotAvailableException_WaitUntilReadyAsync()
+      public async Task WaitUntilReadyAsync_ZeroTimeout_ThrowsUnambiguousTimeout()
       {
+          // NCBC-4269 / RFC 77 CNG-1: WaitUntilReady is now implemented (no longer FeatureNotAvailable).
+          // A non-positive timeout has already elapsed, matching the classic cluster contract. The
+          // serving/retry/delegation behavior is covered in StellarWaitUntilReadyTests.
           await using var cluster = await CreateCluster();
-          await Assert.ThrowsAsync<FeatureNotAvailableException>(async () => await cluster.WaitUntilReadyAsync(TimeSpan.Zero));
+          await Assert.ThrowsAsync<UnambiguousTimeoutException>(async () => await cluster.WaitUntilReadyAsync(TimeSpan.Zero));
       }
 
       [Fact]

--- a/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
@@ -42,61 +42,45 @@ public class StellarWaitUntilReadyTests
             () => Status.DefaultSuccess, () => new Metadata(), () => { });
 
     /// <summary>
-    /// Builds a cluster whose timeout budget, backoff delays and request clock all run on
-    /// <paramref name="timeProvider"/>. Tests pass a <see cref="FakeTimeProvider"/> so the retry loop
-    /// is driven by explicit clock advances rather than the wall clock — on a loaded CI runner a real
-    /// 5s budget can expire during a backoff that nominally costs 60ms.
+    /// Builds a cluster whose timeout budget, backoff waits and request clock all run on a
+    /// <see cref="FakeTimeProvider"/>, with the retry handler's backoff replaced by a delegate that
+    /// advances that clock by the backoff and returns synchronously.
+    /// <para>
+    /// So a retry costs the timeout budget exactly what it costs in production, but there is no timer to
+    /// wait on and nothing to poll: WaitUntilReady runs to completion on the calling thread, and no test
+    /// here depends on the scheduler. That matters — a wall-clock budget racing a real backoff failed on
+    /// CI once (NonServing_IsRetriedUntilServing, 5s budget, 7.5s wall), and pumping the fake clock from
+    /// a background task in its place failed the same way one layer up, exhausting its bounded advances
+    /// before the operation was scheduled.
+    /// </para>
     /// </summary>
-    private static StellarCluster BuildCluster(Health.HealthClient healthClient, TimeProvider timeProvider)
+    private static StellarCluster BuildCluster(Health.HealthClient healthClient)
     {
         var requestTracer = new Mock<IRequestTracer>();
         requestTracer.Setup(x => x.RequestSpan(It.IsAny<string>(), It.IsAny<IRequestSpan>()))
             .Returns(new NoopRequestSpan());
 
+        var fakeTime = new FakeTimeProvider();
+        fakeTime.SetUtcNow(DateTimeOffset.UtcNow);
+
         // Real StellarRetryHandler so the retry/serving-status logic actually runs.
+        var retryHandler = new StellarRetryHandler(fakeTime)
+        {
+            Delay = (backoff, _) =>
+            {
+                fakeTime.Advance(backoff);
+                return Task.CompletedTask;
+            }
+        };
+
         var cluster = new StellarCluster(
             Mock.Of<IBucketManager>(), Mock.Of<ISearchIndexManager>(), Mock.Of<IQueryIndexManager>(),
             Mock.Of<IQueryClient>(), Mock.Of<IAnalyticsClient>(), Mock.Of<IStellarSearchClient>(),
             new Metadata(), requestTracer.Object, GrpcChannel.ForAddress("https://localhost"),
-            Mock.Of<ITypeSerializer>(), new StellarRetryHandler(timeProvider), new ClusterOptions(),
-            Mock.Of<IOperationCompressor>(), timeProvider: timeProvider);
+            Mock.Of<ITypeSerializer>(), retryHandler, new ClusterOptions(),
+            Mock.Of<IOperationCompressor>(), timeProvider: fakeTime);
         cluster.HealthClient = healthClient;
         return cluster;
-    }
-
-    private static FakeTimeProvider NewFakeTime()
-    {
-        var fakeTime = new FakeTimeProvider();
-        fakeTime.SetUtcNow(DateTimeOffset.UtcNow);
-        return fakeTime;
-    }
-
-    /// <summary>
-    /// Runs <paramref name="operation"/> on a background task and advances <paramref name="fakeTime"/> in
-    /// <paramref name="stepMs"/> increments until it completes, then returns the (completed) task for the
-    /// caller to await. The loop is bounded so a regression that never completes fails the test instead of
-    /// hanging the suite.
-    /// <para>
-    /// The pump advances the clock at a rate set by real scheduling, so for a test that must NOT time out,
-    /// keep <c>stepMs * maxAdvances</c> comfortably below the WaitUntilReady budget — otherwise a slow
-    /// runner could pump the fake clock past the deadline and reintroduce the very flake this avoids.
-    /// </para>
-    /// </summary>
-    private static async Task<Task> PumpAsync(FakeTimeProvider fakeTime, Func<Task> operation,
-        int stepMs = 10, int maxAdvances = 200)
-    {
-        var task = Task.Run(operation);
-        var step = TimeSpan.FromMilliseconds(stepMs);
-
-        for (var i = 0; i < maxAdvances && !task.IsCompleted; i++)
-        {
-            fakeTime.Advance(step);
-            await Task.Delay(1); // real yield so the operation can register its next timer
-        }
-
-        Assert.True(task.IsCompleted,
-            $"Operation did not complete after {maxAdvances} advances of {step} on the fake clock.");
-        return task;
     }
 
     [Fact]
@@ -107,7 +91,7 @@ public class StellarWaitUntilReadyTests
             .Returns(UnaryCall(Serving));
 
         // No retries and no backoff, so the fake clock never advances: the 5s budget cannot expire.
-        var cluster = BuildCluster(health.Object, NewFakeTime());
+        using var cluster = BuildCluster(health.Object);
 
         await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
 
@@ -123,14 +107,11 @@ public class StellarWaitUntilReadyTests
             .Returns(UnaryCall(NotServing))
             .Returns(UnaryCall(Serving));
 
-        var fakeTime = NewFakeTime();
-        var cluster = BuildCluster(health.Object, fakeTime);
+        using var cluster = BuildCluster(health.Object);
 
         // A non-SERVING status is retryable, not fatal — it retries and then succeeds. The two backoffs
-        // (10ms + 50ms) are driven by advancing the fake clock; the pump advances at most 200 x 10ms = 2s,
-        // so the 5s budget cannot expire however slowly the runner schedules the pump.
-        var waitUntilReady = await PumpAsync(fakeTime, () => cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5)));
-        await waitUntilReady;
+        // (10ms + 50ms) charge the fake clock 60ms of the 5s budget, so the wait cannot time out.
+        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
 
         health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Exactly(3));
     }
@@ -142,7 +123,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object, NewFakeTime());
+        using var cluster = BuildCluster(health.Object);
 
         // Per RFC these options are ignored (not honored, not rejected): the call still succeeds.
         var options = new WaitUntilReadyOptions()
@@ -159,7 +140,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object, NewFakeTime());
+        using var cluster = BuildCluster(health.Object);
         var bucket = new StellarBucket("default", cluster);
 
         await bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
@@ -173,17 +154,46 @@ public class StellarWaitUntilReadyTests
         // The core WaitUntilReady guarantee: a server that never reaches SERVING must fail with
         // UnambiguousTimeoutException once the timeout elapses, not retry forever.
         var health = new Mock<Health.HealthClient>();
+        var calls = 0;
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
-            .Returns(UnaryCall(NotServing));
+            .Returns(() =>
+            {
+                // The loop is bounded by the budget, which the injected backoff charges (10 + 50 + 100 +
+                // 500ms crosses 500ms on the fourth attempt). This fails the test rather than spinning
+                // forever if a regression ever unbinds it — the retries no longer cost real time.
+                Assert.True(++calls <= 50, "WaitUntilReady kept retrying past its timeout budget.");
+                return UnaryCall(NotServing);
+            });
 
-        var fakeTime = NewFakeTime();
-        var cluster = BuildCluster(health.Object, fakeTime);
+        using var cluster = BuildCluster(health.Object);
 
-        // 100ms steps so the fake clock outruns the growing backoff ladder and reaches the 500ms budget.
-        var waitUntilReady = await PumpAsync(fakeTime,
-            () => cluster.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(500)), stepMs: 100);
+        var exception = await Assert.ThrowsAsync<UnambiguousTimeoutException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(500)));
 
-        await Assert.ThrowsAsync<UnambiguousTimeoutException>(() => waitUntilReady);
+        // The status that caused the wait to fail has to reach the user: the RpcException that drives
+        // the retry is swallowed by the retry loop, so a bare "timed out" leaves them with nothing to
+        // go on. Whichever of the three places spots the timeout, the message reads the same.
+        Assert.StartsWith("Timed out after 00:00:00.5000000.", exception.Message);
+        Assert.Contains(nameof(HealthCheckResponse.Types.ServingStatus.NotServing), exception.Message);
+    }
+
+    [Fact]
+    public async Task DisposedBucket_ThrowsObjectDisposed()
+    {
+        // WaitUntilReady delegates to the cluster, which is still alive — so without the bucket's own
+        // disposal check a disposed bucket would happily report ready.
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        using var cluster = BuildCluster(health.Object);
+        var bucket = new StellarBucket("default", cluster);
+        bucket.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(5)));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Never);
     }
 
     [Fact]
@@ -196,7 +206,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object, NewFakeTime());
+        using var cluster = BuildCluster(health.Object);
 
         await Assert.ThrowsAsync<UnambiguousTimeoutException>(
             async () => await cluster.WaitUntilReadyAsync(TimeSpan.Zero));
@@ -207,20 +217,113 @@ public class StellarWaitUntilReadyTests
     [Fact]
     public async Task CancelledToken_ShortCircuits_WithoutCallingHealthCheck()
     {
-        // A caller token that is already cancelled aborts before any health check. Stellar maps a
-        // cancelled retry loop to UnambiguousTimeoutException uniformly (see StellarRetryHandler).
+        // A caller token that is already cancelled aborts before any health check, and surfaces as
+        // OperationCanceledException — the same contract as the classic cluster, which rethrows
+        // external cancellation instead of mapping it to a timeout.
         var health = new Mock<Health.HealthClient>();
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object, NewFakeTime());
+        using var cluster = BuildCluster(health.Object);
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();
         var options = new WaitUntilReadyOptions().CancellationToken(cts.Token);
 
-        await Assert.ThrowsAsync<UnambiguousTimeoutException>(
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
             async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5), options));
+        Assert.Equal(cts.Token, exception.CancellationToken);
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CallerToken_IsForwardedToTheHealthCheckCall()
+    {
+        // The token has to reach the gRPC call itself, otherwise cancelling only takes effect between
+        // attempts and an in-flight health check keeps running to the deadline.
+        var health = new Mock<Health.HealthClient>();
+        CallOptions captured = default;
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Callback((HealthCheckRequest _, CallOptions callOptions) => captured = callOptions)
+            .Returns(UnaryCall(Serving));
+
+        using var cluster = BuildCluster(health.Object);
+
+        using var cts = new CancellationTokenSource();
+        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5),
+            new WaitUntilReadyOptions().CancellationToken(cts.Token));
+
+        Assert.Equal(cts.Token, captured.CancellationToken);
+    }
+
+    [Fact]
+    public async Task TokenCancelledWhileRetrying_ThrowsOperationCanceled_NotTimeout()
+    {
+        // Cancelling mid-wait must break out of the retry loop as cancellation. Without the
+        // normalisation in WaitUntilReadyAsync this reports UnambiguousTimeoutException, because the
+        // retry loop maps any cancelled request token to a timeout.
+        var health = new Mock<Health.HealthClient>();
+        using var cts = new CancellationTokenSource();
+        var calls = 0;
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(() =>
+            {
+                if (++calls == 2)
+                {
+                    cts.Cancel();
+                }
+
+                return UnaryCall(NotServing);
+            });
+
+        using var cluster = BuildCluster(health.Object);
+        var options = new WaitUntilReadyOptions().CancellationToken(cts.Token);
+
+        // A 30s budget against two backoffs charging 60ms, so the only thing that can end this wait is
+        // the caller's token.
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(30), options));
+        Assert.Equal(cts.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GrpcCancelledOnCallerToken_ThrowsOperationCanceled_NotRequestCanceled()
+    {
+        // What actually happens on the wire when the caller cancels an in-flight health check: gRPC
+        // aborts the call with CANCELLED, which the retry handler maps to RequestCanceledException.
+        // WaitUntilReady reports the caller's cancellation instead.
+        var health = new Mock<Health.HealthClient>();
+        using var cts = new CancellationTokenSource();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Callback(() => cts.Cancel())
+            .Throws(new RpcException(new Status(StatusCode.Cancelled, "cancelled by the caller")));
+
+        using var cluster = BuildCluster(health.Object);
+        var options = new WaitUntilReadyOptions().CancellationToken(cts.Token);
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5), options));
+        Assert.Equal(cts.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Bucket_HonoursCallerToken()
+    {
+        // The bucket delegates to the cluster, so the options token has to survive the hop.
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        using var cluster = BuildCluster(health.Object);
+        var bucket = new StellarBucket("default", cluster);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(5),
+                new WaitUntilReadyOptions().CancellationToken(cts.Token)));
 
         health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Never);
     }

--- a/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
@@ -19,6 +19,7 @@ using Couchbase.Stellar.Search;
 using Grpc.Core;
 using Grpc.Health.V1;
 using Grpc.Net.Client;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -40,7 +41,13 @@ public class StellarWaitUntilReadyTests
         new(Task.FromResult(response), Task.FromResult(new Metadata()),
             () => Status.DefaultSuccess, () => new Metadata(), () => { });
 
-    private static StellarCluster BuildCluster(Health.HealthClient healthClient)
+    /// <summary>
+    /// Builds a cluster whose timeout budget, backoff delays and request clock all run on
+    /// <paramref name="timeProvider"/>. Tests pass a <see cref="FakeTimeProvider"/> so the retry loop
+    /// is driven by explicit clock advances rather than the wall clock — on a loaded CI runner a real
+    /// 5s budget can expire during a backoff that nominally costs 60ms.
+    /// </summary>
+    private static StellarCluster BuildCluster(Health.HealthClient healthClient, TimeProvider timeProvider)
     {
         var requestTracer = new Mock<IRequestTracer>();
         requestTracer.Setup(x => x.RequestSpan(It.IsAny<string>(), It.IsAny<IRequestSpan>()))
@@ -51,10 +58,45 @@ public class StellarWaitUntilReadyTests
             Mock.Of<IBucketManager>(), Mock.Of<ISearchIndexManager>(), Mock.Of<IQueryIndexManager>(),
             Mock.Of<IQueryClient>(), Mock.Of<IAnalyticsClient>(), Mock.Of<IStellarSearchClient>(),
             new Metadata(), requestTracer.Object, GrpcChannel.ForAddress("https://localhost"),
-            Mock.Of<ITypeSerializer>(), new StellarRetryHandler(), new ClusterOptions(),
-            Mock.Of<IOperationCompressor>());
+            Mock.Of<ITypeSerializer>(), new StellarRetryHandler(timeProvider), new ClusterOptions(),
+            Mock.Of<IOperationCompressor>(), timeProvider: timeProvider);
         cluster.HealthClient = healthClient;
         return cluster;
+    }
+
+    private static FakeTimeProvider NewFakeTime()
+    {
+        var fakeTime = new FakeTimeProvider();
+        fakeTime.SetUtcNow(DateTimeOffset.UtcNow);
+        return fakeTime;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> on a background task and advances <paramref name="fakeTime"/> in
+    /// <paramref name="stepMs"/> increments until it completes, then returns the (completed) task for the
+    /// caller to await. The loop is bounded so a regression that never completes fails the test instead of
+    /// hanging the suite.
+    /// <para>
+    /// The pump advances the clock at a rate set by real scheduling, so for a test that must NOT time out,
+    /// keep <c>stepMs * maxAdvances</c> comfortably below the WaitUntilReady budget — otherwise a slow
+    /// runner could pump the fake clock past the deadline and reintroduce the very flake this avoids.
+    /// </para>
+    /// </summary>
+    private static async Task<Task> PumpAsync(FakeTimeProvider fakeTime, Func<Task> operation,
+        int stepMs = 10, int maxAdvances = 200)
+    {
+        var task = Task.Run(operation);
+        var step = TimeSpan.FromMilliseconds(stepMs);
+
+        for (var i = 0; i < maxAdvances && !task.IsCompleted; i++)
+        {
+            fakeTime.Advance(step);
+            await Task.Delay(1); // real yield so the operation can register its next timer
+        }
+
+        Assert.True(task.IsCompleted,
+            $"Operation did not complete after {maxAdvances} advances of {step} on the fake clock.");
+        return task;
     }
 
     [Fact]
@@ -64,7 +106,8 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        // No retries and no backoff, so the fake clock never advances: the 5s budget cannot expire.
+        var cluster = BuildCluster(health.Object, NewFakeTime());
 
         await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
 
@@ -80,10 +123,14 @@ public class StellarWaitUntilReadyTests
             .Returns(UnaryCall(NotServing))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        var fakeTime = NewFakeTime();
+        var cluster = BuildCluster(health.Object, fakeTime);
 
-        // A non-SERVING status is retryable, not fatal — it retries and then succeeds.
-        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
+        // A non-SERVING status is retryable, not fatal — it retries and then succeeds. The two backoffs
+        // (10ms + 50ms) are driven by advancing the fake clock; the pump advances at most 200 x 10ms = 2s,
+        // so the 5s budget cannot expire however slowly the runner schedules the pump.
+        var waitUntilReady = await PumpAsync(fakeTime, () => cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5)));
+        await waitUntilReady;
 
         health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Exactly(3));
     }
@@ -95,7 +142,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        var cluster = BuildCluster(health.Object, NewFakeTime());
 
         // Per RFC these options are ignored (not honored, not rejected): the call still succeeds.
         var options = new WaitUntilReadyOptions()
@@ -112,7 +159,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        var cluster = BuildCluster(health.Object, NewFakeTime());
         var bucket = new StellarBucket("default", cluster);
 
         await bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
@@ -129,10 +176,14 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(NotServing));
 
-        var cluster = BuildCluster(health.Object);
+        var fakeTime = NewFakeTime();
+        var cluster = BuildCluster(health.Object, fakeTime);
 
-        await Assert.ThrowsAsync<UnambiguousTimeoutException>(
-            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(500)));
+        // 100ms steps so the fake clock outruns the growing backoff ladder and reaches the 500ms budget.
+        var waitUntilReady = await PumpAsync(fakeTime,
+            () => cluster.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(500)), stepMs: 100);
+
+        await Assert.ThrowsAsync<UnambiguousTimeoutException>(() => waitUntilReady);
     }
 
     [Fact]
@@ -145,7 +196,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        var cluster = BuildCluster(health.Object, NewFakeTime());
 
         await Assert.ThrowsAsync<UnambiguousTimeoutException>(
             async () => await cluster.WaitUntilReadyAsync(TimeSpan.Zero));
@@ -162,7 +213,7 @@ public class StellarWaitUntilReadyTests
         health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
             .Returns(UnaryCall(Serving));
 
-        var cluster = BuildCluster(health.Object);
+        var cluster = BuildCluster(health.Object, NewFakeTime());
 
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
+++ b/tests/Couchbase.UnitTests/Stellar/StellarWaitUntilReadyTests.cs
@@ -1,0 +1,177 @@
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase;
+using Couchbase.Analytics;
+using Couchbase.Core.Diagnostics.Tracing;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.IO.Compression;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Diagnostics;
+using Couchbase.Management.Buckets;
+using Couchbase.Management.Query;
+using Couchbase.Management.Search;
+using Couchbase.Query;
+using Couchbase.Stellar;
+using Couchbase.Stellar.Core.Retry;
+using Couchbase.Stellar.Search;
+using Grpc.Core;
+using Grpc.Health.V1;
+using Grpc.Net.Client;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Stellar;
+
+/// <summary>
+/// NCBC-4269 / RFC 77 CNG-1: WaitUntilReady pings the standard gRPC health-check RPC and succeeds
+/// only when the server reports SERVING, retrying otherwise. The connection-failure/timeout paths
+/// (bad host, server down, no TLS, bad creds → UnambiguousTimeoutException) are covered live/FIT.
+/// </summary>
+public class StellarWaitUntilReadyTests
+{
+    private static readonly HealthCheckResponse Serving =
+        new() { Status = HealthCheckResponse.Types.ServingStatus.Serving };
+    private static readonly HealthCheckResponse NotServing =
+        new() { Status = HealthCheckResponse.Types.ServingStatus.NotServing };
+
+    private static AsyncUnaryCall<HealthCheckResponse> UnaryCall(HealthCheckResponse response) =>
+        new(Task.FromResult(response), Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess, () => new Metadata(), () => { });
+
+    private static StellarCluster BuildCluster(Health.HealthClient healthClient)
+    {
+        var requestTracer = new Mock<IRequestTracer>();
+        requestTracer.Setup(x => x.RequestSpan(It.IsAny<string>(), It.IsAny<IRequestSpan>()))
+            .Returns(new NoopRequestSpan());
+
+        // Real StellarRetryHandler so the retry/serving-status logic actually runs.
+        var cluster = new StellarCluster(
+            Mock.Of<IBucketManager>(), Mock.Of<ISearchIndexManager>(), Mock.Of<IQueryIndexManager>(),
+            Mock.Of<IQueryClient>(), Mock.Of<IAnalyticsClient>(), Mock.Of<IStellarSearchClient>(),
+            new Metadata(), requestTracer.Object, GrpcChannel.ForAddress("https://localhost"),
+            Mock.Of<ITypeSerializer>(), new StellarRetryHandler(), new ClusterOptions(),
+            Mock.Of<IOperationCompressor>());
+        cluster.HealthClient = healthClient;
+        return cluster;
+    }
+
+    [Fact]
+    public async Task Serving_Completes()
+    {
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+
+        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task NonServing_IsRetriedUntilServing()
+    {
+        var health = new Mock<Health.HealthClient>();
+        health.SetupSequence(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(NotServing))
+            .Returns(UnaryCall(NotServing))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+
+        // A non-SERVING status is retryable, not fatal — it retries and then succeeds.
+        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task ServiceTypesAndDesiredState_AreSilentlyIgnored()
+    {
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+
+        // Per RFC these options are ignored (not honored, not rejected): the call still succeeds.
+        var options = new WaitUntilReadyOptions()
+            .ServiceTypes(ServiceType.KeyValue, ServiceType.Query)
+            .DesiredState(ClusterState.Offline);
+
+        await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5), options);
+    }
+
+    [Fact]
+    public async Task Bucket_DelegatesToClusterHealthCheck()
+    {
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+        var bucket = new StellarBucket("default", cluster);
+
+        await bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(5));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PersistentlyNotServing_TimesOut_Unambiguously()
+    {
+        // The core WaitUntilReady guarantee: a server that never reaches SERVING must fail with
+        // UnambiguousTimeoutException once the timeout elapses, not retry forever.
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(NotServing));
+
+        var cluster = BuildCluster(health.Object);
+
+        await Assert.ThrowsAsync<UnambiguousTimeoutException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(500)));
+    }
+
+    [Fact]
+    public async Task ZeroTimeout_ThrowsUnambiguousTimeout_WithoutCallingHealthCheck()
+    {
+        // A non-positive timeout has already elapsed (matches the classic cluster contract) and must
+        // short-circuit before any health check — this is the regression guard for the unbounded
+        // retry loop a zero timeout previously caused (null RemainingTimeout => no gRPC deadline).
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+
+        await Assert.ThrowsAsync<UnambiguousTimeoutException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.Zero));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CancelledToken_ShortCircuits_WithoutCallingHealthCheck()
+    {
+        // A caller token that is already cancelled aborts before any health check. Stellar maps a
+        // cancelled retry loop to UnambiguousTimeoutException uniformly (see StellarRetryHandler).
+        var health = new Mock<Health.HealthClient>();
+        health.Setup(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()))
+            .Returns(UnaryCall(Serving));
+
+        var cluster = BuildCluster(health.Object);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var options = new WaitUntilReadyOptions().CancellationToken(cts.Token);
+
+        await Assert.ThrowsAsync<UnambiguousTimeoutException>(
+            async () => await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(5), options));
+
+        health.Verify(h => h.CheckAsync(It.IsAny<HealthCheckRequest>(), It.IsAny<CallOptions>()), Times.Never);
+    }
+}
+#endif


### PR DESCRIPTION
Motivation
==========
Stellar's cluster and bucket WaitUntilReady threw
FeatureNotAvailableException. RFC 77 defines couchbase2 WaitUntilReady as pinging the standard gRPC health-check RPC until the server reports SERVING, giving the user confidence they can reach a couchbase2 server.

Modification
============
Add the Grpc.HealthCheck package and a Health.HealthClient over the existing GrpcChannel. WaitUntilReadyAsync sends Health.Check with an unset service field through the standard couchbase2 retry rules: SERVING succeeds; a non-SERVING status or UNAVAILABLE/transient error retries; the shrinking per-attempt deadline bounds the operation and surfaces as UnambiguousTimeoutException. No Authorization header is sent and no metrics are emitted, per the RFC. The ServiceTypes and DesiredState options are silently ignored (the health check has no per-service or cluster-state granularity). Bucket delegates to the cluster (identical implementation per the RFC). The lastException diagnostic is deferred to CNG-4 (PENDING in the RFC).

Results
=======
Unit and Fit tests passing, you can see the WaitUntilReady logging in fit so this is working great.