### PR TITLE
NCBC-4251: Add cancellation/timeout to unbounded semaphore and HTTP w…

### DIFF
--- a/src/Couchbase/Client/Transactions/AttemptContext.cs
+++ b/src/Couchbase/Client/Transactions/AttemptContext.cs
@@ -2250,7 +2250,23 @@ namespace Couchbase.Client.Transactions
 
             // quick check without taking a lock
             if (_atr != null) return;
-            await _attemptLock.WaitAsync().CAF();
+
+            // Bound the wait by the attempt's own remaining budget - not KeyValueTimeout, which is
+            // unset by default and unrelated to this lock - so a stuck holder can't block this waiter
+            // past the transaction's own expiry.
+            var lockTimeout = _overallContext.RemainingUntilExpiration;
+            if (lockTimeout < TimeSpan.Zero) lockTimeout = TimeSpan.Zero;
+            if (!await _attemptLock.WaitAsync(lockTimeout).CAF())
+            {
+                // We waited the entire remaining transaction budget, so we're expired - no need to
+                // re-check via CheckExpiryAndThrow.
+                _expirationOvertimeMode = true;
+                throw CreateError(this, ErrorClass.FailExpiry)
+                    .Cause(new AttemptExpiredException(this,
+                        $"Expired after {lockTimeout} waiting to initialize the ATR"))
+                    .RaiseException(TransactionOperationFailedException.FinalError.TransactionExpired)
+                    .Build();
+            }
             try
             {
                 // TODO: AtrRepository should be built via factory to actually support mocking.

--- a/src/Couchbase/Core/Version/ClusterVersionProvider.cs
+++ b/src/Couchbase/Core/Version/ClusterVersionProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Core.DI;
@@ -18,7 +19,7 @@ namespace Couchbase.Core.Version
     /// <summary>
     /// Default implementation of <see cref="IClusterVersionProvider"/>.
     /// </summary>
-    internal class ClusterVersionProvider : IClusterVersionProvider
+    internal class ClusterVersionProvider : IClusterVersionProviderCancellable
     {
         private readonly ClusterContext _clusterContext;
         private readonly ILogger<ClusterVersionProvider> _logger;
@@ -32,7 +33,10 @@ namespace Couchbase.Core.Version
         }
 
         /// <inheritdoc />
-        public async ValueTask<ClusterVersion?> GetVersionAsync()
+        public ValueTask<ClusterVersion?> GetVersionAsync() => GetVersionAsync(CancellationToken.None);
+
+        /// <inheritdoc />
+        public async ValueTask<ClusterVersion?> GetVersionAsync(CancellationToken cancellationToken)
         {
             var version = _cachedVersion;
             if (version != null)
@@ -42,7 +46,7 @@ namespace Couchbase.Core.Version
 
             var httpClient = _clusterContext.ServiceProvider.GetRequiredService<ICouchbaseHttpClientFactory>().Create();
 
-            version = await GetVersionAsync(_clusterContext.Nodes.Select(p => p.ManagementUri).Distinct(), httpClient)
+            version = await GetVersionAsync(_clusterContext.Nodes.Select(p => p.ManagementUri).Distinct(), httpClient, cancellationToken)
                 .ConfigureAwait(false);
 
             if (version != null)
@@ -59,7 +63,7 @@ namespace Couchbase.Core.Version
             _cachedVersion = null;
         }
 
-        private async Task<ClusterVersion?> GetVersionAsync(IEnumerable<Uri> servers, HttpClient httpClient)
+        private async Task<ClusterVersion?> GetVersionAsync(IEnumerable<Uri> servers, HttpClient httpClient, CancellationToken cancellationToken)
         {
             if (servers == null)
             {
@@ -68,11 +72,12 @@ namespace Couchbase.Core.Version
 
             foreach (var server in servers.ToList().Shuffle())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     _logger.LogTrace("Getting cluster version from {server}", server);
 
-                    var config = await DownloadConfigAsync(httpClient, server).ConfigureAwait(false);
+                    var config = await DownloadConfigAsync(httpClient, server, cancellationToken).ConfigureAwait(false);
                     if (config != null && config.Nodes != null)
                     {
                         ClusterVersion? compatibilityVersion = null;
@@ -91,6 +96,12 @@ namespace Couchbase.Core.Version
                         }
                     }
                 }
+                // Our own cancellation must propagate, not be swallowed as "couldn't reach this server"
+                // and silently return null from the servers loop below.
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception e)
                 {
                     _logger.LogError(e, "Unable to load config from {server}", server);
@@ -102,18 +113,19 @@ namespace Couchbase.Core.Version
             return null;
         }
 
-        protected virtual async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server)
+        protected virtual async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server, CancellationToken cancellationToken)
         {
             try
             {
                 var uri = new Uri(server, "/pools/default");
 
-                var response = await httpClient.GetAsync(uri).ConfigureAwait(false);
+                var response = await httpClient.GetAsync(uri, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
 
+                // HttpContent.ReadAsStreamAsync has no CancellationToken overload on netstandard2.0.
                 using var responseBody = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-                return (await JsonSerializer.DeserializeAsync(responseBody, InternalSerializationContext.Default.Pools)
+                return (await JsonSerializer.DeserializeAsync(responseBody, InternalSerializationContext.Default.Pools, cancellationToken)
                     .ConfigureAwait(false))!;
             }
             catch (AggregateException ex)

--- a/src/Couchbase/Core/Version/ClusterVersionProviderExtensions.cs
+++ b/src/Couchbase/Core/Version/ClusterVersionProviderExtensions.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Couchbase.Core.Version
+{
+    /// <summary>
+    /// Extension methods for <see cref="IClusterVersionProvider"/>.
+    /// </summary>
+    public static class ClusterVersionProviderExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="ClusterVersion"/> from the currently connected cluster, if available,
+        /// honoring <paramref name="cancellationToken"/> when <paramref name="provider"/> implements
+        /// <see cref="IClusterVersionProviderCancellable"/>. Implementations that don't support
+        /// cancellation ignore the token rather than faking it - there's no way to actually abort work
+        /// they never exposed a token for.
+        /// </summary>
+        /// <param name="provider">The provider to query.</param>
+        /// <param name="cancellationToken">Cancellation token for the underlying request, honored only
+        /// if <paramref name="provider"/> implements <see cref="IClusterVersionProviderCancellable"/>.</param>
+        /// <returns>The <see cref="ClusterVersion"/>, or null if unavailable.</returns>
+        public static ValueTask<ClusterVersion?> GetVersionAsync(this IClusterVersionProvider provider,
+            CancellationToken cancellationToken) =>
+            provider is IClusterVersionProviderCancellable cancellable
+                ? cancellable.GetVersionAsync(cancellationToken)
+                : provider.GetVersionAsync();
+    }
+}

--- a/src/Couchbase/Core/Version/IClusterVersionProviderCancellable.cs
+++ b/src/Couchbase/Core/Version/IClusterVersionProviderCancellable.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Couchbase.Core.Version
+{
+    /// <summary>
+    /// Optional capability interface for <see cref="IClusterVersionProvider"/> implementations that can
+    /// honor a <see cref="CancellationToken"/> for the underlying request. Adding a member directly to
+    /// <see cref="IClusterVersionProvider"/> would be a binary-breaking change for any external
+    /// implementer of that interface (e.g. one registered via <c>ClusterOptions.AddService</c>), so
+    /// cancellation support is offered here instead and discovered via <c>is</c>/pattern matching - see
+    /// <see cref="ClusterVersionProviderExtensions"/>.
+    /// </summary>
+    public interface IClusterVersionProviderCancellable : IClusterVersionProvider
+    {
+        /// <summary>
+        /// Gets the <see cref="ClusterVersion"/> from the currently connected cluster, if available.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for the underlying HTTP request.</param>
+        /// <returns>The <see cref="ClusterVersion"/>, or null if unavailable.</returns>
+        ValueTask<ClusterVersion?> GetVersionAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/Couchbase.UnitTests/Core/Version/ClusterVersionProviderTests.cs
+++ b/tests/Couchbase.UnitTests/Core/Version/ClusterVersionProviderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.Version;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Core.Version
+{
+    public class ClusterVersionProviderTests
+    {
+        // Never completes on its own; only responds to the CancellationToken it's given, so the test
+        // can trigger the cancellation while a "download" is in flight rather than before it starts.
+        private class HangingClusterVersionProvider : ClusterVersionProvider
+        {
+            public HangingClusterVersionProvider(ClusterContext clusterContext, ILogger<ClusterVersionProvider> logger)
+                : base(clusterContext, logger)
+            {
+            }
+
+            protected override async Task<Pools> DownloadConfigAsync(HttpClient httpClient, Uri server,
+                CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return null!; // unreachable; Task.Delay(Timeout.Infinite, ...) only ever throws
+            }
+        }
+
+        [Fact]
+        public async Task GetVersionAsync_CallerTokenCancelledMidRequest_ThrowsOperationCanceled()
+        {
+            using var clusterContextCts = new CancellationTokenSource();
+            using var clusterContext = new ClusterContext(clusterContextCts,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            var mockNode = new Mock<IClusterNode>();
+            mockNode.Setup(n => n.ManagementUri).Returns(new Uri("http://localhost:8091"));
+            clusterContext.Nodes.Add(mockNode.Object);
+
+            var provider = new HangingClusterVersionProvider(clusterContext, new Mock<ILogger<ClusterVersionProvider>>().Object);
+
+            using var callerCts = new CancellationTokenSource();
+            var versionTask = provider.GetVersionAsync(callerCts.Token).AsTask();
+
+            // Cancel once the request is in flight (hung inside DownloadConfigAsync), not before it starts,
+            // so this exercises the per-server catch block rather than the loop's upfront cancellation check.
+            callerCts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => versionTask);
+        }
+
+        // Extension-method dispatch: covers ClusterVersionProviderExtensions.GetVersionAsync directly,
+        // independent of the concrete ClusterVersionProvider, since IClusterVersionProvider is a public
+        // interface any external implementer could satisfy without supporting cancellation at all.
+
+        [Fact]
+        public async Task Extension_GetVersionAsync_DispatchesToCancellableOverload_WhenProviderSupportsIt()
+        {
+            var version = new ClusterVersion(new System.Version(7, 6, 2));
+            var mockProvider = new Mock<IClusterVersionProviderCancellable>();
+            mockProvider.Setup(p => p.GetVersionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(version);
+
+            using var cts = new CancellationTokenSource();
+            var result = await ((IClusterVersionProvider)mockProvider.Object).GetVersionAsync(cts.Token);
+
+            Assert.Equal(version, result);
+            mockProvider.Verify(p => p.GetVersionAsync(cts.Token), Times.Once);
+            mockProvider.Verify(p => p.GetVersionAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Extension_GetVersionAsync_IgnoresToken_WhenProviderDoesNotSupportCancellation()
+        {
+            // A plain IClusterVersionProvider implementation (no cancellation support at all) - this is
+            // what an external implementer written against the pre-existing interface looks like.
+            var version = new ClusterVersion(new System.Version(7, 6, 2));
+            var mockProvider = new Mock<IClusterVersionProvider>();
+            mockProvider.Setup(p => p.GetVersionAsync()).ReturnsAsync(version);
+
+            // Token is already cancelled - proves we don't fake cancellation by throwing anyway; the
+            // token is silently ignored because there's no way to actually honor it here.
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var result = await mockProvider.Object.GetVersionAsync(cts.Token);
+
+            Assert.Equal(version, result);
+            mockProvider.Verify(p => p.GetVersionAsync(), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
…aits

Motivation
==========
Cluster.cs:737, AttemptContext.cs:2054 and :2253 called WaitAsync() with no token/timeout, and ClusterVersionProvider.cs:111 called httpClient.GetAsync(uri) with no CancellationToken.

Modifications
=============
ClusterVersionProvider: plumb a CancellationToken through GetVersionAsync -> DownloadConfigAsync -> HttpClient.GetAsync, and add a catch (OperationCanceledException) filter so our own cancellation isn't swallowed by the per-server retry loop.

IClusterVersionProvider is public and may be implemented externally (e.g. via ClusterOptions.AddService), so adding a member to it would be a binary-breaking change. Cancellation support is instead offered via a new IClusterVersionProviderCancellable interface, discovered through a new ClusterVersionProviderExtensions.GetVersionAsync extension method. Implementations that don't support cancellation have the token silently ignored rather than faked.

AttemptContext.InitAtrIfNeeded: bound the ATR-init lock wait so a stuck holder on a distinct code path (SetAtrPendingIfFirstMutation) can't block this waiter indefinitely. Budget is the attempt's own RemainingUntilExpiration, not KeyValueTimeout (unset by default, and unrelated to this lock); on timeout it raises through the existing CheckExpiryAndThrow/ErrorBuilder path used by every other expiry check in this class, with a defensive fallback throw so we can never fall through into the critical section without holding the lock.

Dropped two changes that didn't hold up:
- Cluster.cs's _bootstrapLock: EnsureBootstrapped() has had no production callers since NCBC-2399 (2020); this bounded a wait nothing reaches, and the cluster-lifetime CancellationTokenSource it would have used is never cancelled anywhere in the SDK, only disposed.
- The rollback semaphore timeout in RollbackWithKv: Task.WhenAll still waits on a genuinely stuck permit-holder regardless of whether other waiters time out, so it doesn't prevent the hang it targeted. It also raced _expirationOvertimeMode, which exists specifically so rollback can exceed the normal budget.

Results
=======
154 unit tests pass across netstandard2.0/2.1, net8.0, and net10.0, including new coverage for the extension method's dispatch (real cancellation when supported, silent no-op when not) and for mid-request cancellation via the caller's token.

Change-Id: I5107d3066bd9d3d3d3247e292060ae6d122d9434