### PR TITLE
NCBC-4286: Publish a FIT performer image per PR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,21 @@
+# Workflows
+
+## Build and test
+
+- **build-and-test.yml** — Builds the SDK and runs unit tests. Push to `master`, PRs, manual. Ubuntu x64/arm64, Windows, macOS.
+- **nightly-unit-tests.yml** — Same unit tests across the full OS and framework matrix. Daily at 06:00 UTC, manual. 8 OS images, net8.0/net10.0, plus net48 on Windows.
+- **build-fit-performer.yml** — Builds `couchbase-fit-performer.sln` only, to catch performer build breaks early. Push to `master`, PRs, manual. Ubuntu, macOS.
+
+## FIT
+
+- **fit-testing-dotnet.yml** — Runs FIT presets against a performer image. Daily at 00:00 UTC against `main`, manual with preset and performer tag inputs. Calls the shared `couchbaselabs/fit-cli` workflow, one job per preset.
+- **publish-fit-performer.yml** — Publishes `ghcr.io/couchbase/dotnet-fit-performer`, tagged with the SDK version. Push of any tag, daily at 23:00 UTC for `main`, manual for any ref. Ubuntu.
+- **pr-fit-performer.yml** — Publishes a performer image for the PR and comments how to run FIT with it. PRs that touch SDK or performer code. Ubuntu. Skips fork PRs.
+- **prune-stale-images.yml** — Deletes performer images after 7 days, keeping `main` and release tags. Daily at 03:53 UTC, manual. Ubuntu. Same job as the other SDK repos.
+
+## Release
+
+- **release.yml** — Builds, tests, signs, and packs the NuGet packages, then publishes to NuGet and S3 and calls the docs workflow. Published GitHub release, or manual with a version tag. Windows for pack and sign, Ubuntu for publish.
+- **apidocs.yml** — Builds the DocFX API docs and publishes them to S3. Manual, or called by `release.yml`. Ubuntu.
+
+Manual runs of `release.yml` and `apidocs.yml` default to `publish: false`, which gives a smoke run that publishes nothing.

--- a/.github/workflows/pr-fit-performer.yml
+++ b/.github/workflows/pr-fit-performer.yml
@@ -83,7 +83,7 @@ jobs:
             body.md
 
           COMMENT_ID=$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- pr-fit-performer -->")) | .id' | head -1)
+            --jq '.[] | select(.body | startswith("<!-- pr-fit-performer -->")) | .id' | tail -n 1)
 
           jq -n --rawfile body body.md '{body: $body}' > payload.json
 

--- a/.github/workflows/pr-fit-performer.yml
+++ b/.github/workflows/pr-fit-performer.yml
@@ -1,0 +1,103 @@
+name: PR FIT Performer
+
+# Publishes a performer image for each PR, then comments the image name and the
+# command to run FIT against it. The tag is the head branch name, sanitized the
+# way Docker tags are, so `dk/ncbc-4261` gives `dk-ncbc-4261`.
+# prune-stale-images.yml deletes the image 7 days later.
+#
+# Fork PRs are skipped: their token cannot push to ghcr.io. Build those with
+# publish-fit-performer.yml and ref `refs/pull/<n>/merge`.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'fit/**'
+      - '*.sln'
+      - 'Directory.*.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'NuGet.Config'
+      - '.github/workflows/pr-fit-performer.yml'
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+concurrency:
+  group: pr-fit-performer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build & publish performer for this PR
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and publish performer image
+        id: build
+        uses: couchbaselabs/sdk-docker-build-action@v1
+        with:
+          sdk: dotnet
+          ref: ${{ github.head_ref }}
+          dockerfile: fit/Couchbase.FitPerformer/Dockerfile
+        env:
+          DOCKER_BUILD_SUMMARY: false
+
+      - name: Comment on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ steps.build.outputs.image }}
+          PINNED_IMAGE: ${{ steps.build.outputs.pinned-image }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Keep the body at this indentation. YAML strips it before bash sees it.
+          cat > body.md <<'EOF'
+          <!-- pr-fit-performer -->
+          ### FIT performer image
+
+          `__IMAGE__`
+
+          Built from `__HEAD_SHA__` in [this run](__RUN_URL__).
+
+          Run FIT locally against this PR:
+
+          ```sh
+          fit run preset op-multi-lite --performer __PERFORMER__
+          ```
+
+          Pull the image directly:
+
+          ```sh
+          docker pull __IMAGE__
+          ```
+
+          Exact image for a repeatable run: `__PINNED_IMAGE__`
+
+          Each push to this PR replaces the image. It is deleted 7 days after the last push.
+          EOF
+
+          sed -i \
+            -e "s|__IMAGE__|${IMAGE}|g" \
+            -e "s|__PINNED_IMAGE__|${PINNED_IMAGE}|g" \
+            -e "s|__PERFORMER__|${IMAGE##*/}|g" \
+            -e "s|__HEAD_SHA__|${HEAD_SHA}|g" \
+            -e "s|__RUN_URL__|${RUN_URL}|g" \
+            body.md
+
+          COMMENT_ID=$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- pr-fit-performer -->")) | .id' | head -1)
+
+          jq -n --rawfile body body.md '{body: $body}' > payload.json
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" --input payload.json --silent
+          else
+            gh api -X POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --input payload.json --silent
+          fi

--- a/.github/workflows/pr-fit-performer.yml
+++ b/.github/workflows/pr-fit-performer.yml
@@ -1,11 +1,10 @@
-name: PR FIT Performer
+name: PR Performer Bot
 
 # Publishes a performer image for each PR, then comments the image name and the
-# command to run FIT against it. The tag is the head branch name, sanitized the
-# way Docker tags are, so `dk/ncbc-4261` gives `dk-ncbc-4261`.
+# command to run FIT against it.
 # prune-stale-images.yml deletes the image 7 days later.
 #
-# Fork PRs are skipped: their token cannot push to ghcr.io. Build those with
+# Fork PRs are skipped. Build those with
 # publish-fit-performer.yml and ref `refs/pull/<n>/merge`.
 
 on:
@@ -50,10 +49,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE: ${{ steps.build.outputs.image }}
-          PINNED_IMAGE: ${{ steps.build.outputs.pinned-image }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FIT_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/fit-testing-dotnet.yml
         run: |
           set -euo pipefail
 
@@ -62,33 +59,27 @@ jobs:
           <!-- pr-fit-performer -->
           ### FIT performer image
 
-          `__IMAGE__`
-
-          Built from `__HEAD_SHA__` in [this run](__RUN_URL__).
+          Published:
+          ```sh
+          __IMAGE__
+          ```
 
           Run FIT locally against this PR:
 
           ```sh
-          fit run preset op-multi-lite --performer __PERFORMER__
+          fit run preset <preset-name> --performer __PERFORMER__
           ```
 
-          Pull the image directly:
+          Or run it from the workflow [here](__FIT_WORKFLOW_URL__).
 
-          ```sh
-          docker pull __IMAGE__
-          ```
-
-          Exact image for a repeatable run: `__PINNED_IMAGE__`
-
-          Each push to this PR replaces the image. It is deleted 7 days after the last push.
+          > [!NOTE]
+          > _Each push to this PR replaces the image and edits this comment. The image is deleted 7 days after the last push._
           EOF
 
           sed -i \
             -e "s|__IMAGE__|${IMAGE}|g" \
-            -e "s|__PINNED_IMAGE__|${PINNED_IMAGE}|g" \
             -e "s|__PERFORMER__|${IMAGE##*/}|g" \
-            -e "s|__HEAD_SHA__|${HEAD_SHA}|g" \
-            -e "s|__RUN_URL__|${RUN_URL}|g" \
+            -e "s|__FIT_WORKFLOW_URL__|${FIT_WORKFLOW_URL}|g" \
             body.md
 
           COMMENT_ID=$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \


### PR DESCRIPTION
[NCBC-4286](https://couchbasecloud.atlassian.net/browse/NCBC-4286)

Motivation
----------
Add a Bot that auto-publishes a performer image for each PR made against the repo itself.

Changes
-------
- Add `pr-fit-performer.yml`. (Fork PRs are skipped)
- Add a README for the workflows directory, with one line per workflow, what it is for, when it runs, and where.

[NCBC-4286]: https://couchbasecloud.atlassian.net/browse/NCBC-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ