### PR TITLE
NCBC-4270: Handle lookupIn specs with no contentAs

### DIFF
--- a/fit/Couchbase.FitPerformer/Utils/CommandUtils.cs
+++ b/fit/Couchbase.FitPerformer/Utils/CommandUtils.cs
@@ -44,6 +44,8 @@ public static class CommandUtils
             case ContentAs.AsOneofCase.AsJsonObject:
                 ret.ContentAsBytes = ByteString.CopyFromUtf8(result.ContentAs<dynamic>(index)?.ToString());
                 break;
+            case ContentAs.AsOneofCase.None:
+                return null;
             default:
                 throw new ArgumentException("Unknown ContentType case.");
         }

--- a/fit/Couchbase.FitPerformer/Utils/Results/ResultsUtil.cs
+++ b/fit/Couchbase.FitPerformer/Utils/Results/ResultsUtil.cs
@@ -206,7 +206,7 @@ public static class ResultsUtil
                 ExistsResult = new BooleanOrError()
             };
 
-            var contentAs = specs[i].ContentAs.AsCase;
+            var contentAs = specs[i].ContentAs?.AsCase ?? ContentAs.AsOneofCase.None;
             Serilog.Log.Debug("Adding a Spec({I}) Result with Exists = {E}", i, lookupResult.Exists(i));
 
             try
@@ -271,7 +271,7 @@ public static class ResultsUtil
                 ExistsResult = new BooleanOrError()
             };
 
-            var contentAs = specs[i].ContentAs.AsCase;
+            var contentAs = specs[i].ContentAs?.AsCase ?? ContentAs.AsOneofCase.None;
 
             try
             {
@@ -322,7 +322,7 @@ public static class ResultsUtil
                 ContentAsResult = new ContentOrError(),
                 ExistsResult = new BooleanOrError()
             };
-            var contentAs = specs[i].ContentAs.AsCase;
+            var contentAs = specs[i].ContentAs?.AsCase ?? ContentAs.AsOneofCase.None;
 
             Serilog.Log.Debug("Adding a Spec({I}) Result with Exists = {E}", i, lookupResult.Exists(i));
 

--- a/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
+++ b/fit/Couchbase.FitPerformer/Workload/ClusterBucketScopeCollectionCommandExecutor.cs
@@ -318,7 +318,7 @@ namespace Couchbase.FitPerformer
                     var request = op.CollectionCommand.LookupIn;
                     var options = OptionsUtil.ConvertLookupInOptions(request.Options);
                     var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
-                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                        request.Spec.Any(s => s.ContentAs?.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
                     if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
@@ -335,7 +335,7 @@ namespace Couchbase.FitPerformer
                     var request = op.CollectionCommand.LookupInAllReplicas;
                     var options = OptionsUtil.ConvertLookupInAllReplicasOptions(request.Options, _spans);
                     var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
-                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                        request.Spec.Any(s => s.ContentAs?.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
                     if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);
@@ -363,7 +363,7 @@ namespace Couchbase.FitPerformer
                     var request = op.CollectionCommand.LookupInAnyReplica;
                     var options = OptionsUtil.ConvertLookupInAnyReplicasOptions(request.Options, _spans);
                     var rawByteTranscoder = RawByteArrayTranscoderIfNeeded(
-                        request.Spec.Any(s => s.ContentAs.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
+                        request.Spec.Any(s => s.ContentAs?.AsCase == ContentAs.AsOneofCase.AsByteArray), connection);
                     if (rawByteTranscoder != null) options = options.Transcoder(rawByteTranscoder);
                     var specs = request.Spec.Select(ResultsUtil.ConvertLookupInSpec);
                     var (coll, id) = await CommandUtils.DetermineLocation(request.Location, connection, _counters).ConfigureAwait(false);


### PR DESCRIPTION
The FIT performer dereferences `LookupInSpec.content_as` unconditionally. That is an optional proto field, so a spec built without it makes the performer throw an NRE before the SDK call is made. 
The test driver then sees an unexpected exception type instead of the `CouchbaseException` or `InvalidArgumentException` it expects.

`SubdocServerErrorsTest.lookupInTooManyCommands` sends 17 get-specs with no content_as, so it fails on both the classic and the couchbase2 runs.

This PR adds null-check `content_as` on the `LookupIn`, `LookupInAllReplicas` and `LookupInAnyReplica` paths, and report no content for a spec that leaves it unset.