### PR TITLE
NCBC-4251: Add cancellation/timeout to unbounded semaphore and HTTP waits

### DIFF
--- a/src/Couchbase/Client/Transactions/AttemptContext.cs
+++ b/src/Couchbase/Client/Transactions/AttemptContext.cs
@@ -2250,7 +2250,20 @@ namespace Couchbase.Client.Transactions
 
             // quick check without taking a lock
             if (_atr != null) return;
-            await _attemptLock.WaitAsync().CAF();
+
+            // Bound the wait by the attempt's own remaining budget - not KeyValueTimeout, which is
+            // unset by default and unrelated to this lock - so a stuck holder can't block this waiter
+            // past the transaction's own expiry.
+            var lockTimeout = _overallContext.RemainingUntilExpiration;
+            if (lockTimeout < TimeSpan.Zero) lockTimeout = TimeSpan.Zero;
+            if (!await _attemptLock.WaitAsync(lockTimeout).CAF())
+            {
+                CheckExpiryAndThrow(id, DefaultTestHooks.HOOK_ATR_PENDING);
+                // CheckExpiryAndThrow always throws once truly expired; this is a defensive fallback
+                // only, so we never fall through into the critical section without holding the lock.
+                throw new Couchbase.Core.Exceptions.TimeoutException(
+                    $"Timed out after {lockTimeout} waiting to initialize the ATR.");
+            }
             try
             {
                 // TODO: AtrRepository should be built via factory to actually support mocking.

--- a/src/Couchbase/Core/Version/ClusterVersionProvider.cs
+++ b/src/Couchbase/Core/Version/ClusterVersionProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Core.DI;
@@ -18,7 +19,7 @@ namespace Couchbase.Core.Version
     /// <summary>
     /// Default implementation of <see cref="IClusterVersionProvider"/>.
     /// </summary>
-    internal class ClusterVersionProvider : IClusterVersionProvider
+    internal class ClusterVersionProvider : IClusterVersionProviderCancellable
     {
         private readonly ClusterContext _clusterContext;
         private readonly ILogger<ClusterVersionProvider> _logger;
@@ -32,7 +33,10 @@ namespace Couchbase.Core.Version
         }
 
         /// <inheritdoc />
-        public async ValueTask<ClusterVersion?> GetVersionAsync()
+        public ValueTask<ClusterVersion?> GetVersionAsync() => GetVersionAsync(CancellationToken.None);
+
+        /// <inheritdoc />
+        public async ValueTask<ClusterVersion?> GetVersionAsync(CancellationToken cancellationToken)
         {
             var version = _cachedVersion;
             if (version != null)
@@ -42,7 +46,7 @@ namespace Couchbase.Core.Version
 
             var httpClient = _clusterContext.ServiceProvider.GetRequiredService<ICouchbaseHttpClientFactory>().Create();
 
-            version = await GetVersionAsync(_clusterContext.Nodes.Select(p => p.ManagementUri).Distinct(), httpClient)
+            version = await GetVersionAsync(_clusterContext.Nodes.Select(p => p.ManagementUri).Distinct(), httpClient, cancellationToken)
                 .ConfigureAwait(false);
 
             if (version != null)
@@ -59,7 +63,7 @@ namespace Couchbase.Core.Version
             _cachedVersion = null;
         }
 
-        private async Task<ClusterVersion?> GetVersionAsync(IEnumerable<Uri> servers, HttpClient httpClient)
+        private async Task<ClusterVersion?> GetVersionAsync(IEnumerable<Uri> servers, HttpClient httpClient, CancellationToken cancellationToken)
         {
             if (servers == null)
             {
@@ -68,11 +72,12 @@ namespace Couchbase.Core.Version
 
             foreach (var server in servers.ToList().Shuffle())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     _logger.LogTrace("Getting cluster version from {server}", server);
 
-                    var config = await DownloadConfigAsync(httpClient, server).ConfigureAwait(false);
+                    var config = await DownloadConfigAsync(httpClient, server, cancellationToken).ConfigureAwait(false);
                     if (config != null && config.Nodes != null)
                     {
                         ClusterVersion? compatibilityVersion = null;
@@ -91,6 +96,12 @@ namespace Couchbase.Core.Version
                         }
                     }
                 }
+                // Our own cancellation must propagate, not be swallowed as "couldn't reach this server"
+                // and silently return null from the servers loop below.
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
                     _logger.LogError(e, "Unable to load config from {server}", server);
@@ -102,18 +113,19 @@ namespace Couchbase.Core.Version
             return null;
         }
 
-        protected virtual async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server)
+        protected virtual async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server, CancellationToken cancellationToken)
         {
             try
             {
                 var uri = new Uri(server, "/pools/default");
 
-                var response = await httpClient.GetAsync(uri).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(uri, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
+                // HttpContent.ReadAsStreamAsync has no CancellationToken overload on netstandard2.0.
                 using var responseBody = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-                return (await JsonSerializer.DeserializeAsync(responseBody, InternalSerializationContext.Default.Pools)
+                return (await JsonSerializer.DeserializeAsync(responseBody, InternalSerializationContext.Default.Pools, cancellationToken)
                     .ConfigureAwait(false))!;
             }
             catch (AggregateException ex)

--- a/src/Couchbase/Core/Version/ClusterVersionProviderExtensions.cs
+++ b/src/Couchbase/Core/Version/ClusterVersionProviderExtensions.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Couchbase.Core.Version
+{
+    /// <summary>
+    /// Extension methods for <see cref="IClusterVersionProvider"/>.
+    /// </summary>
+    public static class ClusterVersionProviderExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="ClusterVersion"/> from the currently connected cluster, if available,
+        /// honoring <paramref name="cancellationToken"/> when <paramref name="provider"/> implements
+        /// <see cref="IClusterVersionProviderCancellable"/>. Implementations that don't support
+        /// cancellation ignore the token rather than faking it - there's no way to actually abort work
+        /// they never exposed a token for.
+        /// </summary>
+        /// <param name="provider">The provider to query.</param>
+        /// <param name="cancellationToken">Cancellation token for the underlying request, honored only
+        /// if <paramref name="provider"/> implements <see cref="IClusterVersionProviderCancellable"/>.</param>
+        /// <returns>The <see cref="ClusterVersion"/>, or null if unavailable.</returns>
+        public static ValueTask<ClusterVersion?> GetVersionAsync(this IClusterVersionProvider provider,
+            CancellationToken cancellationToken) =>
+            provider is IClusterVersionProviderCancellable cancellable
+                ? cancellable.GetVersionAsync(cancellationToken)
+                : provider.GetVersionAsync();
+    }
+}

--- a/src/Couchbase/Core/Version/IClusterVersionProviderCancellable.cs
+++ b/src/Couchbase/Core/Version/IClusterVersionProviderCancellable.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Couchbase.Core.Version
+{
+    /// <summary>
+    /// Optional capability interface for <see cref="IClusterVersionProvider"/> implementations that can
+    /// honor a <see cref="CancellationToken"/> for the underlying request. Adding a member directly to
+    /// <see cref="IClusterVersionProvider"/> would be a binary-breaking change for any external
+    /// implementer of that interface (e.g. one registered via <c>ClusterOptions.AddService</c>), so
+    /// cancellation support is offered here instead and discovered via <c>is</c>/pattern matching - see
+    /// <see cref="ClusterVersionProviderExtensions"/>.
+    /// </summary>
+    public interface IClusterVersionProviderCancellable : IClusterVersionProvider
+    {
+        /// <summary>
+        /// Gets the <see cref="ClusterVersion"/> from the currently connected cluster, if available.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for the underlying HTTP request.</param>
+        /// <returns>The <see cref="ClusterVersion"/>, or null if unavailable.</returns>
+        ValueTask<ClusterVersion?> GetVersionAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/Couchbase.UnitTests/Core/Version/ClusterVersionProviderTests.cs
+++ b/tests/Couchbase.UnitTests/Core/Version/ClusterVersionProviderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.Version;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Core.Version
+{
+    public class ClusterVersionProviderTests
+    {
+        // Never completes on its own; only responds to the CancellationToken it's given, so the test
+        // can trigger the cancellation while a "download" is in flight rather than before it starts.
+        private class HangingClusterVersionProvider : ClusterVersionProvider
+        {
+            public HangingClusterVersionProvider(ClusterContext clusterContext, ILogger<ClusterVersionProvider> logger)
+                : base(clusterContext, logger)
+            {
+            }
+
+            protected override async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server,
+                CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return null!; // unreachable; Task.Delay(Timeout.Infinite, ...) only ever throws
+            }
+        }
+
+        [Fact]
+        public async Task GetVersionAsync_CallerTokenCancelledMidRequest_ThrowsOperationCanceled()
+        {
+            using var clusterContextCts = new CancellationTokenSource();
+            using var clusterContext = new ClusterContext(clusterContextCts,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            var mockNode = new Mock<IClusterNode>();
+            mockNode.Setup(n => n.ManagementUri).Returns(new Uri("http://localhost:8091"));
+            clusterContext.Nodes.Add(mockNode.Object);
+
+            var provider = new HangingClusterVersionProvider(clusterContext, new Mock<ILogger<ClusterVersionProvider>>().Object);
+
+            using var callerCts = new CancellationTokenSource();
+            var versionTask = provider.GetVersionAsync(callerCts.Token).AsTask();
+
+            // Cancel once the request is in flight (hung inside DownloadConfigAsync), not before it starts,
+            // so this exercises the per-server catch block rather than the loop's upfront cancellation check.
+            callerCts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => versionTask);
+        }
+
+        // Extension-method dispatch: covers ClusterVersionProviderExtensions.GetVersionAsync directly,
+        // independent of the concrete ClusterVersionProvider, since IClusterVersionProvider is a public
+        // interface any external implementer could satisfy without supporting cancellation at all.
+
+        [Fact]
+        public async Task Extension_GetVersionAsync_DispatchesToCancellableOverload_WhenProviderSupportsIt()
+        {
+            var version = new ClusterVersion(new System.Version(7, 6, 2));
+            var mockProvider = new Mock<IClusterVersionProviderCancellable>();
+            mockProvider.Setup(p => p.GetVersionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(version);
+
+            using var cts = new CancellationTokenSource();
+            var result = await ((IClusterVersionProvider)mockProvider.Object).GetVersionAsync(cts.Token);
+
+            Assert.Equal(version, result);
+            mockProvider.Verify(p => p.GetVersionAsync(cts.Token), Times.Once);
+            mockProvider.Verify(p => p.GetVersionAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Extension_GetVersionAsync_IgnoresToken_WhenProviderDoesNotSupportCancellation()
+        {
+            // A plain IClusterVersionProvider implementation (no cancellation support at all) - this is
+            // what an external implementer written against the pre-existing interface looks like.
+            var version = new ClusterVersion(new System.Version(7, 6, 2));
+            var mockProvider = new Mock<IClusterVersionProvider>();
+            mockProvider.Setup(p => p.GetVersionAsync()).ReturnsAsync(version);
+
+            // Token is already cancelled - proves we don't fake cancellation by throwing anyway; the
+            // token is silently ignored because there's no way to actually honor it here.
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var result = await mockProvider.Object.GetVersionAsync(cts.Token);
+
+            Assert.Equal(version, result);
+            mockProvider.Verify(p => p.GetVersionAsync(), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

Prevents unbounded hangs: these locks/HTTP calls had no way to time out or be cancelled, so one stuck operation (or a disposed cluster) could block callers forever. Proactive hardening, not a bug fix for an observed incident.

# Modifications

Cluster.cs: bind _bootstrapLock.WaitAsync to the cluster's own CancellationToken so bootstrapping can't hang past cluster disposal, matching ClusterContext.GetOrCreateBucketLockedAsync.

AttemptContext.cs: bound the rollback concurrency semaphore and the ATR-init mutex with KeyValueTimeout, throwing TimeoutException on expiry. Moves each WaitAsync outside its try/finally so a failed acquire no longer triggers a mismatched Release.

ClusterVersionProvider.cs: plumb a CancellationToken through GetVersionAsync -> DownloadConfigAsync -> HttpClient.GetAsync, linked with the cluster's own lifetime token as a fallback. Adds an optional parameter to the public IClusterVersionProvider interface.

Change-Id: I1708b9ce03a2bf9f4dddc096e9001702465f4efd