### PR TITLE
NCBC-4280: Keep a usable node when one KV connection fails to connect

### DIFF
--- a/src/Couchbase/Cluster.cs
+++ b/src/Couchbase/Cluster.cs
@@ -52,6 +52,11 @@ namespace Couchbase
         private bool _disposed;
         private readonly ClusterContext _context;
         private bool _hasBootStrapped = false;
+
+        // Warn once on entering the failed state, not on every bootstrapper poll (2.5s by
+        // default), which would warn forever on a cluster that stays down.
+        private bool _bootstrapFailureLogged;
+
         private readonly SemaphoreSlim _bootstrapLock = new SemaphoreSlim(1);
         private readonly IRedactor _redactor;
         private readonly IBootstrapper _bootstrapper;
@@ -218,6 +223,16 @@ namespace Couchbase
             {
                 await ((IBootstrappable)cluster).BootStrapAsync(cancellationToken).ConfigureAwait(false);
                 cluster.StartBootstrapper();
+
+                // BootStrapAsync defers most failures rather than throwing, so reaching here
+                // does not mean the cluster is usable.
+                if (!cluster.IsBootstrapped)
+                {
+                    cluster._logger.LogWarning(
+                        "ConnectAsync is returning a cluster which has not bootstrapped; cluster-level operations will fail "
+                        + "until it does. If the cluster is 6.5 or earlier this is expected — it bootstraps per-bucket, so "
+                        + "open a bucket instead. Otherwise, await WaitUntilReadyAsync(..) to wait for bootstrapping to complete.");
+                }
 
                 // We can re-ify the Transactions now that we are bootstrapped.  We need
                 // to do this because extSDKIntegration means we may configure the cleanup
@@ -670,6 +685,7 @@ namespace Couchbase
                 //if we succeeded set the state of the cluster to bootstrapped
                 _hasBootStrapped = _context.GlobalConfig != null;
                 _deferredExceptions.Clear();
+                _bootstrapFailureLogged = false;
 
                 //start the collector here now that we have bootstrapped and global bootstrap is not null
                 _appTelemetryCollector.Initialize();
@@ -698,7 +714,23 @@ namespace Couchbase
             catch (Exception e)
             {
                 _deferredExceptions.Add(e);
-                _logger.LogDebug("Error encountered bootstrapping cluster; if the cluster is 6.5 or earlier, this can be ignored. {exception}.", e);
+
+                // Deferring is only excusable for 6.5-or-earlier, which bootstraps per-bucket.
+                // Anything else deferred here fails every cluster-level operation until a later
+                // attempt succeeds, so entering that state warrants more than Debug.
+                if (!_bootstrapFailureLogged)
+                {
+                    _bootstrapFailureLogged = true;
+
+                    _logger.LogWarning(e,
+                        "Error encountered bootstrapping the cluster; cluster-level operations will fail until it bootstraps. "
+                        + "This is expected only for clusters at 6.5 or earlier, which bootstrap per-bucket instead. "
+                        + "Further failures will be logged at Debug until it bootstraps.");
+                }
+                else
+                {
+                    _logger.LogDebug(e, "The cluster still has not bootstrapped.");
+                }
             }
         }
 

--- a/src/Couchbase/Core/Bootstrapping/Bootstrapper.cs
+++ b/src/Couchbase/Core/Bootstrapping/Bootstrapper.cs
@@ -70,12 +70,16 @@ namespace Couchbase.Core.Bootstrapping
                 if (!subject.IsBootstrapped)
                 {
                     _logger.LogDebug("The subject is not bootstrapped.");
+
+                    // A subject may record a failure in DeferredExceptions instead of throwing, so a
+                    // normal return is not success — clearing the list would report the failed attempt
+                    // as bootstrapped and stop the retry loop. Discard only the failures already
+                    // present, by identity: subjects clear the list themselves on success, so removing
+                    // by position could take this attempt's instead.
+                    var staleFailures = subject.DeferredExceptions.ToArray();
                     try
                     {
                         await subject.BootStrapAsync(token).ConfigureAwait(false);
-                        subject.DeferredExceptions.Clear();
-
-                        _logger.LogDebug("The subject has successfully bootstrapped.");
                     }
                     catch (Exception e)
                     {
@@ -83,6 +87,25 @@ namespace Couchbase.Core.Bootstrapping
 
                         //catch any errors not caught in the bootstrap catch clause
                         subject.DeferredExceptions.Add(e);
+                    }
+                    finally
+                    {
+                        // In a finally, so a subject which throws every attempt does not accumulate
+                        // one exception per poll indefinitely.
+                        foreach (var staleFailure in staleFailures)
+                        {
+                            subject.DeferredExceptions.Remove(staleFailure);
+                        }
+                    }
+
+                    if (subject.IsBootstrapped)
+                    {
+                        _logger.LogDebug("The subject has successfully bootstrapped.");
+                    }
+                    else
+                    {
+                        _logger.LogDebug("The subject did not bootstrap; {failureCount} deferred failure(s) recorded.",
+                            subject.DeferredExceptions.Count);
                     }
                 }
 

--- a/src/Couchbase/Core/IO/Connections/Channels/ChannelConnectionPool.cs
+++ b/src/Couchbase/Core/IO/Connections/Channels/ChannelConnectionPool.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Couchbase.Core.Diagnostics.Metrics;
+using Couchbase.Core.Exceptions;
 using Couchbase.Core.IO.Operations;
 using Couchbase.Core.Logging;
 using Couchbase.Utils;
@@ -105,11 +106,29 @@ namespace Couchbase.Core.IO.Connections.Channels
                 return;
             }
 
-            await AddConnectionsAsync(MinimumSize, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await AddConnectionsAsync(MinimumSize, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (Size > 0 && !cancellationToken.IsCancellationRequested)
+            {
+                // One working connection is enough to keep the node; the scale controller backfills
+                // the rest. A lossy path can drop one connection's handshake while its sibling
+                // succeeds, and discarding the node then throws away a usable connection.
+                LogPartialPoolInitialization(_redactor.SystemData(EndPoint), Size, MinimumSize, ex);
+            }
+
+            // AddConnectionsAsync drops a dead connection without throwing, so the pool can end up
+            // empty with nothing for the filter above to catch. Unlike DataFlowConnectionPool there
+            // is no recovery on send here, so reject it.
+            if (MinimumSize > 0 && Size == 0)
+            {
+                throw new ConnectException($"Unable to open any connections to {EndPoint}.");
+            }
 
             _scaleController.Start(this);
 
-            InitializedConnectionPool(_redactor.SystemData(EndPoint), MinimumSize);
+            InitializedConnectionPool(_redactor.SystemData(EndPoint), Size);
 
             _initialized = true;
             _disposed = false;
@@ -295,7 +314,9 @@ namespace Couchbase.Core.IO.Connections.Channels
 
                 if (connection.IsDead)
                 {
+                    // Already connected, so it owns a socket even though it is unusable.
                     LogConnectionToEndpointError(EndPoint);
+                    connection.Dispose();
                     return;
                 }
 
@@ -378,6 +399,9 @@ namespace Couchbase.Core.IO.Connections.Channels
 
         [LoggerMessage(102, LogLevel.Debug, "Disposing pool for {endpoint} that was already disposed")]
         private partial void LogAlreadyDisposedConnectionPool(HostEndpointWithPort endpoint);
+
+        [LoggerMessage(103, LogLevel.Warning, "Connection pool for {endpoint} started with {size} of {minimumSize} connections; continuing with a partial pool.")]
+        private partial void LogPartialPoolInitialization(object endpoint, int size, int minimumSize, Exception exception);
 
         #endregion
     }

--- a/src/Couchbase/Core/IO/Connections/ConnectionFactory.cs
+++ b/src/Couchbase/Core/IO/Connections/ConnectionFactory.cs
@@ -38,7 +38,7 @@ namespace Couchbase.Core.IO.Connections
             _ipEndPointService = ipEndPointService ?? throw new ArgumentNullException(nameof(ipEndPointService));
             _multiplexLogger = multiplexLogger ?? throw new ArgumentNullException(nameof(multiplexLogger));
             _sslLogger = sslLogger ?? throw new ArgumentNullException(nameof(sslLogger));
-            _redactor = redactor;
+            _redactor = redactor ?? throw new ArgumentNullException(nameof(redactor));
             _callbackFactory = callbackFactory ?? throw new ArgumentNullException(nameof(callbackFactory));
         }
 
@@ -57,6 +57,11 @@ namespace Couchbase.Core.IO.Connections
             {
                 throw new ConnectException($"Unable to resolve host '{hostEndpoint}'.");
             }
+
+            // The resolved address is otherwise unlogged on .NET Core and later, so a connect
+            // failure cannot be attributed to an address after the fact.
+            _multiplexLogger.LogDebug("Connecting to {Host} at {Address}.",
+                _redactor.SystemData(hostEndpoint.Host), _redactor.SystemData(endPoint));
 
             var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             try

--- a/src/Couchbase/Core/IO/Connections/DataFlow/DataFlowConnectionPool.cs
+++ b/src/Couchbase/Core/IO/Connections/DataFlow/DataFlowConnectionPool.cs
@@ -85,12 +85,27 @@ namespace Couchbase.Core.IO.Connections.DataFlow
                 return;
             }
 
-            await AddConnectionsAsync(MinimumSize, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await AddConnectionsAsync(MinimumSize, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (Size > 0 && !cancellationToken.IsCancellationRequested)
+            {
+                // One working connection is enough to keep the node; the scale controller backfills
+                // the rest. A lossy path can drop one connection's handshake while its sibling
+                // succeeds, and discarding the node then throws away a usable connection.
+                _logger.LogWarning(ex,
+                    "Connection pool for {endpoint} started with {size} of {minimumSize} connections; continuing with a partial pool.",
+                    _redactor.SystemData(EndPoint), Size, MinimumSize);
+            }
+
+            // An empty pool is tolerated here: SendAsync recovers via CleanupDeadConnectionsAsync.
+            // ChannelConnectionPool has no such path and rejects it.
 
             _scaleController.Start(this);
 
             _logger.LogDebug("Connection pool for {endpoint} initialized with {size} connections.",
-                _redactor.SystemData(EndPoint), MinimumSize);
+                _redactor.SystemData(EndPoint), Size);
 
             _initialized = true;
         }
@@ -297,7 +312,9 @@ namespace Couchbase.Core.IO.Connections.DataFlow
 
                 if (connection.IsDead)
                 {
+                    // Already connected, so it owns a socket even though it is unusable.
                     _logger.LogDebug("Connection for {endpoint} could not be started.", EndPoint);
+                    connection.Dispose();
                     return;
                 }
                 _logger.LogDebug("Connection for {endpoint} has been started.", EndPoint);

--- a/tests/Couchbase.UnitTests/Core/BootstrapperTests.cs
+++ b/tests/Couchbase.UnitTests/Core/BootstrapperTests.cs
@@ -103,6 +103,199 @@ namespace Couchbase.UnitTests.Core
                   Assert.True(bootstrapped, "Expected IsBootstrapped to be true after successful bootstrap");
               }
           }
+         [Fact]
+         public async Task When_Bootstrap_Defers_Failure_Without_Throwing_Failure_Is_Not_Cleared()
+         {
+             // Cluster.BootStrapAsync records a bootstrap failure in DeferredExceptions and returns
+             // normally rather than throwing, so a normal return must not be reported as success.
+             var subject = new DeferringBootstrappable();
+             using var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+             var bootStrapper = new Bootstrapper(tcs, new Mock<ILogger<Bootstrapper>>().Object)
+             {
+                 SleepDuration = TimeSpan.FromMilliseconds(50)
+             };
+
+             // Start un-bootstrapped, so the bootstrapper actually makes an attempt.
+             subject.DeferredExceptions.Add(new Exception("Earlier failure."));
+
+             bootStrapper.Start(subject);
+
+             // Retrying at all proves the failed attempt was not mistaken for a success. The subject
+             // blocks on entry to the second attempt, so observing it means the first attempt has been
+             // fully processed and the list cannot change underneath the assertions below.
+             var retried = await AsyncTestHelper.WaitForConditionAsync(
+                 () => subject.AttemptCount >= 2,
+                 timeout: TimeSpan.FromSeconds(5));
+
+             Assert.True(retried, "Expected the bootstrapper to keep retrying after a deferred failure");
+             Assert.False(subject.IsBootstrapped);
+             Assert.NotEmpty(subject.DeferredExceptions);
+
+             // Stale failures are still discarded, so repeated attempts must not accumulate.
+             Assert.Single(subject.DeferredExceptions);
+
+             // Let the blocked attempt finish so the bootstrapper loop unwinds on cancellation.
+             subject.Release();
+         }
+
+         [Fact]
+         public async Task When_Subject_Clears_Its_Own_Failures_This_Attempts_Failure_Survives()
+         {
+             // CouchbaseBucket clears DeferredExceptions itself before recording a new failure, so the
+             // stale entries cannot be discarded by position — that would remove this attempt's failure
+             // instead, report success and stop the retry loop.
+             var subject = new ClearingBootstrappable();
+             using var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+             var bootStrapper = new Bootstrapper(tcs, new Mock<ILogger<Bootstrapper>>().Object)
+             {
+                 SleepDuration = TimeSpan.FromMilliseconds(50)
+             };
+
+             // Start un-bootstrapped, so the bootstrapper actually makes an attempt.
+             subject.DeferredExceptions.Add(new Exception("Earlier failure."));
+
+             bootStrapper.Start(subject);
+
+             var retried = await AsyncTestHelper.WaitForConditionAsync(
+                 () => subject.AttemptCount >= 2,
+                 timeout: TimeSpan.FromSeconds(5));
+
+             Assert.True(retried, "Expected the bootstrapper to keep retrying; the new failure was discarded");
+             Assert.False(subject.IsBootstrapped);
+             Assert.Single(subject.DeferredExceptions);
+
+             subject.Release();
+         }
+
+         [Fact]
+         public async Task When_Bootstrap_Throws_Failures_Do_Not_Accumulate()
+         {
+             // BucketBase.BootStrapAsync throws rather than defers, and the bootstrapper records the
+             // exception on every poll. Stale failures must still be discarded or the list grows
+             // without bound for as long as the subject stays broken.
+             var subject = new ThrowingBootstrappable();
+             using var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+             var bootStrapper = new Bootstrapper(tcs, new Mock<ILogger<Bootstrapper>>().Object)
+             {
+                 SleepDuration = TimeSpan.FromMilliseconds(50)
+             };
+
+             // Start un-bootstrapped, so the bootstrapper actually makes an attempt.
+             subject.DeferredExceptions.Add(new Exception("Earlier failure."));
+
+             bootStrapper.Start(subject);
+
+             // The subject blocks on entry to the third attempt, so observing it means the first two
+             // were processed to completion and the list cannot change under the assertion.
+             var retried = await AsyncTestHelper.WaitForConditionAsync(
+                 () => subject.AttemptCount >= 3,
+                 timeout: TimeSpan.FromSeconds(5));
+
+             Assert.True(retried, "Expected the bootstrapper to keep retrying after a thrown failure");
+             Assert.False(subject.IsBootstrapped);
+
+             // Only the most recent attempt's failure is retained, however many attempts have run.
+             Assert.Single(subject.DeferredExceptions);
+
+             subject.Release();
+         }
+    }
+
+    /// <summary>
+    /// Records a bootstrap failure the way <see cref="Cluster"/> does — deferred, without throwing.
+    /// </summary>
+    public class DeferringBootstrappable : IBootstrappable
+    {
+        private readonly TaskCompletionSource<bool> _released =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private int _attemptCount;
+
+        public int AttemptCount => Volatile.Read(ref _attemptCount);
+
+        /// <summary>
+        /// Unblocks the second and subsequent attempts.
+        /// </summary>
+        public void Release() => _released.TrySetResult(true);
+
+        async Task IBootstrappable.BootStrapAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _attemptCount) >= 2)
+            {
+                // Hold from the second attempt onwards, before recording anything. The count is
+                // incremented first, so a caller which sees it reach 2 knows the first attempt was
+                // processed to completion and that no further mutation can occur until Release.
+                await _released.Task.ConfigureAwait(false);
+            }
+
+            DeferredExceptions.Add(new Exception("Bootstrapping has failed."));
+        }
+
+        public bool IsBootstrapped => !DeferredExceptions.Any();
+        public List<Exception> DeferredExceptions { get; } = new List<Exception>();
+    }
+
+    /// <summary>
+    /// Clears the deferred failures before recording a new one, the way CouchbaseBucket does.
+    /// </summary>
+    public class ClearingBootstrappable : IBootstrappable
+    {
+        private readonly TaskCompletionSource<bool> _released =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private int _attemptCount;
+
+        public int AttemptCount => Volatile.Read(ref _attemptCount);
+
+        /// <summary>
+        /// Unblocks the second and subsequent attempts.
+        /// </summary>
+        public void Release() => _released.TrySetResult(true);
+
+        async Task IBootstrappable.BootStrapAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _attemptCount) >= 2)
+            {
+                await _released.Task.ConfigureAwait(false);
+            }
+
+            DeferredExceptions.Clear();
+            DeferredExceptions.Add(new Exception("Bootstrapping has failed."));
+        }
+
+        public bool IsBootstrapped => !DeferredExceptions.Any();
+        public List<Exception> DeferredExceptions { get; } = new List<Exception>();
+    }
+
+    /// <summary>
+    /// Throws from the bootstrap the way BucketBase does, rather than deferring.
+    /// </summary>
+    public class ThrowingBootstrappable : IBootstrappable
+    {
+        private readonly TaskCompletionSource<bool> _released =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private int _attemptCount;
+
+        public int AttemptCount => Volatile.Read(ref _attemptCount);
+
+        /// <summary>
+        /// Unblocks the third and subsequent attempts.
+        /// </summary>
+        public void Release() => _released.TrySetResult(true);
+
+        async Task IBootstrappable.BootStrapAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _attemptCount) >= 3)
+            {
+                await _released.Task.ConfigureAwait(false);
+            }
+
+            throw new Exception("Bootstrapping has failed.");
+        }
+
+        public bool IsBootstrapped => !DeferredExceptions.Any();
+        public List<Exception> DeferredExceptions { get; } = new List<Exception>();
     }
 
     public class FakeBootstrappable : IBootstrappable

--- a/tests/Couchbase.UnitTests/Core/IO/Connections/Channels/ChannelConnectionPoolTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Connections/Channels/ChannelConnectionPoolTests.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.Diagnostics.Metrics;
+using Couchbase.Core.Exceptions;
 using Couchbase.Core.Exceptions.KeyValue;
 using Couchbase.Core.IO.Connections;
 using Couchbase.Core.IO.Connections.Channels;
@@ -57,6 +59,144 @@ namespace Couchbase.UnitTests.Core.IO.Connections.Channels
             connectionFactory.Verify(
                 m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()),
                 Times.Exactly(size));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_SomeConnectionsFail_KeepsPartialPool()
+        {
+            // Arrange
+
+            // A host is not always equally reachable on every connection attempt, so one connection can
+            // succeed while a sibling times out. The node is still usable and must not be discarded.
+            var attempt = 0;
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() => Interlocked.Increment(ref attempt) == 1
+                    ? Task.FromResult(new Mock<IConnection>().Object)
+                    : Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut)));
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act
+
+            await pool.InitializeAsync();
+
+            // Assert
+
+            Assert.Equal(1, pool.Size);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_AllConnectionsFail_Throws()
+        {
+            // Arrange
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut)));
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act / Assert
+
+            // An empty pool is not a usable node, so this must still fail rather than be tolerated.
+            await Assert.ThrowsAsync<SocketException>(() => pool.InitializeAsync());
+            Assert.Equal(0, pool.Size);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_AllConnectionsDead_Throws()
+        {
+            // Arrange
+
+            // A connection which comes back dead is dropped without throwing, so an empty pool can be
+            // reached without any exception to catch. That is still not a usable node.
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var connection = new Mock<IConnection>();
+                    connection.SetupGet(m => m.IsDead).Returns(true);
+                    return connection.Object;
+                });
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act / Assert
+
+            await Assert.ThrowsAsync<ConnectException>(() => pool.InitializeAsync());
+            Assert.Equal(0, pool.Size);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_DeadConnection_IsDisposed()
+        {
+            // Arrange
+
+            // A dead connection has already connected, so it owns a socket which nothing else will
+            // close once the pool drops the reference.
+            var connection = new Mock<IConnection>();
+            connection.SetupGet(m => m.IsDead).Returns(true);
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => connection.Object);
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 1;
+            pool.MaximumSize = 1;
+
+            // Act / Assert
+
+            await Assert.ThrowsAsync<ConnectException>(() => pool.InitializeAsync());
+
+            connection.Verify(m => m.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_Cancelled_ThrowsEvenWithAWorkingConnection()
+        {
+            // Arrange
+
+            // A partial pool is only tolerable when the caller still wants the node. If the caller
+            // cancelled, the failure must surface rather than be swallowed.
+            var attempt = 0;
+            using var cts = new CancellationTokenSource();
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref attempt) == 1)
+                    {
+                        return Task.FromResult(new Mock<IConnection>().Object);
+                    }
+
+                    cts.Cancel();
+                    return Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut));
+                });
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act / Assert
+
+            // Without the cancellation check this would be swallowed as a partial pool, since one
+            // connection did come up.
+            await Assert.ThrowsAsync<SocketException>(() => pool.InitializeAsync(cts.Token));
+            Assert.Equal(1, pool.Size);
         }
 
         #endregion

--- a/tests/Couchbase.UnitTests/Core/IO/Connections/DataFlow/DataFlowConnectionPoolTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Connections/DataFlow/DataFlowConnectionPoolTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.Exceptions.KeyValue;
@@ -56,6 +57,121 @@ namespace Couchbase.UnitTests.Core.IO.Connections.DataFlow
             connectionFactory.Verify(
                 m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()),
                 Times.Exactly(size));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_SomeConnectionsFail_KeepsPartialPool()
+        {
+            // Arrange
+
+            // A host is not always equally reachable on every connection attempt, so one connection can
+            // succeed while a sibling times out. The node is still usable and must not be discarded.
+            var attempt = 0;
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() => Interlocked.Increment(ref attempt) == 1
+                    ? Task.FromResult(new Mock<IConnection>().Object)
+                    : Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut)));
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act
+
+            await pool.InitializeAsync();
+
+            // Assert
+
+            Assert.Equal(1, pool.Size);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_AllConnectionsFail_Throws()
+        {
+            // Arrange
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut)));
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act / Assert
+
+            // An empty pool is not a usable node, so this must still fail rather than be tolerated.
+            await Assert.ThrowsAsync<SocketException>(() => pool.InitializeAsync());
+            Assert.Equal(0, pool.Size);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_DeadConnection_IsDisposed()
+        {
+            // Arrange
+
+            // A dead connection has already connected, so it owns a socket which nothing else will
+            // close once the pool drops the reference.
+            var connection = new Mock<IConnection>();
+            connection.SetupGet(m => m.IsDead).Returns(true);
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => connection.Object);
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 1;
+            pool.MaximumSize = 1;
+
+            // Act
+
+            // This pool tolerates an empty result and recovers on send, so initialization succeeds.
+            await pool.InitializeAsync();
+
+            // Assert
+
+            Assert.Equal(0, pool.Size);
+            connection.Verify(m => m.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_Cancelled_ThrowsEvenWithAWorkingConnection()
+        {
+            // Arrange
+
+            // A partial pool is only tolerable when the caller still wants the node. If the caller
+            // cancelled, the failure must surface rather than be swallowed.
+            var attempt = 0;
+            using var cts = new CancellationTokenSource();
+
+            var connectionFactory = new Mock<IConnectionFactory>();
+            connectionFactory
+                .Setup(m => m.CreateAndConnectAsync(_hostEndpoint, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref attempt) == 1)
+                    {
+                        return Task.FromResult(new Mock<IConnection>().Object);
+                    }
+
+                    cts.Cancel();
+                    return Task.FromException<IConnection>(new SocketException((int) SocketError.TimedOut));
+                });
+
+            var pool = CreatePool(connectionFactory: connectionFactory.Object);
+            pool.MinimumSize = 2;
+            pool.MaximumSize = 2;
+
+            // Act / Assert
+
+            // Without the cancellation check this would be swallowed as a partial pool, since one
+            // connection did come up.
+            await Assert.ThrowsAsync<SocketException>(() => pool.InitializeAsync(cts.Token));
+            Assert.Equal(1, pool.Size);
         }
 
         #endregion


### PR DESCRIPTION
Motivation
==========
Scenarios in the Capella private-endpoint situational suite
intermittently failed their scored ramp with tens of thousands of
"Cluster has not yet bootstrapped" errors -- 106830 and 58472 in one 8.0
run. Which scenarios were hit varied from run to run, and none failed
outside the ramp, but the suite never came through clean.

For a window after a PrivateLink endpoint reports available, its data
path is lossy rather than down. Of the two pool connections opened to
the same address, one completed TCP, TLS and Helo while its sibling
never got a SYN through and died at KvConnectTimeout.
AddConnectionsAsync keeps the connections that succeed, but the
Task.WhenAll it ends with rethrows if any failed, so the caller
discarded the whole node along with its working connection. With no
nodes, IsBootstrapped stayed false for the entire ramp.

Bootstrapper.Execute then cleared DeferredExceptions unconditionally
after BootStrapAsync returned. Cluster records most failures there
rather than throwing, so the clear reported the failed attempt as a
success, stopped the retry loop, and left the reported error carrying
no inner exceptions.

Modification
============
Keep a partial pool when at least one connection came up and let the
scale controller backfill the rest; an empty pool still fails. Both
pools are fixed, though ChannelConnectionPool is the one in use. This
matches Java and Go, which treat one connected connection as a usable
node and default to one KV connection per node where .NET uses two --
which is why only .NET was exposed.

Bootstrapper now discards only the failures present before an attempt,
by identity, in a finally so a subject which throws cannot accumulate
one exception per poll. Cluster warns on entering the failed state and
drops to Debug while it persists; ConnectAsync warns when returning an
unbootstrapped cluster.

Also fixed here: a connection which comes back dead is disposed rather
than leaked, and the address a KV connection is made to is logged at
Debug, having been unrecorded on .NET Core and later.

Results
=======
Three runs of op-capella-pe-sit-lite against server 8.0: zero errors
during the scored ramp in all 15 scenarios, against a baseline where 2
of 5 scenarios produced 106830 and 58472. The suite failure remaining
in two of those runs is a single error during the change phase -- a
known scoring issue, not this path.

op-onprem-func-release on 8.0 and 7.6 exercised the new paths about
1270 times per leg without either warning firing, so healthy clusters
are unaffected.

Each fix has a unit test confirmed to fail against the previous
behaviour.
