### PR TITLE
NCBC-4282: Improve WaitUntilReady to follow RFC

### DIFF
--- a/src/Couchbase/Cluster.cs
+++ b/src/Couchbase/Cluster.cs
@@ -410,64 +410,32 @@ namespace Couchbase
             CancellationToken token = ctps.Token;
 
             var bootstrappable = (IBootstrappable)this;
-            var backoff = new WaitUntilReadyBackoff();
             try
             {
-                while (true)
-                {
-                    token.ThrowIfCancellationRequested();
-
-                    if (!IsBootstrapped)
+                await WaitUntilReadyEvaluator.PollAsync(_context, options, bucketLevel: false,
+                    () => _context.GlobalConfig,
+                    async cancellationToken =>
                     {
-                        // Don't forward the cancellation token to BootStrapAsync here, otherwise we could leave
-                        // the cluster object in an odd state. Instead, just stop waiting if the token is canceled.
-                        await bootstrappable.BootStrapAsync().WaitAsync(token).ConfigureAwait(false);
                         if (!IsBootstrapped)
                         {
-                            await Task.Delay(100, token).ConfigureAwait(false);
-                            continue;
-                        }
-                    }
-
-                    if (!_context.IsGlobal)
-                        throw new NotSupportedException(
-                            "Cluster level WaitUntilReady is only supported by Couchbase Server 6.5 or greater. " +
-                            "If you think this exception is caused by another error, please check your SDK logs for detail.");
-
-                    // Recomputed every pass because the topology can change while we wait.
-                    var requested = options.EffectiveServiceTypes(_context).ToList();
-                    var expected = WaitUntilReadyEvaluator.ExpectedServices(_context, null, requested, bucketLevel: false);
-
-                    if (expected.Count == 0)
-                    {
-                        LogWaitUntilReadyNoServices(string.Join(", ", requested));
-                    }
-
-                    // Ping only what we evaluate, otherwise every pass pays for a service we ignore.
-                    var pingReport =
-                        await DiagnosticsReportProvider.CreatePingReportAsync(_context, _context.GlobalConfig,
-                            new PingOptions
+                            // Don't forward the cancellation token to BootStrapAsync here, otherwise we could leave
+                            // the cluster object in an odd state. Instead, just stop waiting if the token is canceled.
+                            await bootstrappable.BootStrapAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+                            if (!IsBootstrapped)
                             {
-                                ServiceTypesValue = expected.ToList(),
-                                Token = token
-                            }).ConfigureAwait(false);
+                                return false;
+                            }
+                        }
 
-                    var readiness = WaitUntilReadyEvaluator.Evaluate(pingReport, expected, options.DesiredStateValue);
-                    _clusterState = readiness.State;
+                        if (!_context.IsGlobal)
+                            throw new NotSupportedException(
+                                "Cluster level WaitUntilReady is only supported by Couchbase Server 6.5 or greater. " +
+                                "If you think this exception is caused by another error, please check your SDK logs for detail.");
 
-                    if (readiness.Ready)
-                    {
-                        return;
-                    }
-
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        LogWaitUntilReadyStillWaiting(readiness.State, options.DesiredStateValue,
-                            WaitUntilReadyEvaluator.Describe(pingReport, expected));
-                    }
-
-                    await backoff.DelayAsync(token).ConfigureAwait(false);
-                }
+                        return true;
+                    },
+                    state => _clusterState = state,
+                    _logger, token).ConfigureAwait(false);
             }
             catch (RateLimitedException)
             {
@@ -822,12 +790,6 @@ namespace Couchbase
 
         [LoggerMessage(LogLevel.Warning, "Exception in AuthenticationStale event handler for connection {connectionId}")]
         partial void LogExceptionInAuthStaleEventHandlerForConnectionId(Exception ex, ulong connectionId);
-
-        [LoggerMessage(LogLevel.Debug, "WaitUntilReady is {state} but wants {desiredState}, services: {services}")]
-        partial void LogWaitUntilReadyStillWaiting(ClusterState state, ClusterState desiredState, string services);
-
-        [LoggerMessage(LogLevel.Warning, "WaitUntilReady has no verifiable service from the requested set {requested}, returning immediately")]
-        partial void LogWaitUntilReadyNoServices(string requested);
 
         #endregion
     }

--- a/src/Couchbase/Cluster.cs
+++ b/src/Couchbase/Cluster.cs
@@ -403,12 +403,14 @@ namespace Couchbase
 
             options ??= new WaitUntilReadyOptions();
             if(options.DesiredStateValue == ClusterState.Offline)
-                throw new ArgumentException(nameof(options.DesiredStateValue));
+                throw new InvalidArgumentException(
+                    $"{nameof(ClusterState.Offline)} is not a valid desired state for WaitUntilReady.");
 
             using var ctps = CancellationTokenPairSourcePool.Shared.Rent(timeout, options.CancellationTokenValue);
             CancellationToken token = ctps.Token;
 
             var bootstrappable = (IBootstrappable)this;
+            var backoff = new WaitUntilReadyBackoff();
             try
             {
                 while (true)
@@ -432,39 +434,39 @@ namespace Couchbase
                             "Cluster level WaitUntilReady is only supported by Couchbase Server 6.5 or greater. " +
                             "If you think this exception is caused by another error, please check your SDK logs for detail.");
 
+                    // Recomputed every pass because the topology can change while we wait.
+                    var requested = options.EffectiveServiceTypes(_context).ToList();
+                    var expected = WaitUntilReadyEvaluator.ExpectedServices(_context, null, requested, bucketLevel: false);
+
+                    if (expected.Count == 0)
+                    {
+                        LogWaitUntilReadyNoServices(string.Join(", ", requested));
+                    }
+
+                    // Ping only what we evaluate, otherwise every pass pays for a service we ignore.
                     var pingReport =
                         await DiagnosticsReportProvider.CreatePingReportAsync(_context, _context.GlobalConfig,
                             new PingOptions
                             {
-                                ServiceTypesValue = options.EffectiveServiceTypes(_context).ToList()
+                                ServiceTypesValue = expected.ToList(),
+                                Token = token
                             }).ConfigureAwait(false);
 
-                    var status = new Dictionary<string, bool>();
-                    foreach (var service in pingReport.Services)
-                    {
-                        var failures = service.Value.Any(x => x.State != ServiceState.Ok);
-                        if (failures)
-                        {
-                            //mark a service as failed
-                            status.Add(service.Key, failures);
-                        }
-                    }
+                    var readiness = WaitUntilReadyEvaluator.Evaluate(pingReport, expected, options.DesiredStateValue);
+                    _clusterState = readiness.State;
 
-                    //everything is up
-                    if (status.Count == 0)
-                    {
-                        _clusterState = ClusterState.Online;
-                        return;
-                    }
-
-                    //determine if completely offline or degraded
-                    _clusterState = status.Count == pingReport.Services.Count ? ClusterState.Offline : ClusterState.Degraded;
-                    if(_clusterState == options.DesiredStateValue)
+                    if (readiness.Ready)
                     {
                         return;
                     }
 
-                    await Task.Delay(100, token).ConfigureAwait(false);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        LogWaitUntilReadyStillWaiting(readiness.State, options.DesiredStateValue,
+                            WaitUntilReadyEvaluator.Describe(pingReport, expected));
+                    }
+
+                    await backoff.DelayAsync(token).ConfigureAwait(false);
                 }
             }
             catch (RateLimitedException)
@@ -820,6 +822,12 @@ namespace Couchbase
 
         [LoggerMessage(LogLevel.Warning, "Exception in AuthenticationStale event handler for connection {connectionId}")]
         partial void LogExceptionInAuthStaleEventHandlerForConnectionId(Exception ex, ulong connectionId);
+
+        [LoggerMessage(LogLevel.Debug, "WaitUntilReady is {state} but wants {desiredState}, services: {services}")]
+        partial void LogWaitUntilReadyStillWaiting(ClusterState state, ClusterState desiredState, string services);
+
+        [LoggerMessage(LogLevel.Warning, "WaitUntilReady has no verifiable service from the requested set {requested}, returning immediately")]
+        partial void LogWaitUntilReadyNoServices(string requested);
 
         #endregion
     }

--- a/src/Couchbase/Core/BucketBase.cs
+++ b/src/Couchbase/Core/BucketBase.cs
@@ -223,7 +223,7 @@ namespace Couchbase.Core
             {
                 await WaitUntilReadyEvaluator.PollAsync(Context, options, bucketLevel: true,
                     () => CurrentConfig,
-                    _ => new ValueTask<bool>(true),
+                    _ => new ValueTask<bool>(WaitUntilReadyEvaluator.HasTopology(CurrentConfig, Context.GetNodes(Name))),
                     state => _clusterState = state,
                     _logger, token).ConfigureAwait(false);
             }

--- a/src/Couchbase/Core/BucketBase.cs
+++ b/src/Couchbase/Core/BucketBase.cs
@@ -205,53 +205,60 @@ namespace Couchbase.Core
         /// <param name="options">The optional arguments.</param>
         public async Task WaitUntilReadyAsync(TimeSpan timeout, WaitUntilReadyOptions? options = null)
         {
+            if (timeout <= TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            {
+                // Already timed out
+                throw new UnambiguousTimeoutException($"Timed out after {timeout}.");
+            }
+
             options ??= new WaitUntilReadyOptions();
             if (options.DesiredStateValue == ClusterState.Offline)
-                throw new ArgumentException(nameof(options.DesiredStateValue));
+                throw new InvalidArgumentException(
+                    $"{nameof(ClusterState.Offline)} is not a valid desired state for WaitUntilReady.");
 
             using var ctsp = CancellationTokenPairSourcePool.Shared.Rent(timeout, options.CancellationTokenValue);
             var token = ctsp.Token;
 
+            var backoff = new WaitUntilReadyBackoff();
             try
             {
                 while (true)
                 {
                     token.ThrowIfCancellationRequested();
 
+                    // Recomputed every pass because the topology can change while we wait.
+                    var requested = options.EffectiveServiceTypes(Context).ToList();
+                    var expected = WaitUntilReadyEvaluator.ExpectedServices(Context, CurrentConfig, requested, bucketLevel: true);
+
+                    if (expected.Count == 0)
+                    {
+                        LogWaitUntilReadyNoServices(string.Join(", ", requested));
+                    }
+
+                    // Ping only what we evaluate, otherwise every pass pays for a service we ignore.
                     var pingReport =
                         await DiagnosticsReportProvider.CreatePingReportAsync(Context, CurrentConfig,
                             new PingOptions
                             {
-                                ServiceTypesValue = options.EffectiveServiceTypes(Context).ToList(),
+                                ServiceTypesValue = expected.ToList(),
                                 Token = token,
                             }).ConfigureAwait(false);
 
-                    var status = new Dictionary<string, bool>();
-                    foreach (var service in pingReport.Services)
-                    {
-                        var failures = service.Value.Any(x => x.State != ServiceState.Ok);
-                        if (failures)
-                        {
-                            //mark a service as failed
-                            status.Add(service.Key, failures);
-                        }
-                    }
+                    var readiness = WaitUntilReadyEvaluator.Evaluate(pingReport, expected, options.DesiredStateValue);
+                    _clusterState = readiness.State;
 
-                    //everything is up
-                    if (status.Count == 0)
-                    {
-                        _clusterState = ClusterState.Online;
-                        return;
-                    }
-
-                    //determine if completely offline or degraded
-                    _clusterState = status.Count == pingReport.Services.Count ? ClusterState.Offline : ClusterState.Degraded;
-                    if (_clusterState == options.DesiredStateValue)
+                    if (readiness.Ready)
                     {
                         return;
                     }
 
-                    await Task.Delay(100, token).ConfigureAwait(false);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        LogWaitUntilReadyStillWaiting(readiness.State, options.DesiredStateValue,
+                            WaitUntilReadyEvaluator.Describe(pingReport, expected));
+                    }
+
+                    await backoff.DelayAsync(token).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException e)
@@ -361,6 +368,12 @@ namespace Couchbase.Core
 
         [LoggerMessage(100, LogLevel.Debug, "Disposing bucket [{name}]!")]
         private partial void LogDispose(Redacted<string> name);
+
+        [LoggerMessage(101, LogLevel.Debug, "WaitUntilReady is {state} but wants {desiredState}, services: {services}")]
+        private partial void LogWaitUntilReadyStillWaiting(ClusterState state, ClusterState desiredState, string services);
+
+        [LoggerMessage(102, LogLevel.Warning, "WaitUntilReady has no verifiable service from the requested set {requested}, returning immediately")]
+        private partial void LogWaitUntilReadyNoServices(string requested);
 
         #endregion
     }

--- a/src/Couchbase/Core/BucketBase.cs
+++ b/src/Couchbase/Core/BucketBase.cs
@@ -219,47 +219,13 @@ namespace Couchbase.Core
             using var ctsp = CancellationTokenPairSourcePool.Shared.Rent(timeout, options.CancellationTokenValue);
             var token = ctsp.Token;
 
-            var backoff = new WaitUntilReadyBackoff();
             try
             {
-                while (true)
-                {
-                    token.ThrowIfCancellationRequested();
-
-                    // Recomputed every pass because the topology can change while we wait.
-                    var requested = options.EffectiveServiceTypes(Context).ToList();
-                    var expected = WaitUntilReadyEvaluator.ExpectedServices(Context, CurrentConfig, requested, bucketLevel: true);
-
-                    if (expected.Count == 0)
-                    {
-                        LogWaitUntilReadyNoServices(string.Join(", ", requested));
-                    }
-
-                    // Ping only what we evaluate, otherwise every pass pays for a service we ignore.
-                    var pingReport =
-                        await DiagnosticsReportProvider.CreatePingReportAsync(Context, CurrentConfig,
-                            new PingOptions
-                            {
-                                ServiceTypesValue = expected.ToList(),
-                                Token = token,
-                            }).ConfigureAwait(false);
-
-                    var readiness = WaitUntilReadyEvaluator.Evaluate(pingReport, expected, options.DesiredStateValue);
-                    _clusterState = readiness.State;
-
-                    if (readiness.Ready)
-                    {
-                        return;
-                    }
-
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        LogWaitUntilReadyStillWaiting(readiness.State, options.DesiredStateValue,
-                            WaitUntilReadyEvaluator.Describe(pingReport, expected));
-                    }
-
-                    await backoff.DelayAsync(token).ConfigureAwait(false);
-                }
+                await WaitUntilReadyEvaluator.PollAsync(Context, options, bucketLevel: true,
+                    () => CurrentConfig,
+                    _ => new ValueTask<bool>(true),
+                    state => _clusterState = state,
+                    _logger, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException e)
             {
@@ -368,12 +334,6 @@ namespace Couchbase.Core
 
         [LoggerMessage(100, LogLevel.Debug, "Disposing bucket [{name}]!")]
         private partial void LogDispose(Redacted<string> name);
-
-        [LoggerMessage(101, LogLevel.Debug, "WaitUntilReady is {state} but wants {desiredState}, services: {services}")]
-        private partial void LogWaitUntilReadyStillWaiting(ClusterState state, ClusterState desiredState, string services);
-
-        [LoggerMessage(102, LogLevel.Warning, "WaitUntilReady has no verifiable service from the requested set {requested}, returning immediately")]
-        private partial void LogWaitUntilReadyNoServices(string requested);
 
         #endregion
     }

--- a/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
+++ b/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
@@ -5,18 +5,14 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
-using Couchbase.Analytics;
 using Couchbase.Core;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Core.DI;
-using Couchbase.Core.Exceptions;
 using Couchbase.Core.Exceptions.View;
 using Couchbase.Core.IO.Connections;
+using Couchbase.Core.IO.HTTP;
 using Couchbase.Core.IO.Operations;
 using Couchbase.Core.RateLimiting;
-using Couchbase.Query;
-using Couchbase.Search;
-using Couchbase.Search.Queries;
 using Couchbase.Views;
 
 #nullable enable
@@ -27,6 +23,10 @@ namespace Couchbase.Diagnostics
     {
         internal const string UnknownEndpointValue = "Unknown";
         private const long TicksPerMicrosecond = 10;
+
+        // Health endpoints of the HTTP services, same paths the other SDKs ping.
+        internal const string AdminPingPath = "/admin/ping";
+        internal const string SearchPingPath = "/api/ping";
 
         private static readonly ServiceType[] AllServiceTypes =
         {
@@ -68,6 +68,10 @@ namespace Couchbase.Diagnostics
 
             IOperationConfigurator? operationConfigurator = ping
                 ? context.ServiceProvider.GetRequiredService<IOperationConfigurator>()
+                : null;
+
+            ICouchbaseHttpClientFactory? httpClientFactory = ping
+                ? context.ServiceProvider.GetRequiredService<ICouchbaseHttpClientFactory>()
                 : null;
 
             var pingTasks = new List<Task>();
@@ -141,83 +145,22 @@ namespace Couchbase.Diagnostics
 
             foreach (var clusterNode in clusterNodes)
             {
-                if (serviceTypes.Contains(ServiceType.Query) && clusterNode.HasQuery &&
-                    context.ServiceProvider.IsService<IQueryClient>())
+                if (serviceTypes.Contains(ServiceType.Query) && clusterNode.HasQuery)
                 {
-                    var kvEndpoints = (List<IEndpointDiagnostics>)endpoints.GetOrAdd("n1ql", new List<IEndpointDiagnostics>());
-                    var endPointDiagnostics = CreateEndpointHealth("Cluster", ServiceType.Query, DateTime.UtcNow, clusterNode.LastQueryActivity, clusterNode.EndPoint, ping);
-
-                    if (ping)
-                    {
-                        pingTasks.Add(RecordLatencyAsync(endPointDiagnostics, () =>
-                         {
-                             var token1 = token;
-                             var queryOptions = new QueryOptions();
-                             if (token1 != CancellationToken.None)
-                             {
-                                 queryOptions.CancellationToken(token1);
-                             }
-                             return context.Cluster.QueryAsync<dynamic>("SELECT 1;", queryOptions);
-                         }, token));
-                    }
-
-                    kvEndpoints.Add(endPointDiagnostics);
+                    AddHttpServiceEndpoint(endpoints, pingTasks, httpClientFactory, "n1ql", ServiceType.Query,
+                        clusterNode, AdminPingPath, context.ClusterOptions.QueryTimeout, ping, token);
                 }
 
-                if (serviceTypes.Contains(ServiceType.Analytics) && clusterNode.HasAnalytics &&
-                    context.ServiceProvider.IsService<IAnalyticsClient>())
+                if (serviceTypes.Contains(ServiceType.Analytics) && clusterNode.HasAnalytics)
                 {
-                    var kvEndpoints = (List<IEndpointDiagnostics>)endpoints.GetOrAdd("cbas", new List<IEndpointDiagnostics>());
-                    var endPointDiagnostics = CreateEndpointHealth("Cluster", ServiceType.Analytics, DateTime.UtcNow, clusterNode.LastQueryActivity, clusterNode.EndPoint, ping);
-
-                    if (ping)
-                    {
-                        pingTasks.Add(RecordLatencyAsync(endPointDiagnostics, () =>
-                        {
-                            var token1 = token;
-                            var analyticsOptions = new AnalyticsOptions();
-                            if (token1 != CancellationToken.None)
-                            {
-                                analyticsOptions.CancellationToken(token1);
-                            }
-                            return context.Cluster.AnalyticsQueryAsync<dynamic>("SELECT 1;", analyticsOptions);
-                        }, token));
-                    }
-
-                    kvEndpoints.Add(endPointDiagnostics);
+                    AddHttpServiceEndpoint(endpoints, pingTasks, httpClientFactory, "cbas", ServiceType.Analytics,
+                        clusterNode, AdminPingPath, context.ClusterOptions.AnalyticsTimeout, ping, token);
                 }
 
-                if (serviceTypes.Contains(ServiceType.Search) && clusterNode.HasSearch &&
-                    context.ServiceProvider.IsService<ISearchClient>())
+                if (serviceTypes.Contains(ServiceType.Search) && clusterNode.HasSearch)
                 {
-                    var kvEndpoints = (List<IEndpointDiagnostics>)endpoints.GetOrAdd("fts", new List<IEndpointDiagnostics>());
-                    var endPointDiagnostics = CreateEndpointHealth("Cluster", ServiceType.Search, DateTime.UtcNow, clusterNode.LastQueryActivity, clusterNode.EndPoint, ping);
-
-                    if (ping)
-                    {
-                        var index = "ping";
-                        pingTasks.Add(RecordLatencyAsync(endPointDiagnostics,
-                            async () =>
-                            {
-                                try
-                                {
-                                    var token1 = token;
-                                    var searchOptions = new SearchOptions();
-                                    if (token1 != CancellationToken.None)
-                                    {
-                                        searchOptions.CancellationToken(token1);
-                                    }
-                                    await context.Cluster.SearchQueryAsync(index, new NoOpQuery(), searchOptions)
-                                        .ConfigureAwait(false);
-                                }
-                                catch (IndexNotFoundException)
-                                {
-                                    // This exception is expected for pings, the ping index does not exist
-                                }
-                            }, token));
-                    }
-
-                    kvEndpoints.Add(endPointDiagnostics);
+                    AddHttpServiceEndpoint(endpoints, pingTasks, httpClientFactory, "fts", ServiceType.Search,
+                        clusterNode, SearchPingPath, context.ClusterOptions.SearchTimeout, ping, token);
                 }
             }
 
@@ -228,6 +171,84 @@ namespace Couchbase.Diagnostics
             }
 
             return endpoints;
+        }
+
+        /// <summary>
+        /// Adds the entry for one HTTP service on one node and, when pinging, the ping of that node's own health endpoint.
+        /// </summary>
+        /// <remarks>
+        /// The ping must go to the node being reported, a load balanced client would let several entries hit the same
+        /// node and report the whole service as healthy.
+        /// </remarks>
+        private static void AddHttpServiceEndpoint(
+            ConcurrentDictionary<string, IEnumerable<IEndpointDiagnostics>> endpoints, List<Task> pingTasks,
+            ICouchbaseHttpClientFactory? httpClientFactory, string reportKey, ServiceType serviceType,
+            IClusterNode clusterNode, string pingPath, TimeSpan fallbackTimeout, bool ping,
+            CancellationToken token)
+        {
+            // The activity must be read first, the service URI getter stamps it with the current time.
+            var lastActivity = LastActivity(clusterNode, serviceType);
+
+            // Only a ping needs the service URI, so a diagnostics report leaves the activity alone.
+            var pingUri = ping ? BuildPingUri(ServiceUri(clusterNode, serviceType), pingPath) : null;
+
+            var serviceEndpoints = (List<IEndpointDiagnostics>) endpoints.GetOrAdd(reportKey, new List<IEndpointDiagnostics>());
+            var endPointDiagnostics = CreateEndpointHealth("Cluster", serviceType, DateTime.UtcNow, lastActivity,
+                pingUri?.ToString() ?? clusterNode.EndPoint.ToString(), ping);
+
+            // Without a URI there is nothing to ping, the entry is still reported so it counts as not Ok.
+            if (ping && pingUri is not null)
+            {
+                Debug.Assert(httpClientFactory is not null,
+                    $"{nameof(httpClientFactory)} should not be null when {nameof(ping)} is true.");
+
+                pingTasks.Add(RecordLatencyAsync(endPointDiagnostics,
+                    () => PingHttpServiceAsync(httpClientFactory!, pingUri, fallbackTimeout, token), token));
+            }
+
+            serviceEndpoints.Add(endPointDiagnostics);
+        }
+
+        private static DateTime? LastActivity(IClusterNode clusterNode, ServiceType serviceType) => serviceType switch
+        {
+            ServiceType.Query => clusterNode.LastQueryActivity,
+            ServiceType.Analytics => clusterNode.LastAnalyticsActivity,
+            ServiceType.Search => clusterNode.LastSearchActivity,
+            _ => null
+        };
+
+        /// <remarks>
+        /// Each of these getters stamps the matching last activity, so only read one when it is needed.
+        /// </remarks>
+        private static Uri? ServiceUri(IClusterNode clusterNode, ServiceType serviceType) => serviceType switch
+        {
+            ServiceType.Query => clusterNode.QueryUri,
+            ServiceType.Analytics => clusterNode.AnalyticsUri,
+            ServiceType.Search => clusterNode.SearchUri,
+            _ => null
+        };
+
+        /// <summary>
+        /// The node's own service URI with the health endpoint path.
+        /// </summary>
+        internal static Uri? BuildPingUri(Uri? serviceUri, string pingPath) =>
+            serviceUri is null
+                ? null
+                : new UriBuilder(serviceUri) { Path = pingPath, Query = string.Empty }.Uri;
+
+        /// <summary>
+        /// Pings a single HTTP service endpoint, anything but a success status code is a failure.
+        /// </summary>
+        internal static async Task PingHttpServiceAsync(ICouchbaseHttpClientFactory httpClientFactory, Uri pingUri,
+            TimeSpan fallbackTimeout, CancellationToken token)
+        {
+            using var timeoutSource = token == CancellationToken.None
+                ? new CancellationTokenSource(fallbackTimeout)
+                : null;
+
+            using var httpClient = httpClientFactory.Create();
+            using var response = await httpClient.GetAsync(pingUri, timeoutSource?.Token ?? token).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
         }
 
         private static EndpointDiagnostics CreateEndpointHealth(string? bucketName, DateTime createdAt, IConnection connection, bool ping)
@@ -245,13 +266,17 @@ namespace Couchbase.Diagnostics
         }
 
        internal static EndpointDiagnostics CreateEndpointHealth(string? bucketName, ServiceType serviceType, DateTime createdAt, DateTime? lastActivity,
-            HostEndpointWithPort? endPoint, bool ping)
+            HostEndpointWithPort? endPoint, bool ping) =>
+            CreateEndpointHealth(bucketName, serviceType, createdAt, lastActivity, endPoint?.ToString(), ping);
+
+        internal static EndpointDiagnostics CreateEndpointHealth(string? bucketName, ServiceType serviceType, DateTime createdAt, DateTime? lastActivity,
+            string? remote, bool ping)
         {
             return new EndpointDiagnostics
             {
                 Type = serviceType,
                 LastActivity = ping ? null : CalculateLastActivity(createdAt, lastActivity),
-                Remote = endPoint?.ToString() ?? UnknownEndpointValue,
+                Remote = remote ?? UnknownEndpointValue,
                 State = lastActivity.HasValue ? ServiceState.Active : ServiceState.New,
                 Scope = bucketName
             };

--- a/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
+++ b/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
@@ -193,8 +193,9 @@ namespace Couchbase.Diagnostics
             var pingUri = ping ? BuildPingUri(ServiceUri(clusterNode, serviceType), pingPath) : null;
 
             var serviceEndpoints = (List<IEndpointDiagnostics>) endpoints.GetOrAdd(reportKey, new List<IEndpointDiagnostics>());
+            // The report shows host and port, not the ping URL, to match the other SDKs and the RFC examples.
             var endPointDiagnostics = CreateEndpointHealth("Cluster", serviceType, DateTime.UtcNow, lastActivity,
-                pingUri?.ToString() ?? clusterNode.EndPoint.ToString(), ping);
+                pingUri?.Authority ?? clusterNode.EndPoint.ToString(), ping);
 
             // Without a URI there is nothing to ping, the entry is still reported so it counts as not Ok.
             if (ping && pingUri is not null)

--- a/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
+++ b/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
@@ -40,9 +40,9 @@ namespace Couchbase.Diagnostics
 
         internal static async Task<IPingReport> CreatePingReportAsync(ClusterContext context, BucketConfig? config, PingOptions options)
         {
-            var clusterNodes = context.GetNodes(config?.Name ?? BucketConfig.GlobalBucketName);
+            var bucketNodes = context.GetNodes(config?.Name ?? BucketConfig.GlobalBucketName);
             var endpoints =
-                await GetEndpointDiagnosticsAsync(context, clusterNodes, true, options.ServiceTypesValue,
+                await GetEndpointDiagnosticsAsync(context, bucketNodes, context.Nodes, true, options.ServiceTypesValue,
                    options.Token).ConfigureAwait(false);
             return new PingReport(options.ReportIdValue ?? Guid.NewGuid().ToString(), config?.Rev ?? 0, endpoints);
         }
@@ -51,13 +51,18 @@ namespace Couchbase.Diagnostics
         {
             var clusterNodes = context.Nodes;
             var endpoints =
-                await GetEndpointDiagnosticsAsync(context, clusterNodes, false, AllServiceTypes,
+                await GetEndpointDiagnosticsAsync(context, clusterNodes, clusterNodes, false, AllServiceTypes,
                     CancellationToken.None).ConfigureAwait(false);
             return new DiagnosticsReport(reportId, endpoints);
         }
 
+        /// <remarks>
+        /// KV and Views are scoped to the nodes owned by the bucket, the other services are cluster scoped. A node
+        /// without KV never joins a bucket node set, so scoping them the same way would skip them on an MDS cluster.
+        /// </remarks>
         private static async ValueTask<ConcurrentDictionary<string, IEnumerable<IEndpointDiagnostics>>> GetEndpointDiagnosticsAsync(ClusterContext context,
-           IEnumerable<IClusterNode> clusterNodes, bool ping, ICollection<ServiceType> serviceTypes, CancellationToken token)
+           IEnumerable<IClusterNode> bucketNodes, IEnumerable<IClusterNode> clusterNodes, bool ping,
+           ICollection<ServiceType> serviceTypes, CancellationToken token)
         {
             var endpoints = new ConcurrentDictionary<string, IEnumerable<IEndpointDiagnostics>>();
 
@@ -67,14 +72,17 @@ namespace Couchbase.Diagnostics
 
             var pingTasks = new List<Task>();
 
-            foreach (var clusterNode in clusterNodes)
+            foreach (var clusterNode in bucketNodes)
             {
                 if (serviceTypes.Contains(ServiceType.KeyValue) && clusterNode.HasKv)
                 {
-                    var kvEndpoints = (List<IEndpointDiagnostics>) endpoints.GetOrAdd("kv", new List<IEndpointDiagnostics>());
+                    // Only created once there is a connection, an empty entry would report a service that has nothing behind it.
+                    List<IEndpointDiagnostics>? kvEndpoints = null;
 
                     foreach (var connection in clusterNode.ConnectionPool.GetConnections())
                     {
+                        kvEndpoints ??= (List<IEndpointDiagnostics>) endpoints.GetOrAdd("kv", new List<IEndpointDiagnostics>());
+
                         var endPointDiagnostics =
                             CreateEndpointHealth(clusterNode.Owner?.Name, DateTime.UtcNow, connection, ping);
 
@@ -129,7 +137,10 @@ namespace Couchbase.Diagnostics
                         kvEndpoints.Add(endPointDiagnostics);
                     }
                 }
+            }
 
+            foreach (var clusterNode in clusterNodes)
+            {
                 if (serviceTypes.Contains(ServiceType.Query) && clusterNode.HasQuery &&
                     context.ServiceProvider.IsService<IQueryClient>())
                 {

--- a/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
+++ b/src/Couchbase/Diagnostics/DiagnosticsReportProvider.cs
@@ -183,7 +183,7 @@ namespace Couchbase.Diagnostics
         private static void AddHttpServiceEndpoint(
             ConcurrentDictionary<string, IEnumerable<IEndpointDiagnostics>> endpoints, List<Task> pingTasks,
             ICouchbaseHttpClientFactory? httpClientFactory, string reportKey, ServiceType serviceType,
-            IClusterNode clusterNode, string pingPath, TimeSpan fallbackTimeout, bool ping,
+            IClusterNode clusterNode, string pingPath, TimeSpan serviceTimeout, bool ping,
             CancellationToken token)
         {
             // The activity must be read first, the service URI getter stamps it with the current time.
@@ -203,7 +203,7 @@ namespace Couchbase.Diagnostics
                     $"{nameof(httpClientFactory)} should not be null when {nameof(ping)} is true.");
 
                 pingTasks.Add(RecordLatencyAsync(endPointDiagnostics,
-                    () => PingHttpServiceAsync(httpClientFactory!, pingUri, fallbackTimeout, token), token));
+                    () => PingHttpServiceAsync(httpClientFactory!, pingUri, serviceTimeout, token), token));
             }
 
             serviceEndpoints.Add(endPointDiagnostics);
@@ -239,15 +239,17 @@ namespace Couchbase.Diagnostics
         /// <summary>
         /// Pings a single HTTP service endpoint, anything but a success status code is a failure.
         /// </summary>
+        /// <remarks>
+        /// The service timeout applies even when the caller supplies a token, one hung node must not stall the whole pass.
+        /// </remarks>
         internal static async Task PingHttpServiceAsync(ICouchbaseHttpClientFactory httpClientFactory, Uri pingUri,
-            TimeSpan fallbackTimeout, CancellationToken token)
+            TimeSpan serviceTimeout, CancellationToken token)
         {
-            using var timeoutSource = token == CancellationToken.None
-                ? new CancellationTokenSource(fallbackTimeout)
-                : null;
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            timeoutSource.CancelAfter(serviceTimeout);
 
             using var httpClient = httpClientFactory.Create();
-            using var response = await httpClient.GetAsync(pingUri, timeoutSource?.Token ?? token).ConfigureAwait(false);
+            using var response = await httpClient.GetAsync(pingUri, timeoutSource.Token).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
         }
 

--- a/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
+++ b/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Analytics;
+using Couchbase.Core;
+using Couchbase.Core.Configuration.Server;
+using Couchbase.Core.DI;
+using Couchbase.Query;
+using Couchbase.Search;
+using Couchbase.Views;
+
+#nullable enable
+
+namespace Couchbase.Diagnostics
+{
+    /// <summary>
+    /// Shared readiness logic for the cluster and bucket level WaitUntilReady, per SDK-RFC 61.
+    /// </summary>
+    internal static class WaitUntilReadyEvaluator
+    {
+        /// <summary>
+        /// The services <see cref="DiagnosticsReportProvider"/> is able to ping.
+        /// </summary>
+        private static readonly ServiceType[] PingableServices =
+        {
+            ServiceType.KeyValue,
+            ServiceType.Views,
+            ServiceType.Query,
+            ServiceType.Search,
+            ServiceType.Analytics
+        };
+
+        /// <summary>
+        /// The key <see cref="DiagnosticsReportProvider"/> uses for a service in the ping report.
+        /// </summary>
+        internal static string? ReportKey(ServiceType serviceType) => serviceType switch
+        {
+            ServiceType.KeyValue => "kv",
+            ServiceType.Views => "view",
+            ServiceType.Query => "n1ql",
+            ServiceType.Analytics => "cbas",
+            ServiceType.Search => "fts",
+            _ => null
+        };
+
+        /// <summary>
+        /// The services WaitUntilReady must actually verify.
+        /// </summary>
+        /// <remarks>
+        /// The result must never contain a service the ping report cannot produce an entry for, otherwise
+        /// WaitUntilReady waits for something that will never arrive and only ends on timeout.
+        /// </remarks>
+        internal static ISet<ServiceType> ExpectedServices(ClusterContext context, BucketConfig? bucketConfig,
+            IEnumerable<ServiceType> requested, bool bucketLevel)
+        {
+            var config = bucketLevel ? bucketConfig : context?.GlobalConfig;
+            var advertised = AdvertisedFromConfig(config) ?? AdvertisedFromNodes(context, bucketLevel ? config?.Name : null);
+            var serviceProvider = context?.ServiceProvider;
+
+            var expected = new HashSet<ServiceType>();
+            foreach (var serviceType in requested)
+            {
+                if (Array.IndexOf(PingableServices, serviceType) < 0)
+                {
+                    continue;
+                }
+
+                if (!advertised.Contains(serviceType))
+                {
+                    continue;
+                }
+
+                var supported = serviceType switch
+                {
+                    // Views need an open bucket, the cluster level report never has a view entry.
+#pragma warning disable CS0618 // Type or member is obsolete
+                    ServiceType.Views => bucketLevel
+                                         && HasCouchApi(config)
+                                         && serviceProvider?.IsService<IViewClient>() == true,
+#pragma warning restore CS0618 // Type or member is obsolete
+                    ServiceType.Query => serviceProvider?.IsService<IQueryClient>() == true,
+                    ServiceType.Search => serviceProvider?.IsService<ISearchClient>() == true,
+                    ServiceType.Analytics => serviceProvider?.IsService<IAnalyticsClient>() == true,
+                    _ => true
+                };
+
+                if (supported)
+                {
+                    expected.Add(serviceType);
+                }
+            }
+
+            return expected;
+        }
+
+        /// <summary>
+        /// Applies the RFC 61 cluster state rules to a ping report.
+        /// </summary>
+        internal static ReadinessResult Evaluate(IPingReport report, ICollection<ServiceType> expected, ClusterState desired)
+        {
+            // Nothing to verify, the caller decides whether that is worth a warning.
+            if (expected.Count == 0)
+            {
+                return new ReadinessResult(ClusterState.Online, true);
+            }
+
+            var found = 0;
+            var ok = 0;
+            var anyMissing = false;
+            var allPartlyUp = true;
+
+            foreach (var serviceType in expected)
+            {
+                CountEntries(report, serviceType, out var serviceFound, out var serviceOk);
+
+                found += serviceFound;
+                ok += serviceOk;
+
+                if (serviceFound == 0)
+                {
+                    anyMissing = true;
+                }
+
+                if (serviceOk == 0)
+                {
+                    allPartlyUp = false;
+                }
+            }
+
+            ClusterState state;
+            if (!anyMissing && found > 0 && found == ok)
+            {
+                state = ClusterState.Online;
+            }
+            else if (allPartlyUp)
+            {
+                state = ClusterState.Degraded;
+            }
+            else
+            {
+                state = ClusterState.Offline;
+            }
+
+            var ready = desired switch
+            {
+                ClusterState.Online => state == ClusterState.Online,
+                ClusterState.Degraded => state == ClusterState.Online || state == ClusterState.Degraded,
+                _ => false
+            };
+
+            return new ReadinessResult(state, ready);
+        }
+
+        /// <summary>
+        /// A short per service summary of the ping report, for logging why WaitUntilReady is still waiting.
+        /// </summary>
+        internal static string Describe(IPingReport report, ICollection<ServiceType> expected)
+        {
+            if (expected.Count == 0)
+            {
+                return "none";
+            }
+
+            var builder = new StringBuilder();
+            foreach (var serviceType in expected)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                CountEntries(report, serviceType, out var serviceFound, out var serviceOk);
+                builder.Append(ReportKey(serviceType) ?? serviceType.ToString());
+                builder.Append(serviceFound == 0 ? " missing" : $" {serviceOk}/{serviceFound} ok");
+            }
+
+            return builder.ToString();
+        }
+
+        private static void CountEntries(IPingReport report, ServiceType serviceType, out int found, out int ok)
+        {
+            found = 0;
+            ok = 0;
+
+            var key = ReportKey(serviceType);
+            if (key is null || !report.Services.TryGetValue(key, out var entries) || entries is null)
+            {
+                return;
+            }
+
+            foreach (var entry in entries)
+            {
+                found++;
+                if (entry.State == ServiceState.Ok)
+                {
+                    ok++;
+                }
+            }
+        }
+
+        private static bool HasCouchApi(BucketConfig? config) =>
+            config?.BucketCapabilities?.Contains(BucketCapabilities.COUCHAPI) ?? false;
+
+        private static HashSet<ServiceType>? AdvertisedFromConfig(BucketConfig? config)
+        {
+            if (config is null)
+            {
+                return null;
+            }
+
+            List<NodeAdapter> nodes;
+            try
+            {
+                nodes = config.GetNodes();
+            }
+            catch (Exception)
+            {
+                // The config has no usable node list yet, the caller falls back to the connected nodes.
+                return null;
+            }
+
+            var advertised = new HashSet<ServiceType>();
+            foreach (var node in nodes)
+            {
+                Add(advertised, ServiceType.KeyValue, node.IsKvNode);
+                Add(advertised, ServiceType.Views, node.IsViewNode);
+                Add(advertised, ServiceType.Query, node.IsQueryNode);
+                Add(advertised, ServiceType.Search, node.IsSearchNode);
+                Add(advertised, ServiceType.Analytics, node.IsAnalyticsNode);
+            }
+
+            return advertised;
+        }
+
+        private static HashSet<ServiceType> AdvertisedFromNodes(ClusterContext? context, string? bucketName)
+        {
+            var advertised = new HashSet<ServiceType>();
+            if (context?.Nodes is null)
+            {
+                return advertised;
+            }
+
+            foreach (var node in context.GetNodes(bucketName))
+            {
+                Add(advertised, ServiceType.KeyValue, node.HasKv);
+                Add(advertised, ServiceType.Views, node.HasViews);
+                Add(advertised, ServiceType.Query, node.HasQuery);
+                Add(advertised, ServiceType.Search, node.HasSearch);
+                Add(advertised, ServiceType.Analytics, node.HasAnalytics);
+            }
+
+            return advertised;
+        }
+
+        private static void Add(HashSet<ServiceType> set, ServiceType serviceType, bool present)
+        {
+            if (present)
+            {
+                set.Add(serviceType);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Exponential backoff for the WaitUntilReady poll loops, so a long wait does not keep pinging every node
+    /// at a fixed rate.
+    /// </summary>
+    internal sealed class WaitUntilReadyBackoff
+    {
+        private const int InitialMilliseconds = 10;
+        private const int MaxMilliseconds = 1000;
+
+        private int _milliseconds = InitialMilliseconds;
+
+        /// <summary>
+        /// The delay for this pass, doubled for the next one up to the cap.
+        /// </summary>
+        internal TimeSpan Next()
+        {
+            var delay = _milliseconds;
+            _milliseconds = Math.Min(delay * 2, MaxMilliseconds);
+            return TimeSpan.FromMilliseconds(delay);
+        }
+
+        internal Task DelayAsync(CancellationToken cancellationToken) => Task.Delay(Next(), cancellationToken);
+    }
+
+    internal readonly struct ReadinessResult
+    {
+        public ReadinessResult(ClusterState state, bool ready)
+        {
+            State = state;
+            Ready = ready;
+        }
+
+        public ClusterState State { get; }
+
+        public bool Ready { get; }
+    }
+}
+
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
+++ b/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
@@ -161,6 +161,29 @@ namespace Couchbase.Diagnostics
         }
 
         /// <summary>
+        /// True once there is something to evaluate, a config or at least one node.
+        /// </summary>
+        /// <remarks>
+        /// Without a topology nothing is advertised, so an empty expected set would make WaitUntilReady succeed
+        /// before the bucket is bootstrapped.
+        /// </remarks>
+        internal static bool HasTopology(BucketConfig? config, IEnumerable<IClusterNode>? nodes)
+        {
+            if (config is not null)
+            {
+                return true;
+            }
+
+            if (nodes is null)
+            {
+                return false;
+            }
+
+            using var enumerator = nodes.GetEnumerator();
+            return enumerator.MoveNext();
+        }
+
+        /// <summary>
         /// Applies the RFC 61 cluster state rules to a ping report.
         /// </summary>
         internal static ReadinessResult Evaluate(IPingReport report, ICollection<ServiceType> expected, ClusterState desired)

--- a/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
+++ b/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
@@ -3,12 +3,9 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Couchbase.Analytics;
 using Couchbase.Core;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Core.DI;
-using Couchbase.Query;
-using Couchbase.Search;
 using Couchbase.Views;
 
 #nullable enable
@@ -80,9 +77,6 @@ namespace Couchbase.Diagnostics
                                          && HasCouchApi(config)
                                          && serviceProvider?.IsService<IViewClient>() == true,
 #pragma warning restore CS0618 // Type or member is obsolete
-                    ServiceType.Query => serviceProvider?.IsService<IQueryClient>() == true,
-                    ServiceType.Search => serviceProvider?.IsService<ISearchClient>() == true,
-                    ServiceType.Analytics => serviceProvider?.IsService<IAnalyticsClient>() == true,
                     _ => true
                 };
 

--- a/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
+++ b/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Couchbase.Core;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Core.DI;
 using Couchbase.Views;
+using Microsoft.Extensions.Logging;
 
 #nullable enable
 
@@ -15,7 +17,7 @@ namespace Couchbase.Diagnostics
     /// <summary>
     /// Shared readiness logic for the cluster and bucket level WaitUntilReady, per SDK-RFC 61.
     /// </summary>
-    internal static class WaitUntilReadyEvaluator
+    internal static partial class WaitUntilReadyEvaluator
     {
         /// <summary>
         /// The services <see cref="DiagnosticsReportProvider"/> is able to ping.
@@ -87,6 +89,75 @@ namespace Couchbase.Diagnostics
             }
 
             return expected;
+        }
+
+        /// <summary>
+        /// Pings and evaluates until the desired state is reached or the token ends the wait.
+        /// </summary>
+        /// <param name="context">The cluster context.</param>
+        /// <param name="options">The options given to WaitUntilReady.</param>
+        /// <param name="bucketLevel">True for a bucket level wait, false for a cluster level wait.</param>
+        /// <param name="currentConfig">The config to evaluate and ping against, read again on every pass.</param>
+        /// <param name="canEvaluate">Gate for a pass, false backs off and retries.</param>
+        /// <param name="onState">Receives the state of every pass.</param>
+        /// <param name="logger">The caller's logger.</param>
+        /// <param name="token">Ends the wait, the caller decides what that means.</param>
+        internal static async Task PollAsync(
+            ClusterContext context,
+            WaitUntilReadyOptions options,
+            bool bucketLevel,
+            Func<BucketConfig?> currentConfig,
+            Func<CancellationToken, ValueTask<bool>> canEvaluate,
+            Action<ClusterState> onState,
+            ILogger logger,
+            CancellationToken token)
+        {
+            var backoff = new WaitUntilReadyBackoff();
+
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (!await canEvaluate(token).ConfigureAwait(false))
+                {
+                    await backoff.DelayAsync(token).ConfigureAwait(false);
+                    continue;
+                }
+
+                var config = currentConfig();
+
+                // Recomputed every pass because the topology can change while we wait.
+                var requested = options.EffectiveServiceTypes(context).ToList();
+                var expected = ExpectedServices(context, config, requested, bucketLevel);
+
+                if (expected.Count == 0)
+                {
+                    LogNoServices(logger, string.Join(", ", requested));
+                }
+
+                // Ping only what we evaluate, otherwise every pass pays for a service we ignore.
+                var pingReport = await DiagnosticsReportProvider.CreatePingReportAsync(context, config,
+                    new PingOptions
+                    {
+                        ServiceTypesValue = expected.ToList(),
+                        Token = token
+                    }).ConfigureAwait(false);
+
+                var readiness = Evaluate(pingReport, expected, options.DesiredStateValue);
+                onState(readiness.State);
+
+                if (readiness.Ready)
+                {
+                    return;
+                }
+
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    LogStillWaiting(logger, readiness.State, options.DesiredStateValue, Describe(pingReport, expected));
+                }
+
+                await backoff.DelayAsync(token).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -255,6 +326,12 @@ namespace Couchbase.Diagnostics
                 set.Add(serviceType);
             }
         }
+
+        [LoggerMessage(LogLevel.Debug, "WaitUntilReady is {state} but wants {desiredState}, services: {services}")]
+        private static partial void LogStillWaiting(ILogger logger, ClusterState state, ClusterState desiredState, string services);
+
+        [LoggerMessage(LogLevel.Warning, "WaitUntilReady has no verifiable service from the requested set {requested}, returning immediately")]
+        private static partial void LogNoServices(ILogger logger, string requested);
     }
 
     /// <summary>

--- a/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
+++ b/src/Couchbase/Diagnostics/WaitUntilReadyEvaluator.cs
@@ -51,7 +51,7 @@ namespace Couchbase.Diagnostics
         /// The result must never contain a service the ping report cannot produce an entry for, otherwise
         /// WaitUntilReady waits for something that will never arrive and only ends on timeout.
         /// </remarks>
-        internal static ISet<ServiceType> ExpectedServices(ClusterContext context, BucketConfig? bucketConfig,
+        internal static ISet<ServiceType> ExpectedServices(ClusterContext? context, BucketConfig? bucketConfig,
             IEnumerable<ServiceType> requested, bool bucketLevel)
         {
             var config = bucketLevel ? bucketConfig : context?.GlobalConfig;
@@ -218,7 +218,7 @@ namespace Couchbase.Diagnostics
             }
 
             ClusterState state;
-            if (!anyMissing && found > 0 && found == ok)
+            if (!anyMissing && found == ok)
             {
                 state = ClusterState.Online;
             }
@@ -305,7 +305,9 @@ namespace Couchbase.Diagnostics
             }
             catch (Exception)
             {
-                // The config has no usable node list yet, the caller falls back to the connected nodes.
+                // Broad on purpose. GetNodes throws ServiceMissingException when it selects no node adapter, and
+                // building an adapter from a half filled config can throw anything. Either way there is no usable
+                // node list yet, so fall back to the connected nodes.
                 return null;
             }
 

--- a/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
+++ b/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Threading.Tasks;
 using Couchbase.Core;
+using Couchbase.Diagnostics;
 using Couchbase.Core.Bootstrapping;
 using Couchbase.Core.DI;
 using Couchbase.Core.Diagnostics.Metrics;
@@ -41,5 +43,40 @@ namespace Couchbase.UnitTests
             bucket.Scope("doesnotexist");
             await bucket.ScopeAsync("doesnotexist");
         }
+
+        [Fact]
+        public async Task WaitUntilReadyAsync_Offline_DesiredState_Throws_InvalidArgumentException()
+        {
+            var bucket = CreateBucket();
+
+            await Assert.ThrowsAsync<InvalidArgumentException>(() => bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(1),
+                new WaitUntilReadyOptions().DesiredState(ClusterState.Offline)));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task WaitUntilReadyAsync_NonPositive_Timeout_Throws_UnambiguousTimeoutException(int seconds)
+        {
+            var bucket = CreateBucket();
+
+            await Assert.ThrowsAsync<UnambiguousTimeoutException>(() =>
+                bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(seconds)));
+        }
+
+        private static CouchbaseBucket CreateBucket() =>
+            new("default",
+                new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password")),
+                new Mock<IScopeFactory>().Object,
+                new Mock<IRetryOrchestrator>().Object,
+                new Mock<IVBucketKeyMapperFactory>().Object,
+                new Mock<ILogger<CouchbaseBucket>>().Object,
+                new TypedRedactor(RedactionLevel.None),
+                new Mock<IBootstrapperFactory>().Object,
+                NoopRequestTracer.Instance,
+                new Mock<IOperationConfigurator>().Object,
+                new BestEffortRetryStrategy(),
+                new BucketConfig(),
+                new Mock<IConfigPushHandlerFactory>().Object);
     }
 }

--- a/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
+++ b/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
@@ -64,7 +64,18 @@ namespace Couchbase.UnitTests
                 bucket.WaitUntilReadyAsync(TimeSpan.FromSeconds(seconds)));
         }
 
-        private static CouchbaseBucket CreateBucket() =>
+        [Fact]
+        public async Task WaitUntilReadyAsync_Without_A_Config_Or_Nodes_Times_Out()
+        {
+            var bucket = CreateBucket(config: null);
+
+            await Assert.ThrowsAsync<UnambiguousTimeoutException>(() =>
+                bucket.WaitUntilReadyAsync(TimeSpan.FromMilliseconds(100)));
+        }
+
+        private static CouchbaseBucket CreateBucket() => CreateBucket(new BucketConfig());
+
+        private static CouchbaseBucket CreateBucket(BucketConfig config) =>
             new("default",
                 new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password")),
                 new Mock<IScopeFactory>().Object,
@@ -76,7 +87,7 @@ namespace Couchbase.UnitTests
                 NoopRequestTracer.Instance,
                 new Mock<IOperationConfigurator>().Object,
                 new BestEffortRetryStrategy(),
-                new BucketConfig(),
+                config,
                 new Mock<IConfigPushHandlerFactory>().Object);
     }
 }

--- a/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
@@ -91,7 +91,7 @@ namespace Couchbase.UnitTests.Diagnostics
         }
 
         [Fact]
-        public async Task PingHttpServiceAsync_Without_A_Token_Uses_The_Fallback_Timeout()
+        public async Task PingHttpServiceAsync_Without_A_Token_Uses_The_Service_Timeout()
         {
             //arrange
 
@@ -99,12 +99,50 @@ namespace Couchbase.UnitTests.Diagnostics
 
             //act, assert
 
-            // A generous fallback must not cancel a healthy ping.
+            // A generous timeout must not cancel a healthy ping.
             await DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
                 TimeSpan.FromMinutes(1), CancellationToken.None);
         }
 
+        [Fact]
+        public async Task PingHttpServiceAsync_Applies_The_Service_Timeout_To_A_Live_Token()
+        {
+            //arrange
+
+            using var external = new CancellationTokenSource();
+            var factory = new MockHttpClientFactory(() =>
+                new HttpClient(new DelayingHttpMessageHandler(TimeSpan.FromMinutes(1))));
+
+            //act, assert
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
+                    TimeSpan.FromMilliseconds(50), external.Token));
+
+            Assert.False(external.IsCancellationRequested);
+        }
+
         private static MockHttpClientFactory CreateFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) =>
             new(() => new HttpClient(FakeHttpMessageHandler.Create(handler)));
+
+        /// <summary>
+        /// Stands in for a node that accepts the connection and never answers.
+        /// </summary>
+        private sealed class DelayingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly TimeSpan _delay;
+
+            public DelayingHttpMessageHandler(TimeSpan delay)
+            {
+                _delay = delay;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        }
     }
 }

--- a/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
@@ -3,9 +3,13 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.IO.Connections;
+using Couchbase.Core.IO.HTTP;
 using Couchbase.Diagnostics;
 using Couchbase.UnitTests.Helpers;
 using Couchbase.UnitTests.Utils;
+using Moq;
 using Xunit;
 
 namespace Couchbase.UnitTests.Diagnostics
@@ -120,6 +124,33 @@ namespace Couchbase.UnitTests.Diagnostics
                     TimeSpan.FromMilliseconds(50), external.Token));
 
             Assert.False(external.IsCancellationRequested);
+        }
+
+        [Fact]
+        public async Task CreatePingReportAsync_Reports_Host_And_Port_As_The_Remote()
+        {
+            //arrange
+
+            var options = new ClusterOptions().WithPasswordAuthentication("username", "password");
+            options.AddClusterService<ICouchbaseHttpClientFactory, MockHttpClientFactory>(
+                CreateFactory(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var context = new ClusterContext(null, options);
+            var node = new Mock<IClusterNode>();
+            node.SetupGet(x => x.HasQuery).Returns(true);
+            node.SetupGet(x => x.QueryUri).Returns(new Uri("http://node1:8093/query/service"));
+            node.SetupGet(x => x.EndPoint).Returns(new HostEndpointWithPort("node1", 8093));
+            context.AddNode(node.Object);
+
+            //act
+
+            var report = await DiagnosticsReportProvider.CreatePingReportAsync(context, null,
+                new PingOptions { ServiceTypesValue = new[] { ServiceType.Query } });
+
+            //assert
+
+            var entry = Assert.Single(report.Services["n1ql"]);
+            Assert.Equal("node1:8093", entry.Remote);
         }
 
         private static MockHttpClientFactory CreateFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) =>

--- a/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/DiagnosticsReportProviderTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Diagnostics;
+using Couchbase.UnitTests.Helpers;
+using Couchbase.UnitTests.Utils;
+using Xunit;
+
+namespace Couchbase.UnitTests.Diagnostics
+{
+    public class DiagnosticsReportProviderTests
+    {
+        [Theory]
+        [InlineData("http://node1:8093/query/service", "/admin/ping", "http://node1:8093/admin/ping")]
+        [InlineData("http://node1:8095/analytics/service", "/admin/ping", "http://node1:8095/admin/ping")]
+        [InlineData("http://node1:8094/", "/api/ping", "http://node1:8094/api/ping")]
+        [InlineData("https://node1:18093/query/service", "/admin/ping", "https://node1:18093/admin/ping")]
+        public void BuildPingUri_Keeps_The_Node_Host_And_Port(string serviceUri, string pingPath, string expected)
+        {
+            //act
+
+            var uri = DiagnosticsReportProvider.BuildPingUri(new Uri(serviceUri), pingPath);
+
+            //assert
+
+            Assert.Equal(expected, uri.ToString());
+        }
+
+        [Fact]
+        public void BuildPingUri_Is_Null_Without_A_Service_Uri()
+        {
+            Assert.Null(DiagnosticsReportProvider.BuildPingUri(null, DiagnosticsReportProvider.AdminPingPath));
+        }
+
+        [Fact]
+        public async Task PingHttpServiceAsync_Requests_The_Given_Uri()
+        {
+            //arrange
+
+            Uri requested = null;
+            var factory = CreateFactory(request =>
+            {
+                requested = request.RequestUri;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+            //act
+
+            await DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
+                TimeSpan.FromSeconds(10), CancellationToken.None);
+
+            //assert
+
+            Assert.Equal("http://node1:8093/admin/ping", requested.ToString());
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.NotFound)]
+        [InlineData(HttpStatusCode.InternalServerError)]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        public async Task PingHttpServiceAsync_Throws_On_A_Failure_Status(HttpStatusCode statusCode)
+        {
+            //arrange
+
+            var factory = CreateFactory(_ => new HttpResponseMessage(statusCode));
+
+            //act, assert
+
+            await Assert.ThrowsAsync<HttpRequestException>(() =>
+                DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
+                    TimeSpan.FromSeconds(10), CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PingHttpServiceAsync_Honours_The_Supplied_Token()
+        {
+            //arrange
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var factory = CreateFactory(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+            //act, assert
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
+                    TimeSpan.FromMinutes(1), cts.Token));
+        }
+
+        [Fact]
+        public async Task PingHttpServiceAsync_Without_A_Token_Uses_The_Fallback_Timeout()
+        {
+            //arrange
+
+            var factory = CreateFactory(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+            //act, assert
+
+            // A generous fallback must not cancel a healthy ping.
+            await DiagnosticsReportProvider.PingHttpServiceAsync(factory, new Uri("http://node1:8093/admin/ping"),
+                TimeSpan.FromMinutes(1), CancellationToken.None);
+        }
+
+        private static MockHttpClientFactory CreateFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) =>
+            new(() => new HttpClient(FakeHttpMessageHandler.Create(handler)));
+    }
+}

--- a/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using Couchbase.Diagnostics;
+using Xunit;
+
+namespace Couchbase.UnitTests.Diagnostics
+{
+    public class WaitUntilReadyEvaluatorTests
+    {
+        [Theory]
+        [InlineData(ServiceType.KeyValue, "kv")]
+        [InlineData(ServiceType.Views, "view")]
+        [InlineData(ServiceType.Query, "n1ql")]
+        [InlineData(ServiceType.Analytics, "cbas")]
+        [InlineData(ServiceType.Search, "fts")]
+        public void ReportKey_Maps_Pingable_Services(ServiceType serviceType, string expected)
+        {
+            Assert.Equal(expected, WaitUntilReadyEvaluator.ReportKey(serviceType));
+        }
+
+        [Theory]
+        [InlineData(ServiceType.Config)]
+        [InlineData(ServiceType.Eventing)]
+        [InlineData(ServiceType.Management)]
+        public void ReportKey_Is_Null_For_Non_Pingable_Services(ServiceType serviceType)
+        {
+            Assert.Null(WaitUntilReadyEvaluator.ReportKey(serviceType));
+        }
+
+        [Fact]
+        public void Evaluate_All_Ok_Is_Online_And_Ready()
+        {
+            //arrange
+
+            var report = CreateReport(
+                ("kv", new[] { ServiceState.Ok, ServiceState.Ok }),
+                ("n1ql", new[] { ServiceState.Ok }));
+
+            //act
+
+            var result = WaitUntilReadyEvaluator.Evaluate(report,
+                new[] { ServiceType.KeyValue, ServiceType.Query }, ClusterState.Online);
+
+            //assert
+
+            Assert.Equal(ClusterState.Online, result.State);
+            Assert.True(result.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_One_Bad_Socket_Is_Degraded()
+        {
+            //arrange
+
+            var report = CreateReport(
+                ("kv", new[] { ServiceState.Ok, ServiceState.Error }),
+                ("n1ql", new[] { ServiceState.Ok }));
+            var expected = new[] { ServiceType.KeyValue, ServiceType.Query };
+
+            //act
+
+            var wantsOnline = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Online);
+            var wantsDegraded = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Degraded);
+
+            //assert
+
+            Assert.Equal(ClusterState.Degraded, wantsOnline.State);
+            Assert.False(wantsOnline.Ready);
+            Assert.True(wantsDegraded.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_Online_Also_Satisfies_A_Desired_Degraded()
+        {
+            //arrange
+
+            var report = CreateReport(("kv", new[] { ServiceState.Ok }));
+
+            //act
+
+            var result = WaitUntilReadyEvaluator.Evaluate(report, new[] { ServiceType.KeyValue }, ClusterState.Degraded);
+
+            //assert
+
+            Assert.Equal(ClusterState.Online, result.State);
+            Assert.True(result.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_Expected_Service_Absent_From_Report_Is_Not_Ready()
+        {
+            //arrange
+
+            var report = CreateReport(("kv", new[] { ServiceState.Ok }));
+            var expected = new[] { ServiceType.KeyValue, ServiceType.Query };
+
+            //act
+
+            var wantsOnline = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Online);
+            var wantsDegraded = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Degraded);
+
+            //assert
+
+            Assert.Equal(ClusterState.Offline, wantsOnline.State);
+            Assert.False(wantsOnline.Ready);
+            Assert.False(wantsDegraded.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_Expected_Service_With_Empty_List_Is_Not_Ready()
+        {
+            //arrange
+
+            var report = CreateReport(
+                ("kv", new ServiceState[0]),
+                ("n1ql", new[] { ServiceState.Ok }));
+            var expected = new[] { ServiceType.KeyValue, ServiceType.Query };
+
+            //act
+
+            var wantsOnline = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Online);
+            var wantsDegraded = WaitUntilReadyEvaluator.Evaluate(report, expected, ClusterState.Degraded);
+
+            //assert
+
+            Assert.Equal(ClusterState.Offline, wantsOnline.State);
+            Assert.False(wantsOnline.Ready);
+            Assert.False(wantsDegraded.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_No_Socket_Ok_For_A_Service_Is_Offline()
+        {
+            //arrange
+
+            var report = CreateReport(
+                ("kv", new[] { ServiceState.Ok }),
+                ("n1ql", new[] { ServiceState.Error, ServiceState.Error }));
+
+            //act
+
+            var result = WaitUntilReadyEvaluator.Evaluate(report,
+                new[] { ServiceType.KeyValue, ServiceType.Query }, ClusterState.Degraded);
+
+            //assert
+
+            Assert.Equal(ClusterState.Offline, result.State);
+            Assert.False(result.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_Empty_Expected_Set_Is_Ready()
+        {
+            //arrange
+
+            var report = CreateReport();
+
+            //act
+
+            var result = WaitUntilReadyEvaluator.Evaluate(report, new ServiceType[0], ClusterState.Online);
+
+            //assert
+
+            Assert.Equal(ClusterState.Online, result.State);
+            Assert.True(result.Ready);
+        }
+
+        [Fact]
+        public void Evaluate_Ignores_Services_That_Are_Not_Expected()
+        {
+            //arrange
+
+            var report = CreateReport(
+                ("kv", new[] { ServiceState.Ok }),
+                ("cbas", new[] { ServiceState.Error }));
+
+            //act
+
+            var result = WaitUntilReadyEvaluator.Evaluate(report, new[] { ServiceType.KeyValue }, ClusterState.Online);
+
+            //assert
+
+            Assert.Equal(ClusterState.Online, result.State);
+            Assert.True(result.Ready);
+        }
+
+        [Fact]
+        public void Describe_Reports_Missing_And_Partial_Services()
+        {
+            //arrange
+
+            var report = CreateReport(("kv", new[] { ServiceState.Ok, ServiceState.Error }));
+
+            //act
+
+            var description = WaitUntilReadyEvaluator.Describe(report,
+                new[] { ServiceType.KeyValue, ServiceType.Query });
+
+            //assert
+
+            Assert.Equal("kv 1/2 ok, n1ql missing", description);
+        }
+
+        [Fact]
+        public void Backoff_Doubles_From_Ten_Milliseconds()
+        {
+            //arrange
+
+            var backoff = new WaitUntilReadyBackoff();
+
+            //act
+
+            var delays = new List<double>();
+            for (var i = 0; i < 5; i++)
+            {
+                delays.Add(backoff.Next().TotalMilliseconds);
+            }
+
+            //assert
+
+            Assert.Equal(new double[] { 10, 20, 40, 80, 160 }, delays);
+        }
+
+        [Fact]
+        public void Backoff_Caps_At_One_Second()
+        {
+            //arrange
+
+            var backoff = new WaitUntilReadyBackoff();
+
+            //act
+
+            TimeSpan delay = default;
+            for (var i = 0; i < 20; i++)
+            {
+                delay = backoff.Next();
+            }
+
+            //assert
+
+            Assert.Equal(TimeSpan.FromSeconds(1), delay);
+        }
+
+        private static IPingReport CreateReport(params (string Key, ServiceState[] States)[] services)
+        {
+            var endpoints = new Dictionary<string, IEnumerable<IEndpointDiagnostics>>();
+            foreach (var service in services)
+            {
+                var entries = new List<IEndpointDiagnostics>();
+                foreach (var state in service.States)
+                {
+                    entries.Add(new EndpointDiagnostics { State = state });
+                }
+
+                endpoints.Add(service.Key, entries);
+            }
+
+            return new PingReport("report-id", 0, endpoints);
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Couchbase.Core.Configuration.Server;
 using Couchbase.Diagnostics;
 using Xunit;
 
@@ -240,6 +241,65 @@ namespace Couchbase.UnitTests.Diagnostics
 
             Assert.Equal(TimeSpan.FromSeconds(1), delay);
         }
+
+        [Fact]
+        public void ExpectedServices_Includes_The_Http_Services_Without_Their_Clients()
+        {
+            //arrange
+
+            var config = CreateConfig();
+
+            //act
+
+            var expected = WaitUntilReadyEvaluator.ExpectedServices(null, config,
+                new[] { ServiceType.Query, ServiceType.Search, ServiceType.Analytics }, bucketLevel: true);
+
+            //assert
+
+            Assert.Equal(new HashSet<ServiceType>
+            {
+                ServiceType.Query, ServiceType.Search, ServiceType.Analytics
+            }, expected);
+        }
+
+        [Fact]
+        public void ExpectedServices_Drops_Views_Without_A_View_Client()
+        {
+            //arrange
+
+            var config = CreateConfig();
+
+            //act
+
+            var expected = WaitUntilReadyEvaluator.ExpectedServices(null, config,
+                new[] { ServiceType.Views }, bucketLevel: true);
+
+            //assert
+
+            Assert.Empty(expected);
+        }
+
+        private static BucketConfig CreateConfig() =>
+            new()
+            {
+                Name = "default",
+                BucketCapabilities = new List<string> { BucketCapabilities.COUCHAPI },
+                NodesExt = new List<NodesExt>
+                {
+                    new()
+                    {
+                        Hostname = "node1",
+                        Services = new Services
+                        {
+                            Kv = 11210,
+                            Capi = 8092,
+                            N1Ql = 8093,
+                            Fts = 8094,
+                            Cbas = 8095
+                        }
+                    }
+                }
+            };
 
         private static IPingReport CreateReport(params (string Key, ServiceState[] States)[] services)
         {

--- a/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
+++ b/tests/Couchbase.UnitTests/Diagnostics/WaitUntilReadyEvaluatorTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Couchbase.Core;
 using Couchbase.Core.Configuration.Server;
 using Couchbase.Diagnostics;
+using Moq;
 using Xunit;
 
 namespace Couchbase.UnitTests.Diagnostics
@@ -277,6 +279,25 @@ namespace Couchbase.UnitTests.Diagnostics
             //assert
 
             Assert.Empty(expected);
+        }
+
+        [Fact]
+        public void HasTopology_Is_False_Without_A_Config_And_Without_Nodes()
+        {
+            Assert.False(WaitUntilReadyEvaluator.HasTopology(null, Array.Empty<IClusterNode>()));
+            Assert.False(WaitUntilReadyEvaluator.HasTopology(null, null));
+        }
+
+        [Fact]
+        public void HasTopology_Is_True_With_A_Config()
+        {
+            Assert.True(WaitUntilReadyEvaluator.HasTopology(CreateConfig(), Array.Empty<IClusterNode>()));
+        }
+
+        [Fact]
+        public void HasTopology_Is_True_With_A_Node()
+        {
+            Assert.True(WaitUntilReadyEvaluator.HasTopology(null, new[] { new Mock<IClusterNode>().Object }));
         }
 
         private static BucketConfig CreateConfig() =>


### PR DESCRIPTION
## Motivation

This PR makes the cluster state rules match the RFC by pinging each HTTP service node on its own health endpoint, bound each ping by its service timeout, waiting for a real topology before evaluating, and sharing one poll loop with exponential backoff between cluster and bucket.

- A requested service with no entry in the ping report was treated as healthy, so WaitUntilReady could return Online before that service was reachable.
- Degraded and Offline were decided by counting failed services, not by checking that every service still had at least one healthy endpoint as the RFC requires.
- Query, Analytics and Search were pinged at random, so one healthy node could answer for every entry and hide a node that was down. On a cluster with dedicated service nodes, a bucket level ping skipped nodes that had no KV service.
- The ping timeout only applied when the caller gave no cancellation token, so one unresponsive node could stall a whole pass and block a caller waiting for Degraded.
- A bucket with no config or nodes yet had nothing to verify and reported ready before bootstrap.
- Cluster and bucket duplicated the poll loop and polled at a fixed 100 ms.

## Changes

- A service is expected only when the topology advertises it and the SDK can ping it, and every expected service must have an entry to be Online.
- Ping Query, Analytics and Search on each node's own health endpoint, scoped to the whole cluster so service only nodes are covered. Report host and port as the remote, in line with the other SDKs.
- Apply the service timeout to every HTTP ping, with or without a caller token, and stop the `HttpClient`'s default timeout from cutting it short.
- Ping each host once when several open buckets each hold their own copy of a node, using the copy with the newest config.
- Keep polling until the bucket has a config with nodes or at least one connected node.
- Share the poll loop, backoff and logging between cluster and bucket level WaitUntilReady.
