### PR TITLE
NCBC-4284: Prune stale dotnet-fit-performer images

### DIFF
--- a/.github/workflows/prune-stale-images.yml
+++ b/.github/workflows/prune-stale-images.yml
@@ -1,0 +1,46 @@
+name: Prune stale images
+
+# Nothing else prunes ghcr.io/couchbase/dotnet-fit-performer. Most of the growth is
+# publish-fit-performer.yml rebuilding `:main` nightly: moving the tag leaves the
+# previous digest behind as an untagged version.
+#
+# Only two things are kept indefinitely: release tags, so a released SDK can still
+# be FIT tested (fit-cli can pin a performer version), and `main`, which is what
+# fit-testing-dotnet.yml pulls. Everything else ages out - untagged digests, the
+# `refs-`/`sha-` tags sdk-docker-build-action generates for Gerrit, PR and commit
+# builds, and per-branch `dk-*` tags. Losing a branch image costs nothing: it is
+# one publish-fit-performer.yml dispatch away, and a rebuild picks up new commits.
+#
+# Modelled on couchbase/couchbase-jvm-clients/.github/workflows/prune-stale-images.yml
+
+on:
+  schedule:
+    # 03:53 UTC, clear of the 23:00 performer publish and the 00:00 FIT run
+    - cron: '53 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  prune:
+    name: Prune dotnet-fit-performer
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Prune
+        uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 # v0.6.0
+        with:
+          token: ${{ github.token }}
+          organization: ${{ github.repository_owner }}
+          container: dotnet-fit-performer
+          keep-younger-than: 7 # days
+          prune-untagged: true
+          keep-tags: |
+            main
+          # Release tags: 3.9.5, and the 3.9.x style used by other SDKs.
+          keep-tags-regexes: |
+            ^[0-9]+\.[0-9]+
+          # Catch-all. Checked only after the two keep rules above, so it means
+          # "any tag that isn't a release tag or `main`".
+          prune-tags-regexes: |
+            .+

--- a/.github/workflows/prune-stale-images.yml
+++ b/.github/workflows/prune-stale-images.yml
@@ -37,9 +37,12 @@ jobs:
           prune-untagged: true
           keep-tags: |
             main
-          # Release tags: 3.9.5, and the 3.9.x style used by other SDKs.
+          # Release tags: 3.9.5, and the 3.9.x style used by other SDKs. Anchored
+          # at both ends - the action matches unanchored, so `^[0-9]+\.[0-9]+`
+          # alone would keep pre-release images forever too: publish-fit-performer.yml
+          # triggers on `tags: '*'`, and this repo pushes 3.9.3-rc1 style tags.
           keep-tags-regexes: |
-            ^[0-9]+\.[0-9]+
+            ^[0-9]+\.[0-9]+\.([0-9]+|x)$
           # Catch-all. Checked only after the two keep rules above, so it means
           # "any tag that isn't a release tag or `main`".
           prune-tags-regexes: |


### PR DESCRIPTION
Motivation
----------
Nothing prunes ghcr.io/couchbase/dotnet-fit-performer: 41 versions, 29 of them untagged. Rebuilding `:main` nightly orphans a digest a day, and Gerrit `refs-` and per-branch `dk-*` tags are never collected at all. It cannot be done by hand either - package permissions inherit from the repo and deleting a version needs admin, so maintainers get a 404.

Modification
------------
Add prune-stale-images.yml on a daily cron, using vlaurin/action-ghcr-prune pinned by SHA, as couchbase-jvm-clients already does.

Keep `main`, which fit-testing-dotnet.yml pulls, and release tags, which fit-cli can pin and which cannot be faithfully rebuilt - the Dockerfile's aspnet base is a floating tag. Everything else ages out after 7 days via a `.+` catch-all, so a tag shape nobody anticipated is pruned by default rather than kept: a stale `master` tag survived two months under named patterns.

The release-tag pattern is anchored at both ends. The action matches unanchored, so `^[0-9]+\.[0-9]+` would have kept anything merely starting like a version - including every pre-release image, since publish-fit-performer.yml triggers on `tags: '*'` and this repo pushes 3.9.3-rc1 style tags.

Results
-------
Replaying the action's filter over the live version list prunes 29 of 41, keeping `main`, 3.9.5, 3.9.4 and the last week's builds. Steady state is 12-15 versions. That replay is what stands in for a trial run: there is no dry-run mode, and the workflow cannot run before it merges anyway, since workflow_dispatch only registers from the default branch. The action logs each version as it deletes it, so the first scheduled run is auditable after the fact.
