### PR TITLE
NCBC-4283: Let FIT runs test a branch's performer image

### DIFF
--- a/.github/workflows/fit-testing-dotnet.yml
+++ b/.github/workflows/fit-testing-dotnet.yml
@@ -29,6 +29,14 @@ on:
         required: false
         type: string
         default: ci
+      performer_tag:
+        description: >-
+          Tag of the ghcr.io/couchbase/dotnet-fit-performer image to test. Defaults to the branch
+          this workflow is run from. The SDK under test lives inside that image, so build it first
+          via "Publish FIT Performer Image" with ref=<your-branch> — otherwise the run fails to
+          pull the image. Use "main" to test master's SDK from a branch.
+        required: false
+        type: string
 
 permissions:
   id-token: write   # required for GitHub OIDC
@@ -36,10 +44,39 @@ permissions:
   checks: write
 
 jobs:
+  # The SDK under test is baked into the performer image, not taken from the branch this workflow
+  # runs on, so the image tag has to track the branch for a branch run to test that branch's code.
+  # A `uses:` job cannot also have `steps`, hence the separate job to derive the tag.
+  performer-tag:
+    runs-on: ubuntu-latest
+    permissions: {}   # no OIDC token needed here, unlike the fit job
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - id: resolve
+        env:
+          # Via env, not inlined into the script: ${{ }} is substituted before bash parses it.
+          PERFORMER_TAG: ${{ inputs.performer_tag }}
+        run: |
+          TAG="$PERFORMER_TAG"
+          if [[ -z "$TAG" ]]; then
+            # No input (a branch run with the default, or the nightly, which passes no inputs at
+            # all) — derive the tag the same way the publish side does. See
+            # couchbaselabs/sdk-docker-build-action, which renames master to main, and
+            # docker/metadata-action, which collapses runs of [^a-zA-Z0-9._-] to '-' (so a branch
+            # like dk/ncbc-4300 is published as dk-ncbc-4300).
+            TAG="$GITHUB_REF_NAME"
+            [[ "$TAG" == "master" ]] && TAG=main
+            TAG=$(printf '%s' "$TAG" | sed -E 's/[^a-zA-Z0-9._-]+/-/g')
+          fi
+          echo "Testing performer image dotnet-fit-performer:$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
   fit:
+    needs: performer-tag
     uses: couchbaselabs/fit-cli/.github/workflows/fit-cli.yaml@main
     with:
       preset: ${{ vars.FIT_CLI_PRESET || inputs.preset || 'op-multi-lite' }}
       collect_extra_diagnostics: ${{ inputs.collect_extra_diagnostics == '' && true || inputs.collect_extra_diagnostics }}
-      performer: 'dotnet-fit-performer:main'
+      performer: dotnet-fit-performer:${{ needs.performer-tag.outputs.tag }}
       channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'ci' }}


### PR DESCRIPTION
[NCBC-4283](https://couchbasecloud.atlassian.net/browse/NCBC-4283)

## Problem

`fit-testing-dotnet.yml` hardcoded `performer: 'dotnet-fit-performer:main'`, so every FIT run tested master's SDK.

The SDK under test is baked into the performer image (built by `publish-fit-performer.yml` from a chosen ref), not taken from the calling workflow's checkout. Selecting a branch in the Actions UI therefore changed *which YAML ran* but not *which code was tested* — the UI implies otherwise, so a PR could pass FIT without its changes ever being exercised. The workaround was a throwaway commit editing the hardcoded tag on the branch.

## Change

Adds an optional `performer_tag` dispatch input, defaulting to the branch the workflow is run from.

Deriving that tag needs shell — `dk/ncbc-4283` is not a valid Docker tag — and a `uses:` job cannot also have `steps`, so a small `performer-tag` job resolves it and passes it via job outputs. It mirrors the two rules the publish side already applies:

- `sdk-docker-build-action` renames `master` → `main`
- `docker/metadata-action` collapses runs of `[^a-zA-Z0-9._-]` to `-`

Verified against the tags actually published to ghcr.io today:

| `GITHUB_REF_NAME` | performer tag |
| --- | --- |
| `master` (nightly) | `main` |
| `dk/ncbc-4300` | `dk-ncbc-4300` |
| `dk/pe-ramp-bootstrap` | `dk-pe-ramp-bootstrap` |
| `NCBC-4271` | `NCBC-4271` |
| `release/3.9.x` | `release-3.9.x` |

The resolved image is echoed into the job log, so a run states what it tested.

The input is passed via `env:` rather than interpolated into the script body, since `${{ }}` is substituted before bash parses it. The tag job gets `permissions: {}` — it has no need for the OIDC token the `fit` job requires.

## Nightly is unchanged

`schedule` passes no inputs and `GITHUB_REF_NAME` is `master`, which resolves to `main` exactly as before.

## Usage

Build the image first, or the run fails to pull it:

1. **Publish FIT Performer Image** with `ref=<your-branch>`
2. **Run FIT-CLI** from `<your-branch>` — no `performer_tag` needed

Pass `performer_tag: main` to test master's SDK from a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NCBC-4283]: https://couchbasecloud.atlassian.net/browse/NCBC-4283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ