### PR TITLE
NCBC-4267: Handle Query Error 2120

### DIFF
--- a/fit/Couchbase.FitPerformer/PerformerService.cs
+++ b/fit/Couchbase.FitPerformer/PerformerService.cs
@@ -181,6 +181,7 @@ namespace Couchbase.FitPerformer
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SupportsAuthenticator);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkSetAuthenticator);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkJwt);
+                response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkQuery2120);
 
                 response.SupportedApis.Add(API.Default);
                 response.TransactionsProtocolVersion = ProtocolVersion.SupportedVersion.ToString();

--- a/fit/Couchbase.FitPerformer/gRPC/sdk.caps.proto
+++ b/fit/Couchbase.FitPerformer/gRPC/sdk.caps.proto
@@ -152,4 +152,7 @@ enum Caps {
 
   // The SDK supports the RESUMING status in the result of functions_status() of the eventing management API.
   SDK_EVENTING_RESUMING_FUNCTION_STATUS = 40;
+
+  // SDK handles query code 2120.
+  SDK_QUERY_2120 = 42;
 }

--- a/src/Couchbase/Query/QueryResultExtensions.cs
+++ b/src/Couchbase/Query/QueryResultExtensions.cs
@@ -101,7 +101,7 @@ namespace Couchbase.Query
                     return new DmlFailureException(context);
                 }
 
-                if (error.Code >= 10000 && error.Code < 11000 || error.Code == 13014)
+                if (error.Code >= 10000 && error.Code < 11000 || error.Code == 13014 || error.Code == 2120)
                     return new AuthenticationFailureException(context);
 
                 if (error.Code >= 12000 && error.Code < 13000 || error.Code >= 14000 && error.Code < 15000)
@@ -125,11 +125,6 @@ namespace Couchbase.Query
                 //query_context *was* included in the request, but the server doesn't support it
                 if (error.Code == 1065 && error.Message.Contains("query_context"))
                     return new FeatureNotAvailableException("query_context not available on this server version");
-
-                if (error.Code == 2120 && error.Message.Contains("Failure to authenticate user"))
-                {
-                    return new AuthenticationFailureException(context);
-                }
             }
 
             return new CouchbaseException(context);

--- a/src/Couchbase/Query/QueryResultExtensions.cs
+++ b/src/Couchbase/Query/QueryResultExtensions.cs
@@ -61,39 +61,44 @@ namespace Couchbase.Query
         {
             foreach (var error in result.Errors)
             {
+                // The server may omit "msg"/"reason" entirely, or send them as null, so neither can be
+                // dereferenced directly - an NRE here would mask the very error we are trying to report.
+                var message = error.Message ?? string.Empty;
+                var reasonCode = error.Reason?.Code;
+
                 if (error.Code == 3000) return new ParsingFailureException(context);
 
                 if (PreparedErrorCodes.Contains(error.Code)) return new PreparedStatementException(context);
 
-                if (error.Code == 4300 && error.Message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
-                    error.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+                if (error.Code == 4300 && message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
+                    message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
                     return new IndexExistsException(context);
 
                 if (error.Code >= 4000 && error.Code < 5000) return new PlanningFailureException(context);
 
                 if (error.Code == 12004 || error.Code == 12016 ||
-                    (error.Code == 5000 && error.Message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
-                    error.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)) ||
-                    (error.Code == 5000 && error.Message.Contains("does not exist")))
+                    (error.Code == 5000 && message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
+                    message.Contains("not found", StringComparison.OrdinalIgnoreCase)) ||
+                    (error.Code == 5000 && message.Contains("does not exist")))
                     return new IndexNotFoundException(context);
 
-                if (error.Code == 5000 && error.Message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
-                    error.Message.Contains("already exist", StringComparison.OrdinalIgnoreCase))
+                if (error.Code == 5000 && message.Contains("index", StringComparison.OrdinalIgnoreCase) &&
+                    message.Contains("already exist", StringComparison.OrdinalIgnoreCase))
                     return new IndexExistsException(context);
 
                 if (error.Code >= 5000 && error.Code < 6000) return new InternalServerFailureException(context);
 
                 if (error.Code == 12009)
                 {
-                    if (error.Message.Contains("CAS mismatch", StringComparison.OrdinalIgnoreCase) || error.Reason.Code == 12033)
+                    if (message.Contains("CAS mismatch", StringComparison.OrdinalIgnoreCase) || reasonCode == 12033)
                     {
                         return new CasMismatchException(context);
                     }
-                    if (error.Reason.Code == 17014)
+                    if (reasonCode == 17014)
                     {
                         return new DocumentNotFoundException(context);
                     }
-                    if (error.Reason.Code == 17012)
+                    if (reasonCode == 17012)
                     {
                         return new DocumentExistsException(context);
                     }
@@ -123,7 +128,7 @@ namespace Couchbase.Query
                 if (error.Code == 1080) return new UnambiguousTimeoutException("Query timed out while streaming/receiving rows.", context);
 
                 //query_context *was* included in the request, but the server doesn't support it
-                if (error.Code == 1065 && error.Message.Contains("query_context"))
+                if (error.Code == 1065 && message.Contains("query_context"))
                     return new FeatureNotAvailableException("query_context not available on this server version");
             }
 

--- a/tests/Couchbase.UnitTests/Query/QueryResultExtensionsTests.cs
+++ b/tests/Couchbase.UnitTests/Query/QueryResultExtensionsTests.cs
@@ -172,4 +172,53 @@ public class QueryResultExtensionsTests
         Assert.Equal(2120, error.Code);
         Assert.Equal(serverMessage, error.Message);
     }
+
+    [Theory]
+    // "msg" and "reason" are both optional in the server's error payload - the fixture in
+    // Test_QueryContext_UnknownParameter shows a real response carrying "reason": null. Mapping must fall
+    // through to the code-only result rather than throwing an NRE while building the exception, which would
+    // replace the server's error with a meaningless one.
+    [InlineData(null, null)]
+    [InlineData("Some DML failure the SDK has no special mapping for", null)]
+    [InlineData(null, 99999)]
+    public void Test_Missing_Message_And_Reason_Do_Not_Throw(string message, int? reasonCode)
+    {
+        List<Error> errors = new()
+        {
+            new Error
+            {
+                Code = 12009,
+                Message = message,
+                Reason = reasonCode.HasValue ? new Reason { Code = reasonCode.Value } : null,
+                Severity = 0,
+                Retry = false
+            }
+        };
+
+        var mockQueryResult = new Mock<IQueryResult<object>>(MockBehavior.Strict);
+        mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
+        var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, new QueryErrorContext());
+        Assert.IsAssignableFrom<DmlFailureException>(ex);
+    }
+
+    [Fact]
+    public void Test_Reason_Code_Still_Maps_When_Message_Is_Null()
+    {
+        List<Error> errors = new()
+        {
+            new Error
+            {
+                Code = 12009,
+                Message = null,
+                Reason = new Reason { Code = 17014 },
+                Severity = 0,
+                Retry = false
+            }
+        };
+
+        var mockQueryResult = new Mock<IQueryResult<object>>(MockBehavior.Strict);
+        mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
+        var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, new QueryErrorContext());
+        Assert.IsAssignableFrom<DocumentNotFoundException>(ex);
+    }
 }

--- a/tests/Couchbase.UnitTests/Query/QueryResultExtensionsTests.cs
+++ b/tests/Couchbase.UnitTests/Query/QueryResultExtensionsTests.cs
@@ -2,6 +2,7 @@ using Couchbase.Core.Exceptions.KeyValue;
 using Couchbase.Core.Exceptions.Query;
 using Couchbase.Core.IO.Operations;
 using System.Collections.Generic;
+using System.Net;
 using System.Text.Json;
 using Couchbase.Core.Exceptions;
 using Couchbase.Query;
@@ -72,5 +73,103 @@ public class QueryResultExtensionsTests
         mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
         var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, new QueryErrorContext());
         Assert.IsAssignableFrom<IndexNotFoundException>(ex);
+    }
+
+    [Theory]
+    // Error range 10xxx, per RFC 58.
+    [InlineData(10000, "User does not have credentials to run queries")]
+    [InlineData(10999, "User does not have credentials to run queries")]
+    [InlineData(13014, "Unable to authorize user")]
+    // Code 2120, added in RFC 58 revision 21. The message must not be taken into account.
+    [InlineData(2120, "Error authorizing against cluster cause: Failure to authenticate user")]
+    [InlineData(2120, "Error authorizing against cluster")]
+    [InlineData(2120, null)]
+    public void Test_AuthenticationFailure_Codes(int code, string message)
+    {
+        List<Error> errors = new()
+        {
+            new Error
+            {
+                Code = code,
+                Message = message,
+                Severity = 0,
+                Retry = false
+            }
+        };
+
+        var mockQueryResult = new Mock<IQueryResult<object>>(MockBehavior.Strict);
+        mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
+        var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, new QueryErrorContext());
+        Assert.IsAssignableFrom<AuthenticationFailureException>(ex);
+    }
+
+    [Theory]
+    // 2120 is the *only* admin code that maps to AuthenticationFailure; RFC 58 revision 21 added the
+    // single code, not the 2xxx range. These are its real neighbours in the admin family, plus the
+    // codes either side of it, so widening the check to a range would fail here.
+    [InlineData(2110, "Error creating metric")]
+    [InlineData(2119, "Unassigned admin code")]
+    [InlineData(2121, "Unassigned admin code")]
+    [InlineData(2130, "The admin endpoint encountered an error.")]
+    public void Test_Adjacent_Admin_Codes_Are_Not_AuthenticationFailure(int code, string message)
+    {
+        List<Error> errors = new()
+        {
+            new Error
+            {
+                Code = code,
+                Message = message,
+                Severity = 0,
+                Retry = false
+            }
+        };
+
+        var mockQueryResult = new Mock<IQueryResult<object>>(MockBehavior.Strict);
+        mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
+        var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, new QueryErrorContext());
+
+        // Exact type, not IsAssignableFrom: every mapped exception derives from CouchbaseException, so
+        // IsAssignableFrom would still pass if these codes were mis-mapped to AuthenticationFailure.
+        Assert.IsType<CouchbaseException>(ex);
+    }
+
+    [Fact]
+    public void Test_AuthenticationFailure_Preserves_Server_Explanation()
+    {
+        // A locked account is reported as code 2120; the server's explanation is the only way the user can
+        // tell why authentication failed, so it must survive into the exception. See NCBC-3962.
+        const string serverMessage = "Error authorizing against cluster cause: Failure to authenticate user";
+
+        List<Error> errors = new()
+        {
+            new Error
+            {
+                Code = 2120,
+                Message = serverMessage,
+                Severity = 0,
+                Retry = false
+            }
+        };
+
+        // QueryClient composes the context message as "{msg} [{code}]" from the first error.
+        QueryErrorContext errorContext = new()
+        {
+            Statement = "SELECT 1;",
+            Message = $"{serverMessage} [2120]",
+            Errors = errors,
+            HttpStatus = HttpStatusCode.Unauthorized,
+            QueryStatus = QueryStatus.Fatal
+        };
+
+        var mockQueryResult = new Mock<IQueryResult<object>>(MockBehavior.Strict);
+        mockQueryResult.Setup(qr => qr.Errors).Returns(errors);
+        var ex = QueryResultExtensions.CreateExceptionForError(mockQueryResult.Object, errorContext);
+
+        Assert.IsAssignableFrom<AuthenticationFailureException>(ex);
+        Assert.Contains(serverMessage, ex.Message);
+        Assert.Same(errorContext, ex.Context);
+        var error = Assert.Single(Assert.IsType<QueryErrorContext>(ex.Context).Errors);
+        Assert.Equal(2120, error.Code);
+        Assert.Equal(serverMessage, error.Message);
     }
 }


### PR DESCRIPTION
Motivation
==========
This does come up occasionally, and we were only handling as an
auth error in some circumstances.   Lets always consider it an
auth error.

Modification
============
We made the conditional throw not conditional on the messaging that
came with the error.   Added tests

Note I modified the proto file (as did jvm).  This allows us to stage this for testing but ideally the underlying proto repo gets the update, then we pull that in via the script.

Results
======
All tests pass.