### PR TITLE
NCBC-4285: Resolve the collection ID in GetPrimary

### DIFF
--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -1381,6 +1381,13 @@ namespace Couchbase.KeyValue
         private async Task<IGetReplicaResult> GetPrimary(string id, IRequestSpan span,
             CancellationToken cancellationToken, ITranscoderOverrideOptions options)
         {
+            //Check to see if the CID is needed
+            if (RequiresCid())
+            {
+                //Get the collection ID
+                await PopulateCidAsync().ConfigureAwait(false);
+            }
+
             using var childSpan = _tracer.RequestSpan(OuterRequestSpans.ServiceSpan.Kv.Get, span);
             using var getOp = new Get<object>
             {


### PR DESCRIPTION
[NCBC-4285](https://couchbasecloud.atlassian.net/browse/NCBC-4285)

`GetPrimary` builds its `Get` with `Cid = Cid` but never resolves the collection ID first, so when it is the first CID-requiring operation on a collection instance it dispatches an unprefixed key. On a connection that negotiated collections in HELO the server parses offset 0 as a leb128 collection ID and eats the first byte of the key, and the read looks in the wrong collection.

`GetReplica`, twelve lines below, has the guard. The two are near-identical copies and only one of them got it — the guard was added to `GetReplica` by NCBC-2881, five weeks after NCBC-2858 introduced both.

This runs the same `RequiresCid()` / `PopulateCidAsync()` guard in `GetPrimary`, ahead of the object initializer so the operation picks up the resolved value rather than a stale null. `GetAllReplicasAsync` now frames the primary read the same way as the replica reads, and the same way as every other collection-oriented KV operation.

### Why it rarely surfaced

`PopulateCidAsync` short-circuits once `Cid` is cached, so only a `GetAllReplicasAsync` that is the first such call on the instance was exposed, and `RefreshCollectionId` hides it while CIDs are sparse. It becomes a reliable wrong answer once a bucket's lifetime collection-creation count passes ~120, where CIDs no longer fit in the one leb128 byte an ASCII key leaves room for.

### No test here, deliberately

[NCBC-4287](https://couchbasecloud.atlassian.net/browse/NCBC-4287) replaces all 23 `RequiresCid()` guard sites with a single `PrepareAsync` that cannot be skipped, because the caller needs its return value. The coverage belongs there, asserted once against every KV operation with a reflection-based completeness guard, and that ticket's verification section now specifies it. A test written against this guard would pin a line 4287 deletes.

Verified by build (all four TFMs, 0 warnings) and `Couchbase.UnitTests --filter KeyValue` (237 passed). The changed path needs a live cluster, so nothing automated exercises it today — see 4287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NCBC-4285]: https://couchbasecloud.atlassian.net/browse/NCBC-4285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NCBC-4287]: https://couchbasecloud.atlassian.net/browse/NCBC-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ