### PR TITLE
NCBC-4279: Stop unit tests asserting exact sizes on pooled buffers

### DIFF
--- a/tests/Couchbase.UnitTests/Core/IO/Operations/OperationBuilderTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/OperationBuilderTests.cs
@@ -494,73 +494,83 @@ namespace Couchbase.UnitTests.Core.IO.Operations
             Assert.Equal(currentCapacity, builder.Capacity);
         }
 
+        // The growth tests below assert an inequality. EnsureCapacity rents from ArrayPool and
+        // promises only that the buffer is at least as large as requested; any doubling is the
+        // pool's bucket rounding, not something OperationBuilder implements. Asserting an exact
+        // size makes these depend on pool internals, which on .NET Framework overshoot to a larger
+        // bucket when the requested one is exhausted.
+
         [Fact]
-        private void EnsureCapacity_OneMore_Doubles()
+        private void EnsureCapacity_OneMore_Grows()
         {
             // Arrange
 
             using var builder = new OperationBuilder();
-            var currentCapacity = builder.Capacity;
+            var requested = builder.Capacity + 1;
 
             // Act
 
-            builder.EnsureCapacity(currentCapacity + 1);
+            builder.EnsureCapacity(requested);
 
             // Assert
 
-            Assert.Equal(currentCapacity * 2, builder.Capacity);
+            AssertAtLeast(requested, builder.Capacity);
         }
 
         [Fact]
-        private void EnsureCapacity_Double_Doubles()
+        private void EnsureCapacity_Double_Grows()
         {
             // Arrange
 
             using var builder = new OperationBuilder();
-            var currentCapacity = builder.Capacity;
+            var requested = builder.Capacity * 2;
 
             // Act
 
-            builder.EnsureCapacity(currentCapacity * 2);
+            builder.EnsureCapacity(requested);
 
             // Assert
 
-            Assert.Equal(currentCapacity * 2, builder.Capacity);
+            AssertAtLeast(requested, builder.Capacity);
         }
 
         [Fact]
-        private void EnsureCapacity_OneMoreThanDouble_Quadruples()
+        private void EnsureCapacity_OneMoreThanDouble_Grows()
         {
             // Arrange
 
             using var builder = new OperationBuilder();
-            var currentCapacity = builder.Capacity;
+            var requested = builder.Capacity * 2 + 1;
 
             // Act
 
-            builder.EnsureCapacity(currentCapacity * 2 + 1);
+            builder.EnsureCapacity(requested);
 
             // Assert
 
-            Assert.Equal(currentCapacity * 4, builder.Capacity);
+            AssertAtLeast(requested, builder.Capacity);
         }
 
         [Fact]
-        private void EnsureCapacity_Quadruple_Quadruples()
+        private void EnsureCapacity_Quadruple_Grows()
         {
             // Arrange
 
             using var builder = new OperationBuilder();
-            var currentCapacity = builder.Capacity;
+            var requested = builder.Capacity * 4;
 
             // Act
 
-            builder.EnsureCapacity(currentCapacity * 4);
+            builder.EnsureCapacity(requested);
 
             // Assert
 
-            Assert.Equal(currentCapacity * 4, builder.Capacity);
+            AssertAtLeast(requested, builder.Capacity);
         }
+
+        private static void AssertAtLeast(int requested, int actualCapacity) =>
+            Assert.True(actualCapacity >= requested,
+                $"Expected a capacity of at least {requested}, found {actualCapacity}.");
 
         #endregion
 

--- a/tests/Couchbase.UnitTests/Utils/SlicedMemoryOwnerTests.cs
+++ b/tests/Couchbase.UnitTests/Utils/SlicedMemoryOwnerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Linq;
 using Couchbase.UnitTests.Helpers;
 using Couchbase.Utils;
@@ -9,6 +8,13 @@ namespace Couchbase.UnitTests.Utils
 {
     public class SlicedMemoryOwnerTests
     {
+        // These tests use FakeMemoryOwner rather than MemoryPool<byte>.Shared.Rent, because Rent
+        // only promises *at least* the requested size. On .NET Framework the pool falls back to a
+        // larger bucket when the requested one is exhausted, so a Rent(32) under load returns 64
+        // and every assertion below that depends on the buffer being exactly 32 bytes fails.
+        private static FakeMemoryOwner<byte> ExactlySized(int length) =>
+            new FakeMemoryOwner<byte>(new byte[length]);
+
         #region ctor1
 
         [Fact]
@@ -27,7 +33,7 @@ namespace Couchbase.UnitTests.Utils
         public void ctor1_StartOutsideRange_ArgumentOutOfRangeException(int start)
         {
             // Act/Assert
-            using (var memory = MemoryPool<byte>.Shared.Rent(32))
+            using (var memory = ExactlySized(32))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => new SlicedMemoryOwner<byte>(memory, start));
             }
@@ -40,7 +46,7 @@ namespace Couchbase.UnitTests.Utils
         public void ctor1_StartWithinRange_SliceUntilEnd(int start, int expectedLength)
         {
             // Act/Assert
-            using (var memory = new SlicedMemoryOwner<byte>(MemoryPool<byte>.Shared.Rent(32), start))
+            using (var memory = new SlicedMemoryOwner<byte>(ExactlySized(32), start))
             {
                 Assert.Equal(expectedLength, memory.Memory.Length);
             }
@@ -82,7 +88,7 @@ namespace Couchbase.UnitTests.Utils
         public void ctor2_NegativeStart_ArgumentOutOfRangeException()
         {
             // Act/Assert
-            using (var memory = MemoryPool<byte>.Shared.Rent(32))
+            using (var memory = ExactlySized(32))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => new SlicedMemoryOwner<byte>(memory, -1, 10));
             }
@@ -96,7 +102,7 @@ namespace Couchbase.UnitTests.Utils
         public void ctor2_StartOutsideRange_ArgumentOutOfRangeException(int start)
         {
             // Act/Assert
-            using (var memory = MemoryPool<byte>.Shared.Rent(32))
+            using (var memory = ExactlySized(32))
             {
                 Assert.Throws<ArgumentOutOfRangeException>(() => new SlicedMemoryOwner<byte>(memory, start, 1));
             }
@@ -109,7 +115,7 @@ namespace Couchbase.UnitTests.Utils
         public void ctor2_StartWithinRange_SliceLength(int start, int length)
         {
             // Act/Assert
-            using (var memory = new SlicedMemoryOwner<byte>(MemoryPool<byte>.Shared.Rent(32), start, length))
+            using (var memory = new SlicedMemoryOwner<byte>(ExactlySized(32), start, length))
             {
                 Assert.Equal(length, memory.Memory.Length);
             }


### PR DESCRIPTION
## Motivation

Five tests in `SlicedMemoryOwnerTests` fail intermittently on **net48 only**, most recently the 2026-08-08 nightly ([run 31243388414](https://github.com/couchbase/couchbase-net-client/actions/runs/31243388414)), where `windows-2025/net48` went red with `Failed: 5, Passed: 2769` while the other 17 legs — including `windows-2022/net48` on the same commit — passed.

| Test | Expected | Actual |
|---|---|---|
| `ctor1_StartWithinRange_SliceUntilEnd(0, 32)` | 32 | 64 |
| `ctor1_StartWithinRange_SliceUntilEnd(10, 22)` | 22 | 54 |
| `ctor1_StartWithinRange_SliceUntilEnd(31, 1)` | 1 | 33 |
| `ctor1_StartOutsideRange_ArgumentOutOfRangeException(33)` | throws | no throw |
| `ctor2_StartOutsideRange_ArgumentOutOfRangeException(32)` | throws | no throw |

The tests are wrong, not `SlicedMemoryOwner`. Each calls `MemoryPool<byte>.Shared.Rent(32)` and then assumes it got exactly 32 bytes, but `Rent(minBufferSize)` promises only *at least* that many. Given a 64-byte buffer, `_length = memory.Length - start` yields 64/54/33, and `start=33` is genuinely in range so the guard correctly does not throw. `SlicedMemoryOwner`'s own summary says as much — it exists because a pool "may return a larger array of memory than desired".

net48 alone because .NET Framework's shared pool searches the next couple of buckets and hands back a 64-byte array when the 32 bucket is exhausted, where Core's allocates exactly the bucket size. That makes the failure load-dependent — hence one Windows image and not the other, and hence it survived the per-TFM job split in `nightly-unit-tests.yml`: that split removed contention *between* TFMs, but xUnit still runs collections in parallel within the single net48 process.

Sweeping the test tree for the same pattern turned up one other site. Four `EnsureCapacity` tests in `OperationBuilderTests` assert `Capacity` doubles or quadruples, but `Capacity` returns the length of a buffer rented from `ArrayPool` (`OperationBuilder.cs:71`, `:521`), so they assert the pool's bucket rounding. `OperationBuilder` implements no growth logic at all — `EnsureCapacity` just calls `Rent(capacity)`, and its own `Debug.Assert(_buffer.Length >= capacity)` (`:535`) states the real contract. These have not failed yet, the 16KB+ buckets being far less contended than the 32-byte one, but the defect is identical.

## Modification

**`SlicedMemoryOwnerTests`** — replace every `MemoryPool<byte>.Shared.Rent(32)` with a private `ExactlySized(int)` helper returning a `FakeMemoryOwner<byte>` over a plain `byte[]`, the same helper the `..._SliceStart` tests in this file already use. Two tests that cannot fail today are converted as well: leaving `Rent` in the file invites the pattern into a test where it does matter.

**`OperationBuilderTests`** — assert capacity is at least what was requested, and rename `_Doubles`/`_Quadruples` to `_Grows` to match. The three `_NoChange` tests are untouched; they exercise the no-grow path and are already immune.

**No production code changes.**

## Results

All 84 tests across the two classes pass on net8.0 locally.

net48 cannot be built on macOS — `Directory.Build.props` adds it to `SdkTestTargets` only on Windows — so the local run shows the rewrites are behaviour-preserving but cannot show the flake is gone, net8.0 having never flaked. The argument is structural: neither class now reads a pooled buffer's length. Note the PR gate runs a single `windows-latest` net48 leg, so a green run here is not proof either, the failure being load-dependent; the nightly's `windows-2025` and `windows-2022` net48 legs are the real signal over the next few days.

The rest of the test tree is clean. Remaining `MemoryPool` uses all go through `RentAndSlice`, which slices to the exact requested length (`MemoryPoolExtensionsTests.RentAndSlice_RequestLength_ReturnsExactlyThatLength` is the regression test for this hazard). `GetBuffer()` is likewise sliced to the written length. `GetMemory()`/`GetSpan()` do return a pool-dependent length, but every test uses them purely as a write target and no test asserts on it.

Not addressed here: the 2026-08-06 nightly failure ([run 31078666014](https://github.com/couchbase/couchbase-net-client/actions/runs/31078666014), `ubuntu-24.04/net10.0`) is unrelated — all 2844 tests passed and `--blame-hang` then killed the host, blaming Stellar `CollectionTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
