### PR TITLE
NCBC-4271: Fail AllReplicas on unusable server group

### DIFF
--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -32,6 +32,7 @@ namespace Couchbase.KeyValue
     internal sealed class CouchbaseCollection : ICouchbaseCollection, IBinaryCollection, IInternalCollection
     {
         public const string DefaultCollectionName = "_default";
+        private const string NoPreferredServerGroupMessage = "No preferred Server group was set in the ClusterOptions.";
         private readonly string? _preferredServerGroup;
         private readonly bool _rangeScanSupported;
         private readonly BucketBase _bucket;
@@ -833,25 +834,22 @@ namespace Couchbase.KeyValue
         {
             var opts = options?.AsReadOnly() ?? LookupInAllReplicasOptions.DefaultReadOnly;
 
+            // The stream below only runs once enumerated, so an unusable server group is rejected here
+            // to fail at the call site like LookupInAnyReplica does. What it resolves is handed to the
+            // stream so the key mapping and the config walk are not repeated there.
+            ZoneAwareTarget? target = null;
             if (opts.ReadPreferenceValue == InternalReadPreference.SelectedServerGroup)
             {
-                _bucket.ThrowIfBootStrapFailed();
-                if (_preferredServerGroup is null)
-                {
-                    throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
-                }
-                if (!PreferredServerGroupHoldsDocument(VBucketForReplicas(id)))
-                {
-                    throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
-                }
+                target = ResolveZoneAwareTarget(id);
             }
 
-            return LookupInAllReplicasStreamAsync(id, specs, opts);
+            return LookupInAllReplicasStreamAsync(id, specs, opts, target);
         }
 
         private async IAsyncEnumerable<ILookupInReplicaResult> LookupInAllReplicasStreamAsync(string id,
             IEnumerable<LookupInSpec> specs,
-            LookupInOptions.ReadOnly opts)
+            LookupInOptions.ReadOnly opts,
+            ZoneAwareTarget? target)
         {
             _bucket.AssertCap(BucketCapabilities.SUBDOC_REPLICA_READ);
 
@@ -869,7 +867,7 @@ namespace Couchbase.KeyValue
             }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAllReplicas, opts.RequestSpan);
-            var vBucket = VBucketForReplicas(id);
+            var vBucket = target?.VBucket ?? VBucketForReplicas(id, nameof(LookupInAllReplicasAsync));
             var enumeratedSpecs = specs.ToList();
 
             var readWithPreference = opts.ReadPreferenceValue != InternalReadPreference.NoPreference;
@@ -877,16 +875,19 @@ namespace Couchbase.KeyValue
 
             if (readWithPreference)
             {
-                if (TryExecuteZoneAwareLookupInReplica(vBucket, id, enumeratedSpecs, rootSpan, opts, out var zoneAwareTasks))
+                if (TryExecuteZoneAwareLookupInReplica(vBucket, id, enumeratedSpecs, rootSpan, opts,
+                        out var zoneAwareTasks, target?.IndexesInGroup))
                 {
                     tasks.AddRange(zoneAwareTasks);
                 }
                 else if (opts.ReadPreferenceValue ==
-                           InternalReadPreference.SelectedServerGroupWithFallback)
+                         InternalReadPreference.SelectedServerGroupWithFallback)
                 {
                     Logger.LogDebug("Falling back to LookupInAllReplica with no server group preference for {id}", Redactor.UserData(id));
                     AddLookupInAllReplicaTasks();
                 }
+                // Without the fallback there is nothing to read, but that case has already been
+                // rejected by LookupInAllReplicasAsync.
             }
             else
             {
@@ -933,21 +934,40 @@ namespace Couchbase.KeyValue
             }
         }
 
-        private bool TryExecuteZoneAwareLookupInReplica(VBucket vBucket, string id, List<LookupInSpec> enumeratedSpecs, IRequestSpan rootSpan, LookupInOptions.ReadOnly options, out List<Task<MultiLookup<byte[]>>> tasks)
+        /// <summary>
+        /// Resolves the group the read will be served from, throwing when it cannot serve the document.
+        /// </summary>
+        private ZoneAwareTarget ResolveZoneAwareTarget(string id)
         {
-            tasks = new List<Task<MultiLookup<byte[]>>>();
+            //sanity check for deferred bootstrapping errors
+            _bucket.ThrowIfBootStrapFailed();
 
-            // If:
-            // 1 - The preferred server group is not set
-            // 2 - No Node/ServerGroup pairs could be made from the config
-            // 3 - The preferred group does not have an entry in the above, or if it does but is null/empty
             if (_preferredServerGroup is null)
             {
                 throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
             }
-            if (_bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes ||
-                !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup) ||
-                indexesInGroup is null || indexesInGroup.Length == 0)
+
+            var vBucket = VBucketForReplicas(id, nameof(LookupInAllReplicasAsync));
+            if (GetPreferredServerGroupIndexes() is not { } indexesInGroup ||
+                !GroupHoldsDocument(vBucket, indexesInGroup))
+            {
+                throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
+            }
+
+            return new ZoneAwareTarget(vBucket, indexesInGroup);
+        }
+
+        // indexesInGroup carries the preferred group's node indexes when the caller already resolved them.
+        private bool TryExecuteZoneAwareLookupInReplica(VBucket vBucket, string id, List<LookupInSpec> enumeratedSpecs, IRequestSpan rootSpan, LookupInOptions.ReadOnly options, out List<Task<MultiLookup<byte[]>>> tasks, int[]? indexesInGroup = null)
+        {
+            tasks = new List<Task<MultiLookup<byte[]>>>();
+
+            if (_preferredServerGroup is null)
+            {
+                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
+            }
+            indexesInGroup ??= GetPreferredServerGroupIndexes();
+            if (indexesInGroup is null)
             {
                 return false;
             }
@@ -1333,7 +1353,7 @@ namespace Couchbase.KeyValue
                         throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
                     }
                     // Fallback when TryGetZoneAwareReplica fails, if asked.
-                    Logger.LogDebug("Falling back to GetPrimary for {id}", Redactor.UserData(id));
+                    Logger.LogDebug("Falling back to GetPrimary for {Id}", Redactor.UserData(id));
                     tasks.Add(GetPrimary(id, rootSpan, options.TokenValue, options));
                 }
             }
@@ -1362,35 +1382,46 @@ namespace Couchbase.KeyValue
             return firstCompleted.Result;
         }
 
-        private const string NoPreferredServerGroupMessage =
-            "No preferred Server group was set in the ClusterOptions.";
-
         private string ZoneAwareUnretrievableMessage(string id) =>
             $"Either neither the primary or replicas for Document: {id}" +
             $" live in the selected Server Group: {_preferredServerGroup}," +
             $" or no node/group matches could be made from the config.";
 
-        private bool PreferredServerGroupHoldsDocument(VBucket vBucket)
+        /// <summary>
+        /// The node indexes of the preferred server group, or null when the group is unset, when no
+        /// node/group pairs could be made from the config, or when the group holds no nodes.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="BucketConfig.ServerGroupNodeIndexes"/> is rebuilt on every access, so callers
+        /// should resolve this once per operation.
+        /// </remarks>
+        private int[]? GetPreferredServerGroupIndexes()
         {
             if (_preferredServerGroup is null
                 || _bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes
                 || !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup)
-                || indexesInGroup is null || indexesInGroup.Length == 0)
+                || indexesInGroup is not { Length: > 0 })
             {
-                return false;
+                return null;
             }
 
-            return indexesInGroup.Contains(vBucket.Primary)
-                   || vBucket.Replicas.Any(index => index > -1 && indexesInGroup.Contains(index));
+            return indexesInGroup;
         }
+
+        /// <summary>
+        /// Whether the given group node indexes hold the primary or any replica of the document.
+        /// </summary>
+        private static bool GroupHoldsDocument(VBucket vBucket, int[] indexesInGroup) =>
+            indexesInGroup.Contains(vBucket.Primary)
+            || vBucket.Replicas.Any(index => index > -1 && indexesInGroup.Contains(index));
+
 
         private VBucket VBucketForReplicas(string id, [CallerMemberName]string caller = "AnyReplica")
         {
             var vBucket = (VBucket)_bucket.KeyMapper!.MapKey(id);
 
             if (!vBucket.HasReplicas)
-                Logger.LogWarning(
-                    $"Call to {caller} for key [{id}] but none are configured. Only the active document will be retrieved.");
+                Logger.LogWarning("Call to {Caller} for key [{Id}] but none are configured. Only the active document will be retrieved", caller, id);
             return vBucket;
         }
 
@@ -1406,8 +1437,7 @@ namespace Couchbase.KeyValue
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAllReplicas, options.RequestSpanValue);
             var vBucket = (VBucket) _bucket.KeyMapper!.MapKey(id);
             if (!vBucket.HasReplicas)
-                Logger.LogWarning(
-                    $"Call to GetAllReplicas for key [{id}] but none are configured. Only the active document will be retrieved.");
+                Logger.LogWarning("Call to GetAllReplicas for key [{Id}] but none are configured. Only the active document will be retrieved", id);
 
             var readWithPreference = options.ReadPreferenceValue != InternalReadPreference.NoPreference;
             var tasks = new List<Task<IGetReplicaResult>>();
@@ -1421,6 +1451,8 @@ namespace Couchbase.KeyValue
                 else if (options.ReadPreferenceValue ==
                          InternalReadPreference.SelectedServerGroupWithFallback)
                 {
+                    // Fallback when TryGetZoneAwareReplicas fails, if asked.
+                    Logger.LogDebug("Falling back to all replicas with no server group preference for {Id}", Redactor.UserData(id));
                     AddAllReplicaTasks();
                 }
                 else
@@ -1454,17 +1486,11 @@ namespace Couchbase.KeyValue
         {
             tasks = new List<Task<IGetReplicaResult>>();
 
-            // If:
-            // 1 - The preferred server group is not set
-            // 2 - No Node/ServerGroup pairs could be made from the config
-            // 3, 4 - The preferred group does not have an entry in the above, or if it does but is null/empty
             if (_preferredServerGroup is null)
             {
                 throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
             }
-            if (_bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes ||
-                     !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup) ||
-                     indexesInGroup is null || indexesInGroup.Length == 0)
+            if (GetPreferredServerGroupIndexes() is not { } indexesInGroup)
             {
                 return false;
             }

--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -769,49 +769,11 @@ namespace Couchbase.KeyValue
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAnyReplica, opts.RequestSpan);
             var vBucket = VBucketForReplicas(id);
             var enumeratedSpecs = specs.ToList();
+            var indexesInGroup = ResolveZoneAwareGroupIndexes(id, vBucket, opts.ReadPreferenceValue);
 
-            var readWithPreference = opts.ReadPreferenceValue != InternalReadPreference.NoPreference;
-            var tasks = new List<Task<MultiLookup<byte[]>>>();
-
-            if (readWithPreference)
-            {
-                if (TryExecuteZoneAwareLookupInReplica(vBucket, id, enumeratedSpecs, rootSpan, opts, out var zoneAwareTasks))
-                {
-                    tasks.AddRange(zoneAwareTasks);
-                }
-                else
-                {
-                    if (opts.ReadPreferenceValue != InternalReadPreference.SelectedServerGroupWithFallback)
-                    {
-                        throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
-                    }
-                    // We did ask for the fallback, so fallback to LookupIn...
-                    Logger.LogDebug("Falling back to LookupIn for {id}", Redactor.UserData(id));
-                    tasks.Add(ExecuteLookupIn(id, enumeratedSpecs, opts, rootSpan));
-                    if (vBucket.HasReplicas)
-                    {
-                        tasks.AddRange(vBucket.Replicas.Select(replica =>
-                        {
-                            var replicaOpts = opts with { ReplicaIndex = replica };
-                            return ExecuteLookupIn(id, enumeratedSpecs, replicaOpts, rootSpan);
-                        }));
-                    }
-                }
-            }
-            else
-            {
-                //LookupIn on primary
-                tasks.Add(ExecuteLookupIn(id, enumeratedSpecs, opts, rootSpan));
-
-                if (vBucket.HasReplicas)
-                {
-                    tasks.AddRange(vBucket.Replicas.Select(replica =>
-                    {
-                        var replicaOpts = opts with { ReplicaIndex = replica };
-                        return ExecuteLookupIn(id, enumeratedSpecs, replicaOpts, rootSpan);
-                    }));
-                }
-            }
+            var tasks = indexesInGroup is null
+                ? LookupInTasksForAllReplicas(vBucket, id, enumeratedSpecs, rootSpan, opts)
+                : LookupInTasksForServerGroup(vBucket, indexesInGroup, id, enumeratedSpecs, rootSpan, opts);
 
             var completed = TaskHelpers.WhenAnySuccessful(tasks, opts.Token);
             try
@@ -832,29 +794,26 @@ namespace Couchbase.KeyValue
             IEnumerable<LookupInSpec> specs,
             LookupInAllReplicasOptions? options = null)
         {
+            // The stream below only runs once enumerated, so anything that must fail at the call site
+            // like LookupInAnyReplica does is resolved here. The key is mapped once and handed over.
+            _bucket.AssertCap(BucketCapabilities.SUBDOC_REPLICA_READ);
+
+            //sanity check for deferred bootstrapping errors
+            _bucket.ThrowIfBootStrapFailed();
+
             var opts = options?.AsReadOnly() ?? LookupInAllReplicasOptions.DefaultReadOnly;
+            var vBucket = VBucketForReplicas(id);
+            var indexesInGroup = ResolveZoneAwareGroupIndexes(id, vBucket, opts.ReadPreferenceValue);
 
-            // The stream below only runs once enumerated, so an unusable server group is rejected here
-            // to fail at the call site like LookupInAnyReplica does. What it resolves is handed to the
-            // stream so the key mapping and the config walk are not repeated there.
-            ZoneAwareTarget? target = null;
-            if (opts.ReadPreferenceValue == InternalReadPreference.SelectedServerGroup)
-            {
-                target = ResolveZoneAwareTarget(id);
-            }
-
-            return LookupInAllReplicasStreamAsync(id, specs, opts, target);
+            return LookupInAllReplicasStreamAsync(id, specs, opts, vBucket, indexesInGroup);
         }
 
         private async IAsyncEnumerable<ILookupInReplicaResult> LookupInAllReplicasStreamAsync(string id,
             IEnumerable<LookupInSpec> specs,
             LookupInOptions.ReadOnly opts,
-            ZoneAwareTarget? target)
+            VBucket vBucket,
+            int[]? indexesInGroup)
         {
-            _bucket.AssertCap(BucketCapabilities.SUBDOC_REPLICA_READ);
-
-            //sanity check for deferred bootstrapping errors
-            _bucket.ThrowIfBootStrapFailed();
             // A top-level failure of the lookup (here, too many specs) must produce an empty stream
             // rather than throwing - unlike LookupIn/LookupInAnyReplica.
             if (specs.Count() > 16) yield break;
@@ -867,32 +826,11 @@ namespace Couchbase.KeyValue
             }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAllReplicas, opts.RequestSpan);
-            var vBucket = target?.VBucket ?? VBucketForReplicas(id, nameof(LookupInAllReplicasAsync));
             var enumeratedSpecs = specs.ToList();
 
-            var readWithPreference = opts.ReadPreferenceValue != InternalReadPreference.NoPreference;
-            var tasks = new List<Task<MultiLookup<byte[]>>>();
-
-            if (readWithPreference)
-            {
-                if (TryExecuteZoneAwareLookupInReplica(vBucket, id, enumeratedSpecs, rootSpan, opts,
-                        out var zoneAwareTasks, target?.IndexesInGroup))
-                {
-                    tasks.AddRange(zoneAwareTasks);
-                }
-                else if (opts.ReadPreferenceValue ==
-                         InternalReadPreference.SelectedServerGroupWithFallback)
-                {
-                    Logger.LogDebug("Falling back to LookupInAllReplica with no server group preference for {id}", Redactor.UserData(id));
-                    AddLookupInAllReplicaTasks();
-                }
-                // Without the fallback there is nothing to read, but that case has already been
-                // rejected by LookupInAllReplicasAsync.
-            }
-            else
-            {
-                AddLookupInAllReplicaTasks();
-            }
+            var tasks = indexesInGroup is null
+                ? LookupInTasksForAllReplicas(vBucket, id, enumeratedSpecs, rootSpan, opts)
+                : LookupInTasksForServerGroup(vBucket, indexesInGroup, id, enumeratedSpecs, rootSpan, opts);
 
             foreach (var lookupTask in tasks)
             {
@@ -915,74 +853,33 @@ namespace Couchbase.KeyValue
                                 responseStatus == ResponseStatus.SubdocMultiPathFailureDeleted;
                 yield return new LookupInResult(lookup, isDeleted, isReplica: lookup.ReplicaIdx != null);
             }
-
-            yield break;
-
-            void AddLookupInAllReplicaTasks()
-            {
-                //LookupIn on primary
-                tasks.Add(ExecuteLookupIn(id, enumeratedSpecs, opts, rootSpan));
-
-                if (vBucket.HasReplicas)
-                {
-                    tasks.AddRange(vBucket.Replicas.Select(replica =>
-                    {
-                        var replicaOpts = opts with { ReplicaIndex = replica };
-                        return ExecuteLookupIn(id, enumeratedSpecs, replicaOpts, rootSpan);
-                    }));
-                }
-            }
         }
 
-        /// <summary>
-        /// Resolves the group the read will be served from, throwing when it cannot serve the document.
-        /// </summary>
-        private ZoneAwareTarget ResolveZoneAwareTarget(string id)
+        private List<Task<MultiLookup<byte[]>>> LookupInTasksForAllReplicas(VBucket vBucket, string id,
+            List<LookupInSpec> specs, IRequestSpan span, LookupInOptions.ReadOnly options)
         {
-            //sanity check for deferred bootstrapping errors
-            _bucket.ThrowIfBootStrapFailed();
+            var tasks = new List<Task<MultiLookup<byte[]>>> { ExecuteLookupIn(id, specs, options, span) };
 
-            if (_preferredServerGroup is null)
-            {
-                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
-            }
+            tasks.AddRange(GetReplicaIndexes(vBucket).Select(index =>
+                ExecuteLookupIn(id, specs, options with { ReplicaIndex = index }, span)));
 
-            var vBucket = VBucketForReplicas(id, nameof(LookupInAllReplicasAsync));
-            if (GetPreferredServerGroupIndexes() is not { } indexesInGroup ||
-                !GroupHoldsDocument(vBucket, indexesInGroup))
-            {
-                throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
-            }
-
-            return new ZoneAwareTarget(vBucket, indexesInGroup);
+            return tasks;
         }
 
-        // indexesInGroup carries the preferred group's node indexes when the caller already resolved them.
-        private bool TryExecuteZoneAwareLookupInReplica(VBucket vBucket, string id, List<LookupInSpec> enumeratedSpecs, IRequestSpan rootSpan, LookupInOptions.ReadOnly options, out List<Task<MultiLookup<byte[]>>> tasks, int[]? indexesInGroup = null)
+        private List<Task<MultiLookup<byte[]>>> LookupInTasksForServerGroup(VBucket vBucket, int[] indexesInGroup,
+            string id, List<LookupInSpec> specs, IRequestSpan span, LookupInOptions.ReadOnly options)
         {
-            tasks = new List<Task<MultiLookup<byte[]>>>();
-
-            if (_preferredServerGroup is null)
-            {
-                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
-            }
-            indexesInGroup ??= GetPreferredServerGroupIndexes();
-            if (indexesInGroup is null)
-            {
-                return false;
-            }
-
-            var preferredIndexes = vBucket.Replicas
-                .Where(index => index > -1 && indexesInGroup.Contains(index))
+            var tasks = GetReplicaIndexes(vBucket)
+                .Where(index => indexesInGroup.Contains(index))
+                .Select(index => ExecuteLookupIn(id, specs, options with { ReplicaIndex = index }, span))
                 .ToList();
 
-            tasks.AddRange(preferredIndexes.Select(index =>
-                ExecuteLookupIn(id, enumeratedSpecs, options with { ReplicaIndex = index }, rootSpan)));
-
             if (indexesInGroup.Contains(vBucket.Primary))
-                tasks.Add(ExecuteLookupIn(id, enumeratedSpecs, options, rootSpan));
+            {
+                tasks.Add(ExecuteLookupIn(id, specs, options, span));
+            }
 
-            return tasks.Count != 0;
+            return tasks;
         }
 
         private async Task<MultiLookup<byte[]>> ExecuteLookupIn(string id, IEnumerable<LookupInSpec> specs,
@@ -1335,39 +1232,11 @@ namespace Couchbase.KeyValue
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAnyReplica, options.RequestSpanValue);
             var vBucket = VBucketForReplicas(id);
+            var indexesInGroup = ResolveZoneAwareGroupIndexes(id, vBucket, options.ReadPreferenceValue);
 
-            var readWithPreference = options.ReadPreferenceValue != InternalReadPreference.NoPreference;
-            var tasks = new List<Task<IGetReplicaResult>>();
-
-            if (readWithPreference)
-            {
-                if (TryGetZoneAwareReplicas(vBucket, id, rootSpan, options.TokenValue, options, out var zoneAwareTasks))
-                {
-                    tasks.AddRange(zoneAwareTasks);
-                }
-                else
-                {
-                    if (options.ReadPreferenceValue !=
-                        InternalReadPreference.SelectedServerGroupWithFallback)
-                    {
-                        throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
-                    }
-                    // Fallback when TryGetZoneAwareReplica fails, if asked.
-                    Logger.LogDebug("Falling back to GetPrimary for {Id}", Redactor.UserData(id));
-                    tasks.Add(GetPrimary(id, rootSpan, options.TokenValue, options));
-                }
-            }
-            else
-            {
-                //get a list of replica indexes
-                var replicas = GetReplicaIndexes(vBucket);
-
-                // get the primary
-                tasks.Add(GetPrimary(id, rootSpan, options.TokenValue, options));
-
-                // get the replicas
-                tasks.AddRange(replicas.Select(index => GetReplica(id, index, rootSpan, options.TokenValue, options)));
-            }
+            var tasks = indexesInGroup is null
+                ? GetTasksForAllReplicas(vBucket, id, rootSpan, options.TokenValue, options)
+                : GetTasksForServerGroup(vBucket, indexesInGroup, id, rootSpan, options.TokenValue, options);
 
             var firstCompleted = TaskHelpers.WhenAnySuccessful(tasks, options.TokenValue);
             try
@@ -1386,6 +1255,41 @@ namespace Couchbase.KeyValue
             $"Either neither the primary or replicas for Document: {id}" +
             $" live in the selected Server Group: {_preferredServerGroup}," +
             $" or no node/group matches could be made from the config.";
+
+        /// <summary>
+        /// The preferred server group node indexes to read the document from, or null when every replica
+        /// should be read: either no preference was asked for, or the group cannot serve the document and
+        /// the fallback was asked for.
+        /// </summary>
+        /// <exception cref="DocumentUnretrievableException">
+        /// The group cannot serve the document and no fallback was asked for, or no group was selected in
+        /// the <see cref="ClusterOptions"/> at all, which no read preference can work around.
+        /// </exception>
+        private int[]? ResolveZoneAwareGroupIndexes(string id, VBucket vBucket, InternalReadPreference readPreference)
+        {
+            if (readPreference == InternalReadPreference.NoPreference)
+            {
+                return null;
+            }
+
+            if (_preferredServerGroup is null)
+            {
+                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
+            }
+
+            if (GetPreferredServerGroupIndexes() is { } indexesInGroup && GroupHoldsDocument(vBucket, indexesInGroup))
+            {
+                return indexesInGroup;
+            }
+
+            if (readPreference != InternalReadPreference.SelectedServerGroupWithFallback)
+            {
+                throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
+            }
+
+            Logger.LogDebug("Falling back to all replicas with no server group preference for {Id}", Redactor.UserData(id));
+            return null;
+        }
 
         /// <summary>
         /// The node indexes of the preferred server group, or null when the group is unset, when no
@@ -1415,7 +1319,6 @@ namespace Couchbase.KeyValue
             indexesInGroup.Contains(vBucket.Primary)
             || vBucket.Replicas.Any(index => index > -1 && indexesInGroup.Contains(index));
 
-
         private VBucket VBucketForReplicas(string id, [CallerMemberName]string caller = "AnyReplica")
         {
             var vBucket = (VBucket)_bucket.KeyMapper!.MapKey(id);
@@ -1435,45 +1338,12 @@ namespace Couchbase.KeyValue
             options ??= GetAllReplicasOptions.Default;
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAllReplicas, options.RequestSpanValue);
-            var vBucket = (VBucket) _bucket.KeyMapper!.MapKey(id);
-            if (!vBucket.HasReplicas)
-                Logger.LogWarning("Call to GetAllReplicas for key [{Id}] but none are configured. Only the active document will be retrieved", id);
+            var vBucket = VBucketForReplicas(id);
+            var indexesInGroup = ResolveZoneAwareGroupIndexes(id, vBucket, options.ReadPreferenceValue);
 
-            var readWithPreference = options.ReadPreferenceValue != InternalReadPreference.NoPreference;
-            var tasks = new List<Task<IGetReplicaResult>>();
-
-            if (readWithPreference)
-            {
-                if (TryGetZoneAwareReplicas(vBucket, id, rootSpan, options.TokenValue, options, out var zoneAwareTasks))
-                {
-                    tasks.AddRange(zoneAwareTasks);
-                }
-                else if (options.ReadPreferenceValue ==
-                         InternalReadPreference.SelectedServerGroupWithFallback)
-                {
-                    // Fallback when TryGetZoneAwareReplicas fails, if asked.
-                    Logger.LogDebug("Falling back to all replicas with no server group preference for {Id}", Redactor.UserData(id));
-                    AddAllReplicaTasks();
-                }
-                else
-                {
-                    throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
-                }
-            }
-            else
-            {
-                AddAllReplicaTasks();
-            }
-
-            return tasks;
-
-            // local function to capture variables
-            void AddAllReplicaTasks()
-            {
-                var replicas = GetReplicaIndexes(vBucket);
-                tasks.Add(GetPrimary(id, rootSpan, options.TokenValue, options));
-                tasks.AddRange(replicas.Select(index => GetReplica(id, index, rootSpan, options.TokenValue, options)));
-            }
+            return indexesInGroup is null
+                ? GetTasksForAllReplicas(vBucket, id, rootSpan, options.TokenValue, options)
+                : GetTasksForServerGroup(vBucket, indexesInGroup, id, rootSpan, options.TokenValue, options);
         }
 
         private static List<short> GetReplicaIndexes(VBucket vBucket)
@@ -1482,35 +1352,30 @@ namespace Couchbase.KeyValue
             return replicas;
         }
 
-        private bool TryGetZoneAwareReplicas(VBucket vBucket, string id, IRequestSpan rootSpan, CancellationToken token, ITranscoderOverrideOptions options, out List<Task<IGetReplicaResult>> tasks)
+        private List<Task<IGetReplicaResult>> GetTasksForAllReplicas(VBucket vBucket, string id, IRequestSpan span,
+            CancellationToken token, ITranscoderOverrideOptions options)
         {
-            tasks = new List<Task<IGetReplicaResult>>();
+            var tasks = new List<Task<IGetReplicaResult>> { GetPrimary(id, span, token, options) };
 
-            if (_preferredServerGroup is null)
-            {
-                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
-            }
-            if (GetPreferredServerGroupIndexes() is not { } indexesInGroup)
-            {
-                return false;
-            }
+            tasks.AddRange(GetReplicaIndexes(vBucket).Select(index => GetReplica(id, index, span, token, options)));
 
-            // Get all valid replica indexes that are in the preferred server group
-            var preferredIndexes = vBucket.Replicas
-                .Where(index => index > -1 && indexesInGroup.Contains(index))
+            return tasks;
+        }
+
+        private List<Task<IGetReplicaResult>> GetTasksForServerGroup(VBucket vBucket, int[] indexesInGroup, string id,
+            IRequestSpan span, CancellationToken token, ITranscoderOverrideOptions options)
+        {
+            var tasks = GetReplicaIndexes(vBucket)
+                .Where(index => indexesInGroup.Contains(index))
+                .Select(index => GetReplica(id, index, span, token, options))
                 .ToList();
 
-            // Add replicas
-            tasks.AddRange(preferredIndexes.Select(index =>
-                GetReplica(id, index, rootSpan, token, options)));
-
-            // Add primary if it's in the preferred group
             if (indexesInGroup.Contains(vBucket.Primary))
             {
-                tasks.Add(GetPrimary(id, rootSpan, token, options));
+                tasks.Add(GetPrimary(id, span, token, options));
             }
 
-            return tasks.Count > 0;
+            return tasks;
         }
 
         private async Task<IGetReplicaResult> GetPrimary(string id, IRequestSpan span,

--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -782,10 +782,7 @@ namespace Couchbase.KeyValue
                 {
                     if (opts.ReadPreferenceValue != InternalReadPreference.SelectedServerGroupWithFallback)
                     {
-                        throw new DocumentUnretrievableException(
-                            $"Either neither the primary or replicas for Document: {id}" +
-                            $" live in the selected Server Group: {_preferredServerGroup}," +
-                            $" or no node/group matches could be made from the config.");
+                        throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
                     }
                     // We did ask for the fallback, so fallback to LookupIn...
                     Logger.LogDebug("Falling back to LookupIn for {id}", Redactor.UserData(id));
@@ -830,9 +827,31 @@ namespace Couchbase.KeyValue
             return new LookupInResult(lookup, isDeleted, isReplica: lookup.ReplicaIdx != null);
         }
 
-        public async IAsyncEnumerable<ILookupInReplicaResult> LookupInAllReplicasAsync(string id,
+        public IAsyncEnumerable<ILookupInReplicaResult> LookupInAllReplicasAsync(string id,
             IEnumerable<LookupInSpec> specs,
             LookupInAllReplicasOptions? options = null)
+        {
+            var opts = options?.AsReadOnly() ?? LookupInAllReplicasOptions.DefaultReadOnly;
+
+            if (opts.ReadPreferenceValue == InternalReadPreference.SelectedServerGroup)
+            {
+                _bucket.ThrowIfBootStrapFailed();
+                if (_preferredServerGroup is null)
+                {
+                    throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
+                }
+                if (!PreferredServerGroupHoldsDocument(VBucketForReplicas(id)))
+                {
+                    throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
+                }
+            }
+
+            return LookupInAllReplicasStreamAsync(id, specs, opts);
+        }
+
+        private async IAsyncEnumerable<ILookupInReplicaResult> LookupInAllReplicasStreamAsync(string id,
+            IEnumerable<LookupInSpec> specs,
+            LookupInOptions.ReadOnly opts)
         {
             _bucket.AssertCap(BucketCapabilities.SUBDOC_REPLICA_READ);
 
@@ -841,7 +860,6 @@ namespace Couchbase.KeyValue
             // A top-level failure of the lookup (here, too many specs) must produce an empty stream
             // rather than throwing - unlike LookupIn/LookupInAnyReplica.
             if (specs.Count() > 16) yield break;
-            var opts = options?.AsReadOnly() ?? LookupInAllReplicasOptions.DefaultReadOnly;
 
             //Check to see if the CID is needed
             if (RequiresCid())
@@ -925,7 +943,7 @@ namespace Couchbase.KeyValue
             // 3 - The preferred group does not have an entry in the above, or if it does but is null/empty
             if (_preferredServerGroup is null)
             {
-                throw new DocumentUnretrievableException("No preferred Server group was set in the ClusterOptions.");
+                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
             }
             if (_bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes ||
                 !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup) ||
@@ -1312,10 +1330,7 @@ namespace Couchbase.KeyValue
                     if (options.ReadPreferenceValue !=
                         InternalReadPreference.SelectedServerGroupWithFallback)
                     {
-                        throw new DocumentUnretrievableException(
-                            $"Either neither the primary or replicas for Document: {id}" +
-                            $" live in the selected Server Group: {_preferredServerGroup}," +
-                            $" or no node/group matches could be made from the config.");
+                        throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
                     }
                     // Fallback when TryGetZoneAwareReplica fails, if asked.
                     Logger.LogDebug("Falling back to GetPrimary for {id}", Redactor.UserData(id));
@@ -1345,6 +1360,28 @@ namespace Couchbase.KeyValue
             }
 
             return firstCompleted.Result;
+        }
+
+        private const string NoPreferredServerGroupMessage =
+            "No preferred Server group was set in the ClusterOptions.";
+
+        private string ZoneAwareUnretrievableMessage(string id) =>
+            $"Either neither the primary or replicas for Document: {id}" +
+            $" live in the selected Server Group: {_preferredServerGroup}," +
+            $" or no node/group matches could be made from the config.";
+
+        private bool PreferredServerGroupHoldsDocument(VBucket vBucket)
+        {
+            if (_preferredServerGroup is null
+                || _bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes
+                || !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup)
+                || indexesInGroup is null || indexesInGroup.Length == 0)
+            {
+                return false;
+            }
+
+            return indexesInGroup.Contains(vBucket.Primary)
+                   || vBucket.Replicas.Any(index => index > -1 && indexesInGroup.Contains(index));
         }
 
         private VBucket VBucketForReplicas(string id, [CallerMemberName]string caller = "AnyReplica")
@@ -1381,13 +1418,14 @@ namespace Couchbase.KeyValue
                 {
                     tasks.AddRange(zoneAwareTasks);
                 }
+                else if (options.ReadPreferenceValue ==
+                         InternalReadPreference.SelectedServerGroupWithFallback)
+                {
+                    AddAllReplicaTasks();
+                }
                 else
                 {
-                    if (options.ReadPreferenceValue ==
-                        InternalReadPreference.SelectedServerGroupWithFallback)
-                    {
-                        AddAllReplicaTasks();
-                    }
+                    throw new DocumentUnretrievableException(ZoneAwareUnretrievableMessage(id));
                 }
             }
             else
@@ -1422,7 +1460,7 @@ namespace Couchbase.KeyValue
             // 3, 4 - The preferred group does not have an entry in the above, or if it does but is null/empty
             if (_preferredServerGroup is null)
             {
-                throw new DocumentUnretrievableException("No preferred Server group was set in the ClusterOptions.");
+                throw new DocumentUnretrievableException(NoPreferredServerGroupMessage);
             }
             if (_bucket.CurrentConfig?.ServerGroupNodeIndexes is not { } groupNodeIndexes ||
                      !groupNodeIndexes.TryGetValue(_preferredServerGroup, out var indexesInGroup) ||

--- a/src/Couchbase/KeyValue/ZoneAware/ZoneAwareTarget.cs
+++ b/src/Couchbase/KeyValue/ZoneAware/ZoneAwareTarget.cs
@@ -1,9 +1,0 @@
-using Couchbase.Core.Sharding;
-
-namespace Couchbase.KeyValue.ZoneAware;
-
-/// <summary>
-/// A zone-aware read target resolved ahead of the operation, so the key mapping and the
-/// server group lookup are done once.
-/// </summary>
-internal readonly record struct ZoneAwareTarget(VBucket VBucket, int[] IndexesInGroup);

--- a/src/Couchbase/KeyValue/ZoneAware/ZoneAwareTarget.cs
+++ b/src/Couchbase/KeyValue/ZoneAware/ZoneAwareTarget.cs
@@ -1,0 +1,9 @@
+using Couchbase.Core.Sharding;
+
+namespace Couchbase.KeyValue.ZoneAware;
+
+/// <summary>
+/// A zone-aware read target resolved ahead of the operation, so the key mapping and the
+/// server group lookup are done once.
+/// </summary>
+internal readonly record struct ZoneAwareTarget(VBucket VBucket, int[] IndexesInGroup);

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.Bootstrapping;
+using Couchbase.Core.Configuration.Server;
+using Couchbase.Core.DI;
+using Couchbase.Core.Diagnostics.Tracing;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.Exceptions.KeyValue;
+using Couchbase.Core.IO.Compression;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+using Couchbase.Core.Logging;
+using Couchbase.Core.Retry;
+using Couchbase.Core.Sharding;
+using Couchbase.KeyValue;
+using Couchbase.KeyValue.ZoneAware;
+using Couchbase.Management.Collections;
+using Couchbase.Management.Views;
+using Couchbase.UnitTests.Utils;
+using Couchbase.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.KeyValue
+{
+    /// <summary>
+    /// Zone-aware replica reads (RFC-0078): which nodes are read, and where an unusable server
+    /// group fails. The fixture config splits four nodes into group_1 (indexes 0 and 1) and
+    /// group_2 (indexes 2 and 3).
+    /// </summary>
+    public class CouchbaseCollectionZoneAwareTests
+    {
+        private const string PreferredGroup = "group_1";
+        private const string DocId = "thekey";
+
+        // group_1 holds the primary (node 1) and one replica (node 0).
+        private static readonly short[] GroupHoldsCopy = [1, 0, 2, 3];
+
+        // Only group_2 nodes hold a copy.
+        private static readonly short[] GroupHoldsNoCopy = [2, 3];
+
+        private static readonly LookupInSpec[] Specs = [LookupInSpec.Get("name")];
+
+        #region No preferred server group in the ClusterOptions
+
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public async Task GetAnyReplica_Without_PreferredServerGroup_Throws(InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(preferredServerGroup: null, GroupHoldsCopy);
+
+            await Assert.ThrowsAsync<DocumentUnretrievableException>(() => collection.GetAnyReplicaAsync(DocId,
+                new GetAnyReplicaOptions().ReadPreference(readPreference)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public void GetAllReplicas_Without_PreferredServerGroup_Throws(InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(preferredServerGroup: null, GroupHoldsCopy);
+
+            Assert.Throws<DocumentUnretrievableException>(() => collection.GetAllReplicasAsync(DocId,
+                new GetAllReplicasOptions().ReadPreference(readPreference)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public async Task LookupInAnyReplica_Without_PreferredServerGroup_Throws(InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(preferredServerGroup: null, GroupHoldsCopy);
+
+            await Assert.ThrowsAsync<DocumentUnretrievableException>(() => collection.LookupInAnyReplicaAsync(DocId, Specs,
+                new LookupInAnyReplicaOptions().ReadPreference(readPreference)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        // No read preference works around an unset group, so both of these must fail at the call
+        // site rather than on the stream.
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public void LookupInAllReplicas_Without_PreferredServerGroup_Throws_Before_Enumeration(
+            InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(preferredServerGroup: null, GroupHoldsCopy);
+
+            Assert.Throws<DocumentUnretrievableException>(() => collection.LookupInAllReplicasAsync(DocId, Specs,
+                new LookupInAllReplicasOptions().ReadPreference(readPreference)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        #endregion
+
+        #region Preferred server group holds no copy of the document
+
+        [Fact]
+        public void GetAllReplicas_SelectedServerGroup_Without_Local_Copy_Throws()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsNoCopy);
+
+            Assert.Throws<DocumentUnretrievableException>(() => collection.GetAllReplicasAsync(DocId,
+                new GetAllReplicasOptions().ReadPreference(InternalReadPreference.SelectedServerGroup)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        [Fact]
+        public void LookupInAllReplicas_SelectedServerGroup_Without_Local_Copy_Throws_Before_Enumeration()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsNoCopy);
+
+            Assert.Throws<DocumentUnretrievableException>(() => collection.LookupInAllReplicasAsync(DocId, Specs,
+                new LookupInAllReplicasOptions().ReadPreference(InternalReadPreference.SelectedServerGroup)));
+            Assert.Empty(bucket.DispatchedReplicaIndexes);
+        }
+
+        [Fact]
+        public async Task GetAllReplicas_Fallback_Without_Local_Copy_Reads_Every_Copy()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsNoCopy);
+
+            await ObserveAsync(collection.GetAllReplicasAsync(DocId,
+                new GetAllReplicasOptions().ReadPreference(InternalReadPreference.SelectedServerGroupWithFallback)));
+
+            // Primary node 2 and replica node 3, neither of which is in group_1.
+            Assert.Equal([null, (short) 3], bucket.DispatchedReplicaIndexes);
+        }
+
+        [Fact]
+        public async Task LookupInAllReplicas_Fallback_Without_Local_Copy_Reads_Every_Copy()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsNoCopy);
+
+            await ObserveAsync(collection.LookupInAllReplicasAsync(DocId, Specs,
+                new LookupInAllReplicasOptions().ReadPreference(InternalReadPreference.SelectedServerGroupWithFallback)));
+
+            Assert.Equal([null, (short) 3], bucket.DispatchedReplicaIndexes);
+        }
+
+        [Fact]
+        public async Task LookupInAllReplicas_Fallback_With_Unknown_Group_Name_Reads_Every_Copy()
+        {
+            var (collection, bucket) = CreateCollection("group_does_not_exist", GroupHoldsCopy);
+
+            await ObserveAsync(collection.LookupInAllReplicasAsync(DocId, Specs,
+                new LookupInAllReplicasOptions().ReadPreference(InternalReadPreference.SelectedServerGroupWithFallback)));
+
+            Assert.Equal([null, (short) 0, (short) 2, (short) 3], bucket.DispatchedReplicaIndexes);
+        }
+
+        #endregion
+
+        #region Preferred server group holds a copy of the document
+
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public async Task GetAllReplicas_Reads_Only_The_Preferred_Group(InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsCopy);
+
+            await ObserveAsync(collection.GetAllReplicasAsync(DocId,
+                new GetAllReplicasOptions().ReadPreference(readPreference)));
+
+            // Replica node 0 then primary node 1, both in group_1. Nodes 2 and 3 are not read.
+            Assert.Equal([(short) 0, null], bucket.DispatchedReplicaIndexes);
+        }
+
+        [Theory]
+        [InlineData(InternalReadPreference.SelectedServerGroup)]
+        [InlineData(InternalReadPreference.SelectedServerGroupWithFallback)]
+        public async Task LookupInAllReplicas_Reads_Only_The_Preferred_Group(InternalReadPreference readPreference)
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsCopy);
+
+            await ObserveAsync(collection.LookupInAllReplicasAsync(DocId, Specs,
+                new LookupInAllReplicasOptions().ReadPreference(readPreference)));
+
+            Assert.Equal([(short) 0, null], bucket.DispatchedReplicaIndexes);
+        }
+
+        #endregion
+
+        #region No read preference
+
+        [Fact]
+        public async Task GetAllReplicas_Without_ReadPreference_Reads_Every_Copy()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsCopy);
+
+            await ObserveAsync(collection.GetAllReplicasAsync(DocId));
+
+            Assert.Equal([null, (short) 0, (short) 2, (short) 3], bucket.DispatchedReplicaIndexes);
+        }
+
+        [Fact]
+        public async Task LookupInAllReplicas_Without_ReadPreference_Reads_Every_Copy()
+        {
+            var (collection, bucket) = CreateCollection(PreferredGroup, GroupHoldsCopy);
+
+            await ObserveAsync(collection.LookupInAllReplicasAsync(DocId, Specs));
+
+            Assert.Equal([null, (short) 0, (short) 2, (short) 3], bucket.DispatchedReplicaIndexes);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Every read the fake bucket receives fails, so drain the results to record what was sent.
+        /// </summary>
+        private static async Task ObserveAsync(IEnumerable<Task<IGetReplicaResult>> tasks)
+        {
+            foreach (var task in tasks)
+            {
+                await Assert.ThrowsAnyAsync<Exception>(() => task);
+            }
+        }
+
+        private static async Task ObserveAsync(IAsyncEnumerable<ILookupInReplicaResult> results)
+        {
+            await foreach (var result in results)
+            {
+                Assert.Fail($"Every read was expected to fail, but the stream yielded {result}");
+            }
+        }
+
+        private static (CouchbaseCollection Collection, ZoneAwareFakeBucket Bucket) CreateCollection(
+            string preferredServerGroup, short[] vBucketMapRow)
+        {
+            var config = ResourceHelper.ReadResource(@"Documents\Configs\configWithReplicasAndServerGroups.json",
+                InternalSerializationContext.Default.BucketConfig);
+
+            // Every key maps to the same topology, and collections are left unsupported so that no
+            // collection ID is fetched.
+            config.VBucketServerMap.VBucketMap = Enumerable.Repeat(vBucketMapRow, 1024).ToArray();
+            config.BucketCapabilities = [BucketCapabilities.SUBDOC_REPLICA_READ];
+
+            var bucket = new ZoneAwareFakeBucket(config, preferredServerGroup);
+
+            var collection = new CouchbaseCollection(bucket,
+                new OperationConfigurator(new LegacyTranscoder(),
+                    Mock.Of<IOperationCompressor>(),
+                    new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy()),
+                    new BestEffortRetryStrategy()),
+                new Mock<ILogger<CouchbaseCollection>>().Object,
+                new Mock<ILogger<GetResult>>().Object,
+                new Mock<IRedactor>().Object,
+                CouchbaseCollection.DefaultCollectionName,
+                Mock.Of<IScope>(),
+                new NoopRequestTracer(),
+                NullFallbackTypeSerializerProvider.Instance,
+                Mock.Of<IServiceProvider>());
+
+            return (collection, bucket);
+        }
+
+        /// <summary>
+        /// Records the node each operation was routed to, then fails it. What is read matters here,
+        /// not what comes back.
+        /// </summary>
+        internal class ZoneAwareFakeBucket : BucketBase
+        {
+            public ZoneAwareFakeBucket(BucketConfig config, string preferredServerGroup)
+                : base(config.Name,
+                    new ClusterContext(null, new ClusterOptions
+                        {
+                            PreferredServerGroup = preferredServerGroup
+                        }.WithPasswordAuthentication("username", "password")),
+                    new Mock<IScopeFactory>().Object,
+                    CreateRetryOrchestrator(),
+                    new Mock<ILogger>().Object,
+                    new TypedRedactor(RedactionLevel.None),
+                    new Mock<IBootstrapperFactory>().Object,
+                    NoopRequestTracer.Instance,
+                    new Mock<IOperationConfigurator>().Object,
+                    new BestEffortRetryStrategy(), null)
+            {
+                CurrentConfig = config;
+                KeyMapper = new VBucketKeyMapper(config, new VBucketServerMap(config.VBucketServerMap),
+                    new VBucketFactory(new Mock<ILogger<VBucket>>().Object));
+            }
+
+            /// <summary>
+            /// The node index each read was sent to, in dispatch order. Null is the primary.
+            /// </summary>
+            public List<short?> DispatchedReplicaIndexes { get; } = new();
+
+            public virtual Task<ResponseStatus> RecordAndFail(IOperation operation)
+            {
+                DispatchedReplicaIndexes.Add(operation.ReplicaIdx);
+                return Task.FromException<ResponseStatus>(
+                    new TemporaryFailureException("The fake bucket serves no documents."));
+            }
+
+            private static IRetryOrchestrator CreateRetryOrchestrator()
+            {
+                var mock = new Mock<IRetryOrchestrator>();
+
+                mock.Setup(m => m.RetryAsync(It.IsAny<BucketBase>(), It.IsAny<IOperation>(),
+                        It.IsAny<CancellationTokenPair>()))
+                    .Returns((BucketBase bucket, IOperation op, CancellationTokenPair _) =>
+                        ((ZoneAwareFakeBucket) bucket).RecordAndFail(op));
+
+                return mock.Object;
+            }
+
+            internal override Task<ResponseStatus> SendAsync(IOperation op, CancellationTokenPair token = default) =>
+                RecordAndFail(op);
+
+            public override ICouchbaseCollectionManager Collections => throw new NotImplementedException();
+
+#pragma warning disable CS0618, CS0672 // Obsolete View service members
+            public override IViewIndexManager ViewIndexes => throw new NotImplementedException();
+
+            public override Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument,
+                string viewName, ViewOptions options = null) => throw new NotImplementedException();
+#pragma warning restore CS0618, CS0672
+
+            public override Task ForceConfigUpdateAsync() => throw new NotImplementedException();
+
+            public override IScope Scope(string scopeName) => throw new NotImplementedException();
+
+            internal override Task BootstrapAsync(IClusterNode bootstrapNodes) => throw new NotImplementedException();
+
+            public override Task ConfigUpdatedAsync(BucketConfig newConfig) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
RFC-0078 wants DocumentUnretrievable when a SELECTED_SERVER_GROUP read cannot be done. AnyReplica did that. AllReplicas returned an empty stream instead, which looks the same as a doc with no replicas.

Changes
-------
- GetAllReplicas and LookupInAllReplicas now throw DocumentUnretrievable when the group is unset, missing from the config, or holds no copy of the doc.
- LookupInAllReplicas checks before returning the stream, so it fails at the call site like GetAllReplicas.

Needs the matching ZoneAwareUtils change in the FIT driver https://review.couchbase.org/c/transactions-fit-performer/+/249547