### PR TITLE
NCBC-4287: Frame the collection ID from the connection NCBC-4285: Resolve the collection ID in GetPrimary

### DIFF
--- a/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
+++ b/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
@@ -153,7 +153,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                                 opts => opts.Cas(op.Cas)
                                     .Durability(cleanupRequest.GetDurabilityLevel())
                                     .AccessDeleted(true)
-                                    .PreserveTtl(collection.Scope.Bucket.SupportsCollections)
+                                    .PreserveTtl(collection.SupportsPreserveTtl())
                                     .Timeout(_keyValueTimeout)).CAF();
                         }
                         else
@@ -177,7 +177,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                                 specs.Remove(TransactionFields.TransactionInterfacePrefixOnly, isXattr: true),
                             opts => opts.Cas(op.Cas)
                                 .AccessDeleted(true)
-                                .PreserveTtl(collection.Scope.Bucket.SupportsCollections)
+                                .PreserveTtl(collection.SupportsPreserveTtl())
                                 .Timeout(_keyValueTimeout)).CAF();
                     }).CAF();
             }
@@ -249,7 +249,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                         .Flags(op.StagedContent!.Transcoder.GetFormat(content))
                         .Timeout(_keyValueTimeout)
                         .Cas(op.Cas)
-                        .PreserveTtl(coll.Scope.Bucket.SupportsCollections);
+                        .PreserveTtl(coll.SupportsPreserveTtl());
                     if (op.Expiry.HasValue)
                     {
                         opts.Expiry(op.Expiry.Value.RemainingTtl());

--- a/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
+++ b/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
@@ -51,8 +51,8 @@ namespace Couchbase.Client.Transactions.DataAccess
                 .AccessDeleted(true)
                 .CreateAsDeleted(true);
 
-            // we always preserve TTLs - using SupportsCollections as a proxy for supporting TTLs
-            opts.PreserveTtl(collection.Scope.Bucket.SupportsCollections);
+            // we always preserve TTLs where the cluster can
+            opts.PreserveTtl(collection.SupportsPreserveTtl());
 
             // we set the flags when staging the insert (though, we do it again when we unstage)
             if (SupportsReplaceBodyWithXattr(collection))
@@ -363,7 +363,7 @@ namespace Couchbase.Client.Transactions.DataAccess
             new MutateInOptions().Defaults(_durability, _keyValueTimeout)
                 .Transcoder(Transactions.MetadataTranscoder)
                 .StoreSemantics(storeSemantics)
-                .PreserveTtl(collection.Scope.Bucket.SupportsCollections);
+                .PreserveTtl(collection.SupportsPreserveTtl());
 
         private List<MutateInSpec> CreateMutationSpecs(IAtrRepository atr, string opType, IContentAsWrapper content, string opId, DocumentMetadata? dm = null, DateTimeOffset? expiry = null)
         {

--- a/src/Couchbase/Client/Transactions/Support/CollectionExtensions.cs
+++ b/src/Couchbase/Client/Transactions/Support/CollectionExtensions.cs
@@ -1,10 +1,27 @@
 ﻿using System;
+using Couchbase.Core;
 using Couchbase.KeyValue;
 
 namespace Couchbase.Client.Transactions.Support
 {
     internal static class CollectionExtensions
     {
+        /// <summary>
+        /// Whether the cluster behind this collection can preserve expiry on a mutation.
+        /// </summary>
+        /// <remarks>
+        /// This used to be <c>Bucket.SupportsCollections</c>, with a comment calling it "a proxy for
+        /// supporting TTLs". They are unrelated capabilities: every node in a mixed-version cluster
+        /// can support collections while some node has not negotiated PreserveTtl, and
+        /// CouchbaseCollection throws FeatureNotAvailableException for exactly that combination - so
+        /// the proxy asked transactions to request something the cluster would then refuse.
+        /// Protostellar has no ClusterContext to ask, so it keeps the old proxy.
+        /// </remarks>
+        public static bool SupportsPreserveTtl(this ICouchbaseCollection collection) =>
+            collection.Scope.Bucket is BucketBase bucket
+                ? bucket.Context.SupportsPreserveTtl
+                : collection.Scope.Bucket.SupportsCollections;
+
         public static RemoveOptions Timeout(this RemoveOptions opts, TimeSpan? timeout)
         {
             if (timeout.HasValue)

--- a/src/Couchbase/Core/ClusterContext.cs
+++ b/src/Couchbase/Core/ClusterContext.cs
@@ -107,8 +107,6 @@ namespace Couchbase.Core
 
         public ICluster Cluster { get; }
 
-        public bool SupportsCollections { get; set; }
-
         public bool SupportsGlobalConfig { get; private set; }
 
         public bool SupportsPreserveTtl { get; internal set; }
@@ -310,7 +308,45 @@ namespace Couchbase.Core
                 _logger.LogDebug(
                     "Added node {endPoint} on {bucket} to {nodes}",
                     _redactor.SystemData(node.EndPoint), node.Owner?.Name, Nodes.Count);
+
+                RecomputeClusterFeatureSupport();
             }
+        }
+
+        /// <summary>
+        /// Recomputes the cluster-wide feature flags from every node currently managed.
+        /// </summary>
+        /// <remarks>
+        /// SupportsPreserveTtl and SupportsBinaryXattr describe the cluster, but they used to be
+        /// assigned from whichever single node was initialized last - eight separate sites, each
+        /// overwriting the one before, so the answer depended on ordering. A feature is only safe to
+        /// use if every node offers it, so this takes the conjunction. Nodes that have not negotiated
+        /// yet are skipped rather than counted as unsupporting, so the flags do not flap to false
+        /// while a node is still coming up.
+        ///
+        /// This stays a field rather than a computed property because it is read on every mutation.
+        /// </remarks>
+        internal void RecomputeClusterFeatureSupport()
+        {
+            var seenAnyNode = false;
+            var preserveTtl = true;
+            var binaryXattr = true;
+
+            foreach (var node in Nodes)
+            {
+                var features = node.ServerFeatures;
+                if (features is null)
+                {
+                    continue;
+                }
+
+                seenAnyNode = true;
+                preserveTtl &= features.PreserveTtl;
+                binaryXattr &= features.SubdocBinaryXattr;
+            }
+
+            SupportsPreserveTtl = seenAnyNode && preserveTtl;
+            SupportsBinaryXattr = seenAnyNode && binaryXattr;
         }
 
         public bool RemoveNode(IClusterNode removedNode)
@@ -322,6 +358,9 @@ namespace Couchbase.Core
                 _logger.LogDebug(
                     "Removed node {endPoint} from {nodes}", _redactor.SystemData(removedNode.EndPoint), Nodes);
                 removedNode.Dispose();
+
+                //A node leaving can restore a feature the whole cluster now offers.
+                RecomputeClusterFeatureSupport();
                 return true;
             }
             return false;
@@ -493,8 +532,6 @@ namespace Couchbase.Core
                                 node.NodesAdapter = nodeAdapter;
                                 if (node.ServerFeatures != null)
                                 {
-                                    SupportsPreserveTtl = node.ServerFeatures.PreserveTtl;
-                                    SupportsBinaryXattr = node.ServerFeatures.SubdocBinaryXattr;
                                 }
 
                                 AddNode(node);
@@ -511,8 +548,6 @@ namespace Couchbase.Core
 
                                 if (newNode.ServerFeatures != null)
                                 {
-                                    SupportsPreserveTtl = newNode.ServerFeatures.PreserveTtl;
-                                    SupportsBinaryXattr = newNode.ServerFeatures.SubdocBinaryXattr;
                                 }
 
                                 AddNode(newNode);
@@ -825,8 +860,6 @@ namespace Couchbase.Core
                             {
                                 clusterNode.Owner = bucket;
                                 await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                                SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                             }
 
                             continue;
@@ -840,8 +873,6 @@ namespace Couchbase.Core
                             {
                                 clusterNode.Owner = bucket;
                                 await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                                SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                             }
                         }
 
@@ -866,8 +897,6 @@ namespace Couchbase.Core
                         {
                             clusterNode.Owner = bucket;
                             await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                            SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                            SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                         }
                     }
                     else
@@ -885,8 +914,6 @@ namespace Couchbase.Core
                         {
                             clusterNode.Owner = bucket;
                             await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                            SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                            SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                         }
 
                         AddNode(clusterNode);
@@ -989,10 +1016,6 @@ namespace Couchbase.Core
 
                             if (newNode.ServerFeatures != null)
                             {
-                                SupportsPreserveTtl =
-                                    newNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = newNode.ServerFeatures
-                                    .SubdocBinaryXattr;
                             }
 
                             AddNode(newNode);

--- a/src/Couchbase/Core/ClusterNode.cs
+++ b/src/Couchbase/Core/ClusterNode.cs
@@ -367,7 +367,21 @@ namespace Couchbase.Core
 
             return await ExecuteInternalOperationAsync(connection, heloOp,
                 ExecuteOp,
-                static (_, op) => op.GetValue(),
+                static (status, op) =>
+                {
+                    //A failed HELO used to be swallowed: the status was discarded here, GetValue()
+                    //returned null on anything but success, and the caller quietly assigned
+                    //ServerFeatureSet.Empty. The connection then stayed in the pool with no
+                    //negotiated features while still being framed as though it had them, which is
+                    //how a rejected HELO produces corrupted document keys. There is no usable
+                    //connection without a HELO, so fail it.
+                    if (status != ResponseStatus.Success)
+                    {
+                        ThrowHelper.ThrowHelloFailedException(status);
+                    }
+
+                    return op.GetValue();
+                },
                 cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -731,7 +745,13 @@ namespace Couchbase.Core
                 }
 
                 var code = (short)status;
-                if (!ErrorMap.TryGetGetErrorCode(code, out var errorCode))
+
+                //The error map is fetched immediately after HELO, so it is still null for anything
+                //that fails during connection initialization - HELO itself above all. Dereferencing
+                //it turned every such failure into a NullReferenceException here, before the caller
+                //could act on the status, which is why a rejected HELO could never be handled.
+                ErrorCode errorCode = null;
+                if (ErrorMap is null || !ErrorMap.TryGetGetErrorCode(code, out errorCode))
                 {
                     //We can ignore transport exceptions here as they are generated internally in cases a KV cannot be completed.
                     if (code != 0x0500)
@@ -856,6 +876,11 @@ namespace Couchbase.Core
                         ? new ServerFeatureSet(serverFeatureList)
                         : ServerFeatureSet.Empty;
                     ServerFeatures = connection.ServerFeatures;
+
+                    //Cluster-wide feature support is the conjunction over every node, so it has to
+                    //be recomputed when a node finishes negotiating - a node may well have been
+                    //added before its features were known.
+                    _context.RecomputeClusterFeatureSupport();
 
                     #if DEBUG
                     _logger.LogDebug("{Features}", ServerFeatures.ToString());

--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslList.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslList.cs
@@ -7,6 +7,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     /// </summary>
     internal sealed class SaslList : OperationBase<string>
     {
+        /// <inheritdoc />
+        // mechanism negotiation, no document key.
+        internal override bool RequiresCollectionId => false;
+
         internal override void WriteExtras(OperationBuilder builder)
         {
         }

--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslStart.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslStart.cs
@@ -8,6 +8,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     // ReSharper disable once IdentifierTypo
     internal class SaslStart : OperationBase<string>
     {
+        /// <inheritdoc />
+        // authentication runs after HELO but before any collection exists.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SaslStart;
 
         internal override void WriteExtras(OperationBuilder builder)

--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslStep.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslStep.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     /// </summary>
     internal class SaslStep : SaslStart
     {
+        /// <inheritdoc />
+        // authentication runs after HELO but before any collection exists.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SaslStep;
     }
 }

--- a/src/Couchbase/Core/IO/Operations/Authentication/SelectBucket.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SelectBucket.cs
@@ -2,6 +2,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
 {
     internal sealed class SelectBucket : OperationBase
     {
+        /// <inheritdoc />
+        // the key is the bucket name.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SelectBucket;
     }
 }

--- a/src/Couchbase/Core/IO/Operations/Collections/GetCid.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetCid.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetCid : OperationBase<string>
     {
+        /// <inheritdoc />
+        // the key is the fully qualified collection name - this is what resolves a CID.
+        internal override bool RequiresCollectionId => false;
+
         /// <summary>
         /// Creates a key either by the Key property or the Content property.
         /// <remarks>Early server versions used the Key for the collection name; later versions use the Content property.</remarks>

--- a/src/Couchbase/Core/IO/Operations/Collections/GetManifest.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetManifest.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetManifest :  OperationBase<Manifest>
     {
+        /// <inheritdoc />
+        // manifest request, no document key.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode  => OpCode.GetCollectionsManifest;
 
         protected override void BeginSend()

--- a/src/Couchbase/Core/IO/Operations/Collections/GetSid.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetSid.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetSid : OperationBase<uint?>
     {
+        /// <inheritdoc />
+        // the key is the scope name.
+        internal override bool RequiresCollectionId => false;
+
         public override bool RequiresVBucketId => false;
 
         public override OpCode OpCode => OpCode.GetSidByName;

--- a/src/Couchbase/Core/IO/Operations/Config.cs
+++ b/src/Couchbase/Core/IO/Operations/Config.cs
@@ -49,6 +49,10 @@ namespace Couchbase.Core.IO.Operations
 
     internal sealed class Config : OperationBase<BucketConfig>
     {
+        /// <inheritdoc />
+        // cluster map request, no document key.
+        internal override bool RequiresCollectionId => false;
+
         internal HostEndpointWithPort EndPoint { get; set; }
 
         internal ulong? Epoch { get; set; }

--- a/src/Couchbase/Core/IO/Operations/Configuration/ClusterMapChangeNotification.cs
+++ b/src/Couchbase/Core/IO/Operations/Configuration/ClusterMapChangeNotification.cs
@@ -7,6 +7,10 @@ namespace Couchbase.Core.IO.Operations.Configuration;
 
 internal sealed class ClusterMapChangeNotification : OperationBase<BucketConfig>
 {
+    /// <inheritdoc />
+    // a server push, no document key.
+    internal override bool RequiresCollectionId => false;
+
     public override OpCode OpCode => OpCode.ClusterMapChangeNotification;
 
     protected override void ReadExtras(ReadOnlySpan<byte> buffer)

--- a/src/Couchbase/Core/IO/Operations/Errors/GetErrorMap.cs
+++ b/src/Couchbase/Core/IO/Operations/Errors/GetErrorMap.cs
@@ -5,11 +5,15 @@ namespace Couchbase.Core.IO.Operations.Errors
 {
     internal sealed class GetErrorMap : OperationBase<ErrorMapDto>
     {
+        /// <inheritdoc />
+        // writes no key at all.
+        internal override bool RequiresCollectionId => false;
+
         private const int DefaultVersion = 2; // will be configurable at some point
 
         public ErrorMap ErrorMap { get; set; }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
 

--- a/src/Couchbase/Core/IO/Operations/Hello.cs
+++ b/src/Couchbase/Core/IO/Operations/Hello.cs
@@ -12,6 +12,10 @@ namespace Couchbase.Core.IO.Operations
 {
     internal sealed class Hello : OperationBase<ServerFeatures[]>
     {
+        /// <inheritdoc />
+        // the key is a connection identifier, and this runs before any bucket is selected.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.Helo;
 
         internal override void WriteBody(OperationBuilder builder)

--- a/src/Couchbase/Core/IO/Operations/Noop.cs
+++ b/src/Couchbase/Core/IO/Operations/Noop.cs
@@ -2,9 +2,13 @@ namespace Couchbase.Core.IO.Operations
 {
     internal sealed class Noop : OperationBase
     {
+        /// <inheritdoc />
+        // writes no key at all.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.NoOp;
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
     }

--- a/src/Couchbase/Core/IO/Operations/Observe.cs
+++ b/src/Couchbase/Core/IO/Operations/Observe.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Core.IO.Operations
         {
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
 
@@ -24,7 +24,10 @@ namespace Couchbase.Core.IO.Operations
             const int vBucketAndLengthSize = sizeof(ushort) * 2;
             var buffer = builder.GetSpan(vBucketAndLengthSize + OperationHeader.MaxKeyLength + Leb128.MaxLength);
 
-            var keyLength = WriteKey(buffer.Slice(vBucketAndLengthSize));
+            //Observe frames its key inside the body with an explicit length, and is dead code
+            //pending removal, so it keeps the old client-side rule rather than the connection's
+            //negotiated state: passing Cid.HasValue reproduces exactly what WriteKey used to do.
+            var keyLength = WriteKey(buffer.Slice(vBucketAndLengthSize), Cid.HasValue);
 
             // ReSharper disable once PossibleInvalidOperationException
             ByteConverter.FromInt16(VBucketId.Value, buffer);

--- a/src/Couchbase/Core/IO/Operations/OperationBase.cs
+++ b/src/Couchbase/Core/IO/Operations/OperationBase.cs
@@ -86,6 +86,18 @@ namespace Couchbase.Core.IO.Operations
         /// <inheritdoc />
         public uint? Cid { get; set; }
 
+        /// <summary>
+        /// Whether this operation addresses a document, and must therefore carry a leb128 collection
+        /// ID when the connection has negotiated collections.
+        /// </summary>
+        /// <remarks>
+        /// True is the default because it is the safe value: an operation added without a thought
+        /// about framing then fails loudly instead of silently addressing the wrong collection.
+        /// Connection and cluster level operations - HELO, SASL, SELECT_BUCKET, GET_CID and the like
+        /// - carry a key that is not a document ID and must override this to false.
+        /// </remarks>
+        internal virtual bool RequiresCollectionId => true;
+
         public byte[]? EncodedKey { get; set; }
 
         /// <inheritdoc />
@@ -534,35 +546,63 @@ namespace Couchbase.Core.IO.Operations
         /// Writes the key to an <see cref="OperationBuilder"/>.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        internal virtual void WriteKey(OperationBuilder builder)
+        /// <param name="collectionsEnabled">
+        /// Whether the connection this operation is being written for negotiated collections in
+        /// HELO, and will therefore read a leb128 collection ID from the start of the key.
+        /// </param>
+        internal virtual void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
-            var keyLength = Cid.HasValue ?
+            var keyLength = collectionsEnabled && RequiresCollectionId ?
                 OperationHeader.MaxKeyLength + Leb128.MaxLength :
                 OperationHeader.MaxKeyLength;
 
             var buffer = builder.GetSpan(keyLength);
 
-            var length = WriteKey(buffer);
+            var length = WriteKey(buffer, collectionsEnabled);
 
             builder.Advance(length);
         }
 
         /// <summary>
-        /// Write the <see cref="Key"/>, with <see cref="Cid"/> if present, to a buffer.
+        /// Write the <see cref="Key"/> to a buffer, prefixed with the leb128 <see cref="Cid"/> when
+        /// the connection has negotiated collections and this operation addresses a document.
         /// </summary>
         /// <param name="buffer">Target buffer.</param>
+        /// <param name="collectionsEnabled">
+        /// Whether the connection this operation is being written for negotiated collections in
+        /// HELO, and will therefore read a leb128 collection ID from the start of the key.
+        /// </param>
         /// <returns>Number of bytes written.</returns>
-        protected int WriteKey(Span<byte> buffer)
+        protected int WriteKey(Span<byte> buffer, bool collectionsEnabled)
         {
             var length = 0;
 
-            //Default collection does not need the CID
-            if (Cid.HasValue)
+            //Whether the server parses a leb128 collection ID at offset 0 is fixed by what this
+            //connection negotiated in HELO, not by whether we happen to be holding a CID. Deciding
+            //it from client-side state is what corrupted document keys in NCBC-4146, in both
+            //directions: a prefix the server does not parse becomes part of the document ID, and a
+            //missing prefix makes the server read the first byte of the key as the collection.
+            if (collectionsEnabled && RequiresCollectionId)
             {
+                if (!Cid.HasValue)
+                {
+                    ThrowHelper.ThrowMissingCollectionIdException(OpCode);
+                }
+
                 length += Leb128.Write(buffer, Cid.GetValueOrDefault());
             }
 
             length += ByteConverter.FromString(Key, buffer.Slice(length));
+
+            if (length > OperationHeader.MaxKeyLength)
+            {
+                //The key field carries the collection ID as well as the document ID, so the prefix
+                //eats into the same 250 byte budget - a 250 byte key does not fit once a CID is
+                //prepended. The Key setter only validates the document ID on its own, so this used
+                //to surface from OperationHeader.KeyLength as a bare ArgumentOutOfRangeException
+                //from inside the write path. Java validates the same way, prefix included.
+                ThrowHelper.ThrowKeyTooLongForCollectionIdException(length);
+            }
 
             return length;
         }
@@ -626,7 +666,7 @@ namespace Couchbase.Core.IO.Operations
                 WriteExtras(builder);
 
                 builder.AdvanceToSegment(OperationSegment.Key);
-                WriteKey(builder);
+                WriteKey(builder, connection.ServerFeatures.Collections);
 
                 builder.AdvanceToSegment(OperationSegment.Body);
                 WriteBody(builder);

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCancel.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCancel.cs
@@ -6,6 +6,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanCancel : OperationBase<SlicedMemoryOwner<byte>>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - identified by the scan UUID.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.RangeScanCancel;
 
         public override bool RequiresVBucketId => true;
@@ -15,7 +19,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
             //no body
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanContinue.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanContinue.cs
@@ -11,6 +11,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanContinue : OperationBase<IDictionary<string, IScanResult>>, IObserver<SlicedMemoryOwner<byte>>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - identified by the scan UUID.
+        internal override bool RequiresCollectionId => false;
+
         //To hold the intermediate responses
         private List<SlicedMemoryOwner<byte>> _responses = new();
 
@@ -49,7 +53,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 
         public ILogger<GetResult> Logger { get;set; }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCreate.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCreate.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanCreate : OperationBase<IScanTypeExt>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - the collection travels in the body.
+        internal override bool RequiresCollectionId => false;
+
         //https://github.com/couchbase/kv_engine/blob/master/docs/range_scans/range_scan_create.md
 
         public override bool RequiresVBucketId => true;
@@ -18,7 +22,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
             //no extras
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -32,6 +32,12 @@ namespace Couchbase.KeyValue
     internal sealed class CouchbaseCollection : ICouchbaseCollection, IBinaryCollection, IInternalCollection
     {
         public const string DefaultCollectionName = "_default";
+
+        /// <summary>
+        /// The collection ID of the default collection. Also the correct ID for a bucket that does
+        /// not support collections at all, when the connection has negotiated collections.
+        /// </summary>
+        internal const uint DefaultCollectionId = 0;
         private const string NoPreferredServerGroupMessage = "No preferred Server group was set in the ClusterOptions.";
         private readonly string? _preferredServerGroup;
         private readonly bool _rangeScanSupported;
@@ -118,14 +124,11 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ScanOptions.Default;
+
+            //PartitionScan builds its own operations and reads Cid directly, so it cannot go
+            //through PrepareAsync: resolve the collection ID before handing it this collection.
+            await EnsureCollectionIdAsync().ConfigureAwait(false);
 
             var mutationTokens = options.ConsistencyTokens;
 
@@ -203,13 +206,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetOptions.Default;
 
             // TODO: Since we're actually using LookupIn for Get requests, which operation name should we use?
@@ -226,16 +222,10 @@ namespace Couchbase.KeyValue
                 using var getOp = new Get<byte[]>
                 {
                     Key = id,
-                    Cid = Cid,
-                    BucketName = _bucket.Name,
-                    CName = Name,
-                    SName = ScopeName,
                     Span = rootSpan,
                     PreferReturns = options.PreferReturn
                 };
-                _operationConfigurator.Configure(getOp, options);
-
-                using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getOp);
+                using var ctp = await PrepareAsync(getOp, options).ConfigureAwait(false);
                 var status = await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
 
                 var result = new GetResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider, status)
@@ -308,28 +298,15 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ExistsOptions.Default;
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetMetaExists, options.RequestSpanValue);
             using var getMetaOp = new GetMeta
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(getMetaOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getMetaOp);
+            using var ctp = await PrepareAsync(getMetaOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(getMetaOp, ctp.TokenPair).ConfigureAwait(false);
             var result = getMetaOp.GetValue();
 
@@ -352,29 +329,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= InsertOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.AddInsert, options.RequestSpanValue);
             using var insertOp = new Add<T>(_bucket.Name, id)
             {
                 Content = content,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                SName = ScopeName,
-                CName = Name,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(insertOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, insertOp);
+            using var ctp = await PrepareAsync(insertOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(insertOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(insertOp.Cas, null, insertOp.MutationToken);
         }
@@ -391,13 +355,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ReplaceOptions.Default;
 
             //Reality check for preserveTtl server support
@@ -412,18 +369,12 @@ namespace Couchbase.KeyValue
             {
                 Content = content,
                 Cas = options.CasValue,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
-            _operationConfigurator.Configure(replaceOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, replaceOp);
+            using var ctp = await PrepareAsync(replaceOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(replaceOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(replaceOp.Cas, null, replaceOp.MutationToken, status);
         }
@@ -438,31 +389,18 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= RemoveOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.DeleteRemove, options.RequestSpanValue);
             using var removeOp = new Delete
             {
                 Key = id,
                 Cas = options.CasValue,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 DurabilityLevel = options.DurabilityLevel,
                 DurabilityTimeout = TimeSpan.FromMilliseconds(1500),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(removeOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, removeOp);
+            using var ctp = await PrepareAsync(removeOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(removeOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
         }
@@ -478,29 +416,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UnlockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Unlock, options.RequestSpanValue);
             using var unlockOp = new Unlock
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Cas = cas,
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(unlockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, unlockOp);
+            using var ctp = await PrepareAsync(unlockOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(unlockOp, ctp.TokenPair).ConfigureAwait(false);
         }
 
@@ -510,29 +435,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UnlockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Unlock);
             using var unlockOp = new Unlock
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Cas = cas,
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(unlockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, unlockOp);
+            using var ctp = await PrepareAsync(unlockOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(unlockOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
         }
@@ -553,30 +465,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= TouchOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Touch, options.RequestSpanValue);
             using var touchOp = new Touch
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                SName = ScopeName,
-                CName = Name,
                 Expires = expiry.ToTtl(),
                 DurabilityTimeout = TimeSpan.FromMilliseconds(1500),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn,
             };
-            _operationConfigurator.Configure(touchOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, touchOp);
+            using var ctp = await PrepareAsync(touchOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(touchOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
             return status == ResponseStatus.Success
@@ -594,27 +493,14 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetAndTouchOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAndTouch, options.RequestSpanValue);
             using var getAndTouchOp = new GetT<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expires = expiry.ToTtl(),
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(getAndTouchOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getAndTouchOp);
+            using var ctp = await PrepareAsync(getAndTouchOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(getAndTouchOp, ctp.TokenPair).ConfigureAwait(false);
 
             return new  GetResult(getAndTouchOp.ExtractBody(), getAndTouchOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
@@ -637,29 +523,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetAndLockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAndLock, options.RequestSpanValue);
             using var getAndLockOp = new GetL<byte[]>
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expiry = lockTime.ToTtl(),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(getAndLockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getAndLockOp);
+            using var ctp = await PrepareAsync(getAndLockOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(getAndLockOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetResult(getAndLockOp.ExtractBody(), getAndLockOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider, status)
             {
@@ -683,13 +556,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UpsertOptions.Default;
 
             //Reality check for preserveTtl server support
@@ -703,19 +569,13 @@ namespace Couchbase.KeyValue
             using var upsertOp = new Set<T>(_bucket.Name, id)
             {
                 Content = content,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
-                Cid = Cid,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
 
-            _operationConfigurator.Configure(upsertOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, upsertOp);
+            using var ctp = await PrepareAsync(upsertOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(upsertOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(upsertOp.Cas, null, upsertOp.MutationToken);
         }
@@ -732,13 +592,6 @@ namespace Couchbase.KeyValue
             _bucket.ThrowIfBootStrapFailed();
             if (specs.Count() > 16) throw new InvalidArgumentException("Too many specs in Lookup operation (Limited to 16)");
             var opts = options?.AsReadOnly() ?? LookupInOptions.DefaultReadOnly;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupIn, opts.RequestSpan);
             using var lookup = await ExecuteLookupIn(id, specs, opts, rootSpan).ConfigureAwait(false);
@@ -758,13 +611,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
             var opts = options?.AsReadOnly() ?? LookupInAnyReplicaOptions.DefaultReadOnly;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAnyReplica, opts.RequestSpan);
             var vBucket = VBucketForReplicas(id);
@@ -817,13 +663,6 @@ namespace Couchbase.KeyValue
             // A top-level failure of the lookup (here, too many specs) must produce an empty stream
             // rather than throwing - unlike LookupIn/LookupInAnyReplica.
             if (specs.Count() > 16) yield break;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAllReplicas, opts.RequestSpan);
             var enumeratedSpecs = specs.ToList();
@@ -888,9 +727,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Get the collection ID
-            await PopulateCidAsync().ConfigureAwait(false);
-
             //add the virtual xattr attribute to get the doc expiration time
             if (options.Expiry)
             {
@@ -924,19 +760,13 @@ namespace Couchbase.KeyValue
 
             var lookup = new MultiLookup<byte[]>(id, specs, options.ReplicaIndex)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 DocFlags = docFlags,
                 Span = span,
                 PreferReturns = options.PreferReturn,
             };
             try
             {
-                _operationConfigurator.Configure(lookup, options);
-
-                using var ctp = CreateRetryTimeoutCancellationTokenSource(options, lookup);
+                using var ctp = await PrepareAsync(lookup, options).ConfigureAwait(false);
                 var status = await _bucket.RetryAsync(lookup, ctp.TokenPair).ConfigureAwait(false);
                 return lookup;
             }
@@ -958,13 +788,6 @@ namespace Couchbase.KeyValue
         {
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             options ??= MutateInOptions.Default;
 
@@ -1023,11 +846,7 @@ namespace Couchbase.KeyValue
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.MutateIn, options.RequestSpanValue);
             using var mutation = new MultiMutation<byte[]>(id, specs)
             {
-                BucketName = _bucket.Name,
                 Cas = options.CasValue,
-                Cid = Cid,
-                CName = Name,
-                SName = ScopeName,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 DocFlags = docFlags,
@@ -1035,9 +854,7 @@ namespace Couchbase.KeyValue
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
-            _operationConfigurator.Configure(mutation, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, mutation);
+            using var ctp = await PrepareAsync(mutation, options).ConfigureAwait(false);
             await _bucket.RetryAsync(mutation, ctp.TokenPair).ConfigureAwait(false);
 
 #pragma warning disable 618 // MutateInResult is marked obsolete until it is made internal
@@ -1071,29 +888,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= AppendOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Append, options.RequestSpanValue);
             using var op = new Append<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Content = value,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Cas = options.CasValue
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(op.Cas, null, op.MutationToken);
         }
@@ -1108,29 +912,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= PrependOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Prepend, options.RequestSpanValue);
             using var op = new Prepend<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Content = value,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Cas = options.CasValue
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(op.Cas, null, op.MutationToken);
         }
@@ -1145,30 +936,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= IncrementOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Increment, options.RequestSpanValue);
             using var op = new Increment(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Delta = options.DeltaValue,
                 Initial = options.InitialValue,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Expires = options.ExpiryValue.ToTtl()
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new CounterResult(op.GetValue(), op.Cas, null, op.MutationToken);
         }
@@ -1183,30 +961,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= DecrementOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Decrement, options.RequestSpanValue);
             using var op = new Decrement(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Delta = options.DeltaValue,
                 Initial = options.InitialValue,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Expires = options.ExpiryValue.ToTtl()
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new CounterResult(op.GetValue(), op.Cas, null, op.MutationToken);
         }
@@ -1220,13 +985,6 @@ namespace Couchbase.KeyValue
         {
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             options ??= GetAnyReplicaOptions.Default;
 
@@ -1385,16 +1143,10 @@ namespace Couchbase.KeyValue
             using var getOp = new Get<object>
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = childSpan
             };
-            _operationConfigurator.Configure(getOp, options);
-
             using var ctp =
-                CreateRetryTimeoutCancellationTokenSource((ITimeoutOptions) options, getOp);
+                await PrepareAsync(getOp, (ITimeoutOptions) options).ConfigureAwait(false);
             await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetReplicaResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
             {
@@ -1410,27 +1162,14 @@ namespace Couchbase.KeyValue
         private async Task<IGetReplicaResult> GetReplica(string id, short index, IRequestSpan span,
             CancellationToken cancellationToken, ITranscoderOverrideOptions options)
         {
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             using var childSpan = _tracer.RequestSpan(OuterRequestSpans.ServiceSpan.Kv.ReplicaRead, span);
             using var getOp = new ReplicaRead<object>(id, index)
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = childSpan
             };
-            _operationConfigurator.Configure(getOp, options);
-
             using var ctp =
-                CreateRetryTimeoutCancellationTokenSource((ITimeoutOptions) options, getOp);
+                await PrepareAsync(getOp, (ITimeoutOptions) options).ConfigureAwait(false);
             await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetReplicaResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
             {
@@ -1442,6 +1181,91 @@ namespace Couchbase.KeyValue
                 IsActive = false
             };
         }
+
+        #endregion
+
+        #region Operation Preparation
+
+        /// <summary>
+        /// Prepares a key/value operation for dispatch: resolves the collection ID if this bucket
+        /// supports collections, stamps the operation with this collection's identity, applies the
+        /// configured services, and rents the retry/timeout token source needed to send it.
+        /// </summary>
+        /// <param name="op">The operation to prepare.</param>
+        /// <param name="options">Options for the operation.</param>
+        /// <returns>
+        /// The rented token source, which the caller owns and must dispose. The caller needs its
+        /// <c>TokenPair</c> in order to dispatch, which is what stops this method from being
+        /// skipped when a new operation is added: see NCBC-4285, where <c>GetPrimary</c> was a
+        /// near-identical copy of <c>GetReplica</c> that never resolved its collection ID.
+        /// </returns>
+        private async Task<CancellationTokenPairSourceWrapper> PrepareAsync(OperationBase op,
+            ITimeoutOptions options)
+        {
+            await EnsureCollectionIdAsync().ConfigureAwait(false);
+
+            op.BucketName = _bucket.Name;
+            op.SName = ScopeName;
+            op.CName = Name;
+            op.Cid = Cid;
+
+            _operationConfigurator.Configure(op, options);
+
+            return CreateRetryTimeoutCancellationTokenSource(options, op);
+        }
+
+        /// <summary>
+        /// Resolves the collection ID, if this bucket supports collections and it is not already
+        /// cached.
+        /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="PrepareAsync"/>, which does this as well and cannot be skipped. This is
+        /// separate only for the range scan path: <see cref="PartitionScan"/> builds its own
+        /// operations and reads <see cref="Cid"/> directly, so the ID has to be resolved before it
+        /// is handed this collection.
+        /// </remarks>
+        private async ValueTask EnsureCollectionIdAsync()
+        {
+            if (!_bucket.SupportsCollections)
+            {
+                if (!IsDefaultCollection)
+                {
+                    //Asking for a named collection on a cluster that has none cannot be satisfied.
+                    //Say so at the boundary rather than sending an operation whose collection the
+                    //server has no way to resolve, which used to surface as CollectionNotFound after
+                    //the full KvTimeout. Matches the JVM's
+                    //BaseKeyValueRequest.encodedExternalKeyWithCollection.
+                    throw new FeatureNotAvailableException(
+                        "Collections are not supported by this cluster or bucket, so the collection " +
+                        $"'{ScopeName}.{Name}' cannot be used.");
+                }
+
+                //Only the default collection exists here - a memcached bucket, or a pre-7.0 server.
+                //The connection may still have negotiated collections in HELO, in which case the
+                //server reads a leb128 collection ID from the start of every key, and the correct
+                //value is 0. Leaving it null is why every KV operation against a memcached bucket
+                //failed with CollectionNotFound after burning the full KvTimeout.
+                Cid ??= DefaultCollectionId;
+                return;
+            }
+
+            if (IsDefaultCollection)
+            {
+                //The default scope and collection are defined to be collection ID 0, so there is
+                //nothing to look up. This saves a GET_CID round trip on the first operation against
+                //every default collection, which is most of them.
+                Cid ??= DefaultCollectionId;
+                return;
+            }
+
+            //Check to see if the CID is needed
+            if (RequiresCid())
+            {
+                //Get the collection ID
+                await PopulateCidAsync().ConfigureAwait(false);
+            }
+        }
+
 
         #endregion
 
@@ -1491,7 +1315,7 @@ namespace Couchbase.KeyValue
                         () => GetCidWithFallbackAsync(retryIfFailure: true),
                         LazyThreadSafetyMode.ExecutionAndPublication);
                     GetCidLazyNoRetry ??= new Lazy<Task<uint?>>(
-                        () => GetCidWithFallbackAsync(retryIfFailure: true),
+                        () => GetCidWithFallbackAsync(retryIfFailure: false),
                         LazyThreadSafetyMode.ExecutionAndPublication);
                 }
 
@@ -1546,16 +1370,23 @@ namespace Couchbase.KeyValue
             var options = new GetOptions();
             _operationConfigurator.Configure(getCid, options.Transcoder(_rawStringTranscoder));
             using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getCid);
-            if (retryIfFailure)
-            {
-                await _bucket.RetryAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
-            }
-            else
-            {
-                await _bucket.SendAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
-            }
+            var status = retryIfFailure
+                ? await _bucket.RetryAsync(getCid, ctp.TokenPair).ConfigureAwait(false)
+                : await _bucket.SendAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
 
             var resultWithValue = getCid.GetValueAsUint();
+
+            if (status == ResponseStatus.Success && !resultWithValue.HasValue)
+            {
+                //GetValueAsUint returns null for a Success response whose body is empty or cannot be
+                //parsed. That null used to be assigned to Cid and carried to the wire; it now fails
+                //at framing time, but with a message about the operation rather than about the
+                //lookup, so name what actually happened while we still know it. The deliberate null
+                //from GetCidWithFallbackAsync's UnsupportedException path is untouched: that one
+                //means the server has no collections, which is a different answer.
+                ThrowHelper.ThrowCollectionIdNotResolvedException(ScopeName, Name);
+            }
+
             return resultWithValue;
         }
 

--- a/src/Couchbase/Utils/ThrowHelper.cs
+++ b/src/Couchbase/Utils/ThrowHelper.cs
@@ -34,6 +34,53 @@ namespace Couchbase.Utils
         public static void ThrowServiceNotAvailableException(ServiceType serviceType) =>
             throw new ServiceNotAvailableException(serviceType);
 
+        /// <summary>
+        /// The connection negotiated collections, so the server will read a leb128 collection ID at
+        /// offset 0 of the key, but the operation has no collection ID to write. Sending it would
+        /// make the server treat the first byte of the document key as the collection.
+        /// </summary>
+        /// <remarks>
+        /// This is an SDK bug rather than a user error: an operation reached the wire without going
+        /// through collection ID resolution. See NCBC-4285 and NCBC-4287.
+        /// </remarks>
+        /// <summary>
+        /// HELO did not succeed, so nothing about the connection's feature set is known. Keeping the
+        /// connection would mean framing operations for features that were never negotiated.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowHelloFailedException(ResponseStatus status) =>
+            throw new ConnectException(
+                $"HELO failed with {status}, so no server features could be negotiated for this " +
+                "connection. Continuing would frame operations for features the server has not " +
+                "agreed to, including the collection ID prefix.");
+
+        /// <summary>
+        /// The document key plus its leb128 collection ID prefix exceeds the 250 byte key field.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowKeyTooLongForCollectionIdException(int length) =>
+            throw new InvalidArgumentException(
+                $"The key is too long: {length} bytes including the collection ID prefix, and the " +
+                $"maximum is {OperationHeader.MaxKeyLength}. On a connection that has negotiated " +
+                "collections the prefix shares the key field with the document ID, so the document " +
+                "ID has to be shorter than the maximum by the size of the prefix.");
+
+        /// <summary>
+        /// GET_CID came back successful but carried no usable collection ID.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowCollectionIdNotResolvedException(string scopeName, string collectionName) =>
+            throw new CouchbaseException(
+                $"The server returned a successful GET_CID for '{scopeName}.{collectionName}' with no " +
+                "usable collection ID in the body, so there is nothing to frame operations with.");
+
+        [DoesNotReturn]
+        public static void ThrowMissingCollectionIdException(OpCode opCode) =>
+            throw new CouchbaseException(
+                $"The {opCode} operation has no collection ID, but the connection has negotiated " +
+                "collections and the server will read one from the start of the key. The operation " +
+                "was dispatched without resolving a collection ID.");
+
         [DoesNotReturn]
         public static void ThrowArgumentException(string message, string paramName) =>
             throw new ArgumentException(message, paramName);

--- a/src/Couchbase/Utils/ThrowHelper.cs
+++ b/src/Couchbase/Utils/ThrowHelper.cs
@@ -35,15 +35,6 @@ namespace Couchbase.Utils
             throw new ServiceNotAvailableException(serviceType);
 
         /// <summary>
-        /// The connection negotiated collections, so the server will read a leb128 collection ID at
-        /// offset 0 of the key, but the operation has no collection ID to write. Sending it would
-        /// make the server treat the first byte of the document key as the collection.
-        /// </summary>
-        /// <remarks>
-        /// This is an SDK bug rather than a user error: an operation reached the wire without going
-        /// through collection ID resolution. See NCBC-4285 and NCBC-4287.
-        /// </remarks>
-        /// <summary>
         /// HELO did not succeed, so nothing about the connection's feature set is known. Keeping the
         /// connection would mean framing operations for features that were never negotiated.
         /// </summary>
@@ -74,6 +65,15 @@ namespace Couchbase.Utils
                 $"The server returned a successful GET_CID for '{scopeName}.{collectionName}' with no " +
                 "usable collection ID in the body, so there is nothing to frame operations with.");
 
+        /// <summary>
+        /// The connection negotiated collections, so the server will read a leb128 collection ID at
+        /// offset 0 of the key, but the operation has no collection ID to write. Sending it would
+        /// make the server treat the first byte of the document key as the collection.
+        /// </summary>
+        /// <remarks>
+        /// This is an SDK bug rather than a user error: an operation reached the wire without going
+        /// through collection ID resolution. See NCBC-4285 and NCBC-4287.
+        /// </remarks>
         [DoesNotReturn]
         public static void ThrowMissingCollectionIdException(OpCode opCode) =>
             throw new CouchbaseException(

--- a/tests/Couchbase.LoadTests/Core/IO/Operations/OperationBaseWriteKey.cs
+++ b/tests/Couchbase.LoadTests/Core/IO/Operations/OperationBaseWriteKey.cs
@@ -29,7 +29,7 @@ namespace Couchbase.LoadTests.Core.IO.Operations
 
         private class FakeOperation : Get<string>
         {
-            public void WriteKeyPublic(OperationBuilder builder) => WriteKey(builder);
+            public void WriteKeyPublic(OperationBuilder builder) => WriteKey(builder, collectionsEnabled: false);
         }
     }
 }

--- a/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
+++ b/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
@@ -136,6 +136,108 @@ namespace Couchbase.UnitTests.Core
             Assert.InRange(chosenNodes.Count, 2, 3);
         }
 
+        #region Cluster-wide feature support
+
+        /// <summary>
+        /// SupportsPreserveTtl and SupportsBinaryXattr describe the cluster, but they used to be
+        /// assigned from whichever node initialized last, at eight separate sites each overwriting
+        /// the one before - so in a mixed-version cluster the answer depended on ordering. A feature
+        /// is only safe to use if every node offers it.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Requires_Every_Node()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            //The restrictive node is added first and the permissive one last, deliberately: under
+            //the old last-write-wins rule the permissive node would win and this would read true.
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl));
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+
+            Assert.True(context.SupportsPreserveTtl);
+            Assert.False(context.SupportsBinaryXattr);
+        }
+
+        [Fact]
+        public void Cluster_Feature_Support_When_Every_Node_Agrees()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+
+            Assert.True(context.SupportsPreserveTtl);
+            Assert.True(context.SupportsBinaryXattr);
+        }
+
+        /// <summary>
+        /// Nothing is known before a node has negotiated, so nothing is claimed.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_With_No_Nodes()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            Assert.False(context.SupportsPreserveTtl);
+            Assert.False(context.SupportsBinaryXattr);
+        }
+
+        /// <summary>
+        /// A node that has been added but has not negotiated yet is skipped rather than counted as
+        /// unsupporting, so the flags do not flap to false while a node is coming up.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Ignores_Nodes_That_Have_Not_Negotiated()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl));
+            context.AddNode(Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == null &&
+                node.EndPoint == new HostEndpointWithPort("host2", 11210)));
+
+            Assert.True(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
+        /// And a lagging node leaving restores what the remaining cluster offers.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Recovers_When_A_Lagging_Node_Leaves()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            //Lagging node first, so the permissive node is the one last-write-wins would have
+            //picked - the assertion below only means something with it in this order.
+            var lagging = Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == new ServerFeatureSet(Array.Empty<ServerFeatures>()) &&
+                node.EndPoint == new HostEndpointWithPort("host1", 11210));
+            context.AddNode(lagging);
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl));
+
+            Assert.False(context.SupportsPreserveTtl);
+
+            context.RemoveNode(lagging);
+
+            Assert.True(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
+        /// Endpoints must differ: ClusterNodeList.Remove matches on EndPoint and BucketName, so nodes
+        /// sharing a default endpoint are indistinguishable and removing one removes both.
+        /// </summary>
+        private static IClusterNode NodeSupporting(string host, params ServerFeatures[] features) =>
+            Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == new ServerFeatureSet(features) &&
+                node.EndPoint == new HostEndpointWithPort(host, 11210));
+
+        #endregion
+
         private IClusterNode CreateMockedNode(string hostname, int port, NodeAdapter nodeAdapter = null)
         {
             var mockConnectionPool = new Mock<IConnectionPool>();

--- a/tests/Couchbase.UnitTests/Core/ClusterNodeTests.cs
+++ b/tests/Couchbase.UnitTests/Core/ClusterNodeTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Core.CircuitBreakers;
 using Couchbase.Core.Exceptions;
+using Couchbase.Core.IO;
 using Couchbase.Core.IO.Connections;
 using Couchbase.Core.IO.Operations;
 using Couchbase.Test.Common.Utils;
@@ -111,6 +112,38 @@ namespace Couchbase.UnitTests.Core
             nodes.Remove(clusterNode2.EndPoint, "default2", out node2);
             nodes.Remove(clusterNode3.EndPoint, "default1", out node3);
             nodes.Remove(clusterNode4.EndPoint, "default2", out node4);
+        }
+
+        /// <summary>
+        /// A failed HELO used to be swallowed: the status was discarded, GetValue() returned null,
+        /// and the caller quietly assigned ServerFeatureSet.Empty - leaving a connection in the pool
+        /// with no negotiated features while operations were still framed as though it had them,
+        /// which is how a rejected HELO produces corrupted document keys (NCBC-4146, NCBC-4287).
+        /// </summary>
+        [Fact]
+        public async Task Failed_Hello_Fails_The_Connection()
+        {
+            using var clusterNode = MockClusterNode("default");
+
+            var connection = new Mock<IConnection>();
+            connection.SetupGet(c => c.ConnectionId).Returns(1UL);
+            connection.SetupGet(c => c.ServerFeatures).Returns(ServerFeatureSet.Empty);
+            connection
+                .Setup(c => c.SendAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<IOperation>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((ReadOnlyMemory<byte> _, IOperation op, CancellationToken _) =>
+                {
+                    //Anything but Success. Not TransportFailure, which already had its own
+                    //ConnectException path, so this exercises the new check rather than the old one.
+                    op.HandleOperationCompleted(
+                        AsyncState.BuildErrorResponse(op.Opaque, ResponseStatus.InternalError));
+                    return default;
+                });
+
+            var exception = await Assert.ThrowsAsync<ConnectException>(() =>
+                ((IConnectionInitializer) clusterNode).InitializeConnectionAsync(connection.Object, default));
+
+            Assert.Contains("HELO failed", exception.Message);
         }
 
         private ClusterNode MockClusterNode(string bucketName, string hostname = "localhost")

--- a/tests/Couchbase.UnitTests/Core/Configuration/Server/BucketConfigExtensionTests.cs
+++ b/tests/Couchbase.UnitTests/Core/Configuration/Server/BucketConfigExtensionTests.cs
@@ -633,10 +633,7 @@ public class BucketConfigExtensionTests
             Returns(Task.FromResult(node.Object));
 
         var options = new ClusterOptions().AddClusterService(clusterNodeFactory.Object).WithPasswordAuthentication("username", "password");
-        var clusterCtx = new ClusterContext(new CancellationTokenSource(), options)
-        {
-            SupportsCollections = true
-        };
+        var clusterCtx = new ClusterContext(new CancellationTokenSource(), options);
 
         var bucket = new CouchbaseBucket("default",
             clusterCtx,

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/CollectionIdFramingTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/CollectionIdFramingTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Operations.Authentication;
+using Couchbase.Core.IO.Operations.Collections;
+using Couchbase.Utils;
+using Xunit;
+
+namespace Couchbase.UnitTests.Core.IO.Operations
+{
+    /// <summary>
+    /// Whether a KV frame carries a leb128 collection ID prefix is a per-connection fact, fixed by
+    /// what that connection negotiated in HELO. Deciding it from client-side state is NCBC-4146, and
+    /// it corrupts keys in both directions: a prefix the server does not parse becomes part of the
+    /// document ID, and a missing prefix makes the server read the first byte of the key as the
+    /// collection.
+    /// </summary>
+    public class CollectionIdFramingTests
+    {
+        private const string Key = "user::1";
+        private const uint Cid = 23;
+
+        /// <summary>Exposes the protected framing method for a document operation.</summary>
+        private class TestableGet : Get<byte[]>
+        {
+            public int Frame(Span<byte> buffer, bool collectionsEnabled) => WriteKey(buffer, collectionsEnabled);
+        }
+
+        /// <summary>
+        /// Stands in for the connection and cluster level operations - HELO, SASL, SELECT_BUCKET and
+        /// the rest are sealed or awkward to construct, and which of them opt out is pinned by
+        /// <see cref="Only_connection_and_cluster_operations_opt_out_of_the_collection_id"/>. What is
+        /// under test here is what opting out does to the frame.
+        /// </summary>
+        private class TestableConnectionOperation : Get<byte[]>
+        {
+            internal override bool RequiresCollectionId => false;
+
+            public int Frame(Span<byte> buffer, bool collectionsEnabled) => WriteKey(buffer, collectionsEnabled);
+        }
+
+        [Fact]
+        public void Collections_negotiated_writes_the_prefix()
+        {
+            var op = new TestableGet { Key = Key, Cid = Cid };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal(Key.Length + 1, length);
+            Assert.Equal(Cid, buffer[0]);
+            Assert.Equal(Key, System.Text.Encoding.UTF8.GetString(buffer, 1, Key.Length));
+        }
+
+        /// <summary>
+        /// Polarity A of NCBC-4146: the SDK used to write a prefix whenever it happened to be holding
+        /// a CID, even on a connection that never negotiated collections. The server then read the
+        /// prefix byte as part of the document ID.
+        /// </summary>
+        [Fact]
+        public void Collections_not_negotiated_writes_no_prefix_even_holding_a_cid()
+        {
+            var op = new TestableGet { Key = Key, Cid = Cid };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: false);
+
+            Assert.Equal(Key.Length, length);
+            Assert.Equal(Key, System.Text.Encoding.UTF8.GetString(buffer, 0, Key.Length));
+        }
+
+        /// <summary>
+        /// Polarity B, and the NCBC-4285 defect: no prefix on a connection that negotiated
+        /// collections means the server eats the first byte of the key. Refuse to send it.
+        /// </summary>
+        [Fact]
+        public void Collections_negotiated_without_a_cid_throws_rather_than_corrupting_the_key()
+        {
+            var op = new TestableGet { Key = Key };
+            var buffer = new byte[64];
+
+            var exception = Assert.Throws<CouchbaseException>(() => op.Frame(buffer, collectionsEnabled: true));
+
+            Assert.Contains("no collection ID", exception.Message);
+        }
+
+        /// <summary>
+        /// The default collection is CID 0, which is a real prefix and not the same frame as no
+        /// prefix at all. Getting these two confused is the origin of the whole defect class.
+        /// </summary>
+        [Fact]
+        public void Default_collection_writes_a_zero_prefix()
+        {
+            var op = new TestableGet { Key = Key, Cid = 0 };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal(Key.Length + 1, length);
+            Assert.Equal(0, buffer[0]);
+        }
+
+        /// <summary>
+        /// SELECT_BUCKET's key is a bucket name, and it is sent before any collection exists. It must
+        /// neither be prefixed nor throw for the absent CID.
+        /// </summary>
+        [Fact]
+        public void An_operation_that_addresses_no_document_is_never_prefixed()
+        {
+            var op = new TestableConnectionOperation { Key = "travel-sample" };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal("travel-sample".Length, length);
+            Assert.Equal("travel-sample", System.Text.Encoding.UTF8.GetString(buffer, 0, length));
+        }
+
+        /// <summary>
+        /// The key field carries the collection ID as well as the document ID, so a 250 byte key does
+        /// not fit once a prefix is prepended. The Key setter only checks the document ID on its own,
+        /// so this used to surface from OperationHeader.KeyLength as a bare
+        /// ArgumentOutOfRangeException from inside the write path.
+        /// </summary>
+        [Fact]
+        public void A_maximum_length_key_does_not_fit_once_prefixed()
+        {
+            var op = new TestableGet { Key = new string('k', 250), Cid = Cid };
+            var buffer = new byte[512];
+
+            var exception = Assert.Throws<InvalidArgumentException>(
+                () => op.Frame(buffer, collectionsEnabled: true));
+
+            Assert.Contains("collection ID prefix", exception.Message);
+        }
+
+        [Fact]
+        public void A_key_that_leaves_room_for_the_prefix_is_accepted()
+        {
+            //Cid 23 is one leb128 byte, so 249 + 1 is exactly the budget.
+            var op = new TestableGet { Key = new string('k', 249), Cid = Cid };
+            var buffer = new byte[512];
+
+            Assert.Equal(250, op.Frame(buffer, collectionsEnabled: true));
+        }
+
+        /// <summary>
+        /// And the full 250 is still fine when no prefix is going to be written.
+        /// </summary>
+        [Fact]
+        public void A_maximum_length_key_still_fits_without_collections()
+        {
+            var op = new TestableGet { Key = new string('k', 250), Cid = Cid };
+            var buffer = new byte[512];
+
+            Assert.Equal(250, op.Frame(buffer, collectionsEnabled: false));
+        }
+
+        /// <summary>
+        /// This is the test that matters. RequiresCollectionId defaults to true because true is the
+        /// safe answer: an operation added without a thought about framing then fails loudly instead
+        /// of silently addressing the wrong collection. So the default is deliberately not pinned -
+        /// only the opt-outs are, because an opt-out is the answer that can corrupt data.
+        ///
+        /// If this fails because you added an operation, decide which it is. Does it address a
+        /// document? Then it needs a collection ID and you should not be here. Is it a connection or
+        /// cluster level operation whose key is not a document ID? Then add it below.
+        /// </summary>
+        [Fact]
+        public void Only_connection_and_cluster_operations_opt_out_of_the_collection_id()
+        {
+            string[] expected =
+            [
+                "ClusterMapChangeNotification", // a server push, no document key
+                "Config",                       // cluster map request
+                "GetCid",                       // the key is a collection name - this resolves CIDs
+                "GetErrorMap",                  // writes no key
+                "GetManifest",                  // manifest request
+                "GetSid",                       // the key is a scope name
+                "Hello",                        // the key is a connection identifier
+                "Noop",                         // writes no key
+                "RangeScanCancel",              // writes no key, identified by scan UUID
+                "RangeScanContinue",            // writes no key, identified by scan UUID
+                "RangeScanCreate",              // writes no key, collection travels in the body
+                "SaslList",                     // mechanism negotiation
+                "SaslStart",                    // authentication, before any collection exists
+                "SaslStep",                     // authentication, before any collection exists
+                "SelectBucket"                  // the key is the bucket name
+            ];
+
+            var actual = typeof(OperationBase).Assembly.GetTypes()
+                .Where(type => typeof(OperationBase).IsAssignableFrom(type) && type != typeof(OperationBase))
+                .Where(type => type.GetProperty(nameof(OperationBase.RequiresCollectionId),
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.DeclaredOnly) is not null)
+                .Select(type => type.Name)
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// SASL is the trap worth a test of its own: HELO completes before authentication, so by the
+        /// time SaslStep runs the connection has already negotiated collections while no collection
+        /// exists. An exemption list drafted by hand had SaslStart and SaslList but not SaslStep,
+        /// which would have failed authentication on every non-TLS connection.
+        /// </summary>
+        [Fact]
+        public void Every_sasl_operation_opts_out()
+        {
+            Assert.False(new SaslStart().RequiresCollectionId);
+            Assert.False(new SaslStep().RequiresCollectionId);
+            Assert.False(new SaslList().RequiresCollectionId);
+        }
+
+        [Fact]
+        public void A_document_operation_requires_a_collection_id_by_default()
+        {
+            Assert.True(new Get<byte[]>().RequiresCollectionId);
+            Assert.True(new Set<byte[]>("bucket", Key).RequiresCollectionId);
+            Assert.True(new Delete().RequiresCollectionId);
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/PacketFormatVBucketIdTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/PacketFormatVBucketIdTests.cs
@@ -28,7 +28,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Build complete packet
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -58,7 +58,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -113,7 +113,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -207,7 +207,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Full packet creation process
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -247,7 +247,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/SubDocument/MultiMutationTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/SubDocument/MultiMutationTests.cs
@@ -38,7 +38,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations.SubDocument
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
 
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             using (op.ParseCommandValues())
@@ -47,7 +47,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations.SubDocument
             }
 
             op.Reset();
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             Assert.Equal(10, op.MutateCommands.Count);
 

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/VBucketIdBugFixIntegrationTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/VBucketIdBugFixIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Execute the complete packet building process
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -67,7 +67,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
                 // Act
                 operation.WriteExtras(builder);
-                operation.WriteKey(builder);
+                operation.WriteKey(builder, collectionsEnabled: false);
                 operation.WriteBody(builder);
 
                 var header = operation.CreateHeader(DataType.Json);
@@ -135,7 +135,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder2);
-            operation.WriteKey(builder2);
+            operation.WriteKey(builder2, collectionsEnabled: false);
             operation.WriteBody(builder2);
 
             var header2 = operation.CreateHeader(DataType.Json);
@@ -165,7 +165,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
                 };
 
                 operation.WriteExtras(builder);
-                operation.WriteKey(builder);
+                operation.WriteKey(builder, collectionsEnabled: false);
                 operation.WriteBody(builder);
 
                 var header = operation.CreateHeader(DataType.Json);

--- a/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
+++ b/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
@@ -22,10 +22,7 @@ namespace Couchbase.UnitTests
         public async Task Scope_DoesNotThrow_ScopeNoteFoundException()
         {
             var bucket = new CouchbaseBucket("default",
-                new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password"))
-                {
-                    SupportsCollections = true
-                },
+                new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password")),
                 new Mock<IScopeFactory>().Object,
                 new Mock<IRetryOrchestrator>().Object,
                 new Mock<IVBucketKeyMapperFactory>().Object,

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionCollectionIdTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionCollectionIdTests.cs
@@ -1,0 +1,493 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.Bootstrapping;
+using Couchbase.Core.Configuration.Server;
+using Couchbase.Core.DI;
+using Couchbase.Core.Diagnostics.Tracing;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.Exceptions.KeyValue;
+using Couchbase.Core.IO.Compression;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Operations.Collections;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+using Couchbase.Core.Logging;
+using Couchbase.Core.Retry;
+using Couchbase.Core.Sharding;
+using Couchbase.KeyValue;
+using Couchbase.KeyValue.RangeScan;
+using Couchbase.Management.Collections;
+using Couchbase.Management.Views;
+using Couchbase.UnitTests.Utils;
+using Couchbase.Utils;
+using Couchbase.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.KeyValue
+{
+    /// <summary>
+    /// Every key/value operation must resolve the collection ID before it dispatches. If it does
+    /// not, and the connection negotiated collections in HELO, the server reads the first byte of
+    /// the document key as a leb128 collection ID and the operation silently addresses the wrong
+    /// collection: NCBC-4285, where GetPrimary was a near-identical copy of GetReplica that had
+    /// never been given the guard.
+    ///
+    /// The point of these tests is <see cref="Every_public_operation_is_covered"/>. A table of
+    /// operations only proves something about the operations someone remembered to add, so the
+    /// reflection test fails when the public surface grows past the table.
+    /// </summary>
+    public class CouchbaseCollectionCollectionIdTests
+    {
+        private const string DocId = "thekey";
+
+        /// <summary>The collection ID encoded in <see cref="GetCidResponse"/>.</summary>
+        private const uint FakeCid = 0x17;
+
+        /// <summary>
+        /// A real GET_CID success response, taken from
+        /// <c>CollectionOperationTests.Test_GetCid_WithValue</c>. Serving a genuine packet means the
+        /// collection actually ends up holding a CID, so the tests can assert on the value that
+        /// reached the wire rather than merely that a fetch was attempted.
+        /// </summary>
+        private static readonly byte[] GetCidResponse =
+        [
+            0x18, 0xbb, 0x03, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x1a,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x1f, 0x00, 0x00, 0x00, 0x17
+        ];
+
+        private static readonly LookupInSpec[] LookupSpecs = [LookupInSpec.Get("name")];
+        private static readonly MutateInSpec[] MutateSpecs = [MutateInSpec.Upsert("name", "mike")];
+
+        /// <summary>
+        /// One entry per public operation. Keys are labels rather than bare method names so the two
+        /// UnlockAsync overloads can both appear; <see cref="Every_public_operation_is_covered"/>
+        /// matches on the part before any generic marker.
+        /// </summary>
+        private static readonly Dictionary<string, Func<CouchbaseCollection, Task>> Operations = new()
+        {
+            ["GetAsync"] = c => c.GetAsync(DocId),
+            ["ExistsAsync"] = c => c.ExistsAsync(DocId),
+            ["UpsertAsync"] = c => c.UpsertAsync(DocId, new { name = "mike" }),
+            ["InsertAsync"] = c => c.InsertAsync(DocId, new { name = "mike" }),
+            ["ReplaceAsync"] = c => c.ReplaceAsync(DocId, new { name = "mike" }),
+            ["RemoveAsync"] = c => c.RemoveAsync(DocId),
+            ["UnlockAsync"] = c => c.UnlockAsync(DocId, 0UL),
+            ["UnlockAsync<T>"] = c => c.UnlockAsync<object>(DocId, 0UL),
+            ["TouchAsync"] = c => c.TouchAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["TouchWithCasAsync"] = c => c.TouchWithCasAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAndTouchAsync"] = c => c.GetAndTouchAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAndLockAsync"] = c => c.GetAndLockAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAnyReplicaAsync"] = c => c.GetAnyReplicaAsync(DocId),
+            ["GetAllReplicasAsync"] = c => Task.WhenAll(c.GetAllReplicasAsync(DocId)),
+            ["LookupInAsync"] = c => c.LookupInAsync(DocId, LookupSpecs),
+            ["LookupInAnyReplicaAsync"] = c => c.LookupInAnyReplicaAsync(DocId, LookupSpecs),
+            ["LookupInAllReplicasAsync"] = c => Drain(c.LookupInAllReplicasAsync(DocId, LookupSpecs)),
+            ["MutateInAsync"] = c => c.MutateInAsync(DocId, MutateSpecs),
+            ["ScanAsync"] = c => Drain(c.ScanAsync(new RangeScan())),
+            ["AppendAsync"] = c => c.AppendAsync(DocId, [1, 2, 3]),
+            ["PrependAsync"] = c => c.PrependAsync(DocId, [1, 2, 3]),
+            ["IncrementAsync"] = c => c.IncrementAsync(DocId),
+            ["DecrementAsync"] = c => c.DecrementAsync(DocId)
+        };
+
+        public static TheoryData<string> OperationLabels => new(Operations.Keys);
+
+        /// <summary>
+        /// ScanAsync cannot be asserted the same way as the rest: PartitionScan builds its own
+        /// operations and reads Cid off the collection, so nothing it sends carries the document
+        /// key. Its coverage is the collection-level assertion that the ID was resolved at all.
+        /// </summary>
+        private const string ScanLabel = "ScanAsync";
+
+        [Theory]
+        [MemberData(nameof(OperationLabels))]
+        public async Task Operation_resolves_the_collection_id_before_dispatch(string label)
+        {
+            var (collection, bucket) = CreateCollection();
+
+            try
+            {
+                await Operations[label](collection).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Every operation fails - the fake bucket serves no documents. What it put on the
+                // wire before failing is the point.
+            }
+
+            Assert.True(bucket.FetchedCid, $"{label} never fetched a collection ID.");
+            Assert.Equal(FakeCid, collection.Cid!.Value);
+
+            var keyedOps = bucket.Dispatched.Where(op => op.Key == DocId).ToList();
+
+            // Without this the assertion below passes for an operation that dispatched nothing.
+            if (label != ScanLabel)
+            {
+                Assert.NotEmpty(keyedOps);
+            }
+
+            Assert.All(keyedOps, op =>
+                Assert.True(op.Cid == FakeCid,
+                    $"{label} dispatched {op.OpType} for key '{op.Key}' with Cid {(op.Cid?.ToString() ?? "null")}."));
+        }
+
+        /// <summary>
+        /// The table above is only as good as its coverage, and a new operation added without an
+        /// entry is exactly how NCBC-4285 happened. This fails when the public surface outgrows it.
+        /// </summary>
+        [Fact]
+        public void Every_public_operation_is_covered()
+        {
+            var surface = typeof(ICouchbaseCollection).GetMethods()
+                .Concat(typeof(IBinaryCollection).GetMethods())
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+                .Distinct()
+                .ToList();
+
+            var covered = Operations.Keys
+                .Select(label => label.Split('<')[0])
+                .ToHashSet();
+
+            var missing = surface.Where(name => !covered.Contains(name)).ToList();
+
+            Assert.True(missing.Count == 0,
+                $"Add to the collection ID coverage table: {string.Join(", ", missing)}. Every " +
+                "key/value operation has to resolve the collection ID before it dispatches, or the " +
+                "server reads the first byte of the document key as the collection ID (NCBC-4285).");
+        }
+
+        /// <summary>
+        /// The CID is cached on the collection and PopulateCidAsync short-circuits on it, so each
+        /// case needs its own collection or every case after the first passes for the wrong reason.
+        /// </summary>
+        [Fact]
+        public void Each_case_starts_without_a_collection_id()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            Assert.Null(collection.Cid);
+            Assert.False(bucket.FetchedCid);
+        }
+
+        /// <summary>
+        /// A bucket with no collections - a memcached bucket - still talks to a connection that
+        /// negotiated collections in HELO, so the server reads a leb128 collection ID from every key.
+        /// The default collection, 0, is the right one, and there is nothing to look up. Leaving the
+        /// CID null is why every KV operation against a memcached bucket failed with
+        /// CollectionNotFound after burning the full KvTimeout.
+        /// </summary>
+        [Fact]
+        public async Task A_bucket_without_collections_uses_the_default_collection_id()
+        {
+            var (collection, bucket) = CreateCollection(supportsCollections: false, defaultCollection: true);
+
+            await Invoke(() => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.False(bucket.FetchedCid);
+            Assert.True(collection.Cid.HasValue,
+                "A bucket without collections left the CID null, so a collections-negotiated " +
+                "connection would read the first byte of the key as the collection ID.");
+            Assert.Equal(CouchbaseCollection.DefaultCollectionId, collection.Cid!.Value);
+            AssertAllKeyedOpsCarry(bucket, CouchbaseCollection.DefaultCollectionId);
+        }
+
+        /// <summary>
+        /// Asking for a named collection on a cluster or bucket that has none cannot be satisfied, so
+        /// say so at the boundary instead of sending an operation whose collection the server cannot
+        /// resolve - which surfaced as CollectionNotFound after the full KvTimeout. Matches the JVM's
+        /// BaseKeyValueRequest.encodedExternalKeyWithCollection.
+        /// </summary>
+        [Fact]
+        public async Task A_named_collection_without_collections_support_throws()
+        {
+            var (collection, bucket) = CreateCollection(supportsCollections: false, defaultCollection: false);
+
+            var exception = await Assert.ThrowsAsync<FeatureNotAvailableException>(
+                () => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.Contains("s.c", exception.Message);
+            Assert.Empty(bucket.Dispatched);
+        }
+
+        /// <summary>
+        /// The default scope and collection are defined to be collection ID 0, so the first operation
+        /// against them should not spend a GET_CID round trip discovering that.
+        /// </summary>
+        [Fact]
+        public async Task The_default_collection_needs_no_lookup()
+        {
+            var (collection, bucket) = CreateCollection(defaultCollection: true);
+
+            await Invoke(() => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.False(bucket.FetchedCid);
+            Assert.Equal(CouchbaseCollection.DefaultCollectionId, collection.Cid!.Value);
+            AssertAllKeyedOpsCarry(bucket, CouchbaseCollection.DefaultCollectionId);
+        }
+
+        /// <summary>
+        /// PopulateCidAsync(retryIfFailure: false) is meant to send the GET_CID without going through
+        /// the retry orchestrator, but both lazies were built with retryIfFailure: true, so the
+        /// no-retry one retried. Only reachable with forceUpdate false, which nothing currently does -
+        /// a trap for the next caller rather than a live bug.
+        /// </summary>
+        [Fact]
+        public async Task A_no_retry_collection_id_fetch_does_not_go_through_the_retry_path()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            await collection.PopulateCidAsync(retryIfFailure: false).ConfigureAwait(false);
+
+            Assert.True(bucket.FetchedCid);
+            Assert.False(bucket.FetchedCidViaRetry,
+                "PopulateCidAsync(retryIfFailure: false) went through the retry path.");
+        }
+
+        [Fact]
+        public async Task A_retrying_collection_id_fetch_does_go_through_the_retry_path()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            await collection.PopulateCidAsync(retryIfFailure: true).ConfigureAwait(false);
+
+            Assert.True(bucket.FetchedCid);
+            Assert.True(bucket.FetchedCidViaRetry);
+        }
+
+        /// <summary>
+        /// GetCid.GetValueAsUint() returns null for a Success response whose body is empty or cannot
+        /// be parsed. That null used to be assigned to Cid and carried to the wire; it must fail where
+        /// the cause is still known.
+        /// </summary>
+        [Fact]
+        public async Task A_successful_get_cid_with_no_body_fails_at_the_lookup()
+        {
+            var (collection, bucket) = CreateCollection();
+            bucket.ServeEmptyCidBody = true;
+
+            var exception = await Assert.ThrowsAsync<CouchbaseException>(
+                () => collection.PopulateCidAsync().AsTask()).ConfigureAwait(false);
+
+            Assert.Contains("s.c", exception.Message);
+            Assert.Null(collection.Cid);
+        }
+
+        private static async Task Invoke(Func<Task> operation)
+        {
+            try
+            {
+                await operation().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // The fake bucket serves no documents. What went on the wire is the point.
+            }
+        }
+
+        private static void AssertAllKeyedOpsCarry(CidFakeBucket bucket, uint expected)
+        {
+            var keyedOps = bucket.Dispatched.Where(op => op.Key == DocId).ToList();
+            Assert.NotEmpty(keyedOps);
+            Assert.All(keyedOps, op => Assert.Equal(expected, op.Cid!.Value));
+        }
+
+        private static async Task Drain<T>(IAsyncEnumerable<T> source)
+        {
+            await foreach (var _ in source.ConfigureAwait(false))
+            {
+            }
+        }
+
+        /// <summary>
+        /// A collections-capable fake bucket on its own, for tests that need a real BucketBase and its
+        /// ClusterContext rather than a whole collection.
+        /// </summary>
+        internal static CidFakeBucket CreateBucketWithCollections()
+        {
+            var config = ResourceHelper.ReadResource(@"Documents\Configs\configWithReplicasAndServerGroups.json",
+                InternalSerializationContext.Default.BucketConfig);
+
+            config.VBucketServerMap.VBucketMap = Enumerable.Repeat<short[]>([1, 0, 2, 3], 1024).ToArray();
+            config.BucketCapabilities =
+            [
+                BucketCapabilities.COLLECTIONS,
+                BucketCapabilities.RANGE_SCAN,
+                BucketCapabilities.SUBDOC_REPLICA_READ
+            ];
+
+            return new CidFakeBucket(config);
+        }
+
+        private static (CouchbaseCollection Collection, CidFakeBucket Bucket) CreateCollection(
+            bool supportsCollections = true, bool defaultCollection = false)
+        {
+            var config = ResourceHelper.ReadResource(@"Documents\Configs\configWithReplicasAndServerGroups.json",
+                InternalSerializationContext.Default.BucketConfig);
+
+            // Every key maps to the same topology. Unlike the zone-aware fixture, collections are
+            // supported here - that is the whole point - and range scans too, so ScanAsync gets
+            // past its feature check.
+            config.VBucketServerMap.VBucketMap = Enumerable.Repeat<short[]>([1, 0, 2, 3], 1024).ToArray();
+            config.BucketCapabilities = supportsCollections
+                ?
+                [
+                    BucketCapabilities.COLLECTIONS,
+                    BucketCapabilities.RANGE_SCAN,
+                    BucketCapabilities.SUBDOC_REPLICA_READ
+                ]
+                :
+                [
+                    BucketCapabilities.RANGE_SCAN,
+                    BucketCapabilities.SUBDOC_REPLICA_READ
+                ];
+
+            var bucket = new CidFakeBucket(config);
+
+            var collection = new CouchbaseCollection(bucket,
+                new OperationConfigurator(new LegacyTranscoder(),
+                    Mock.Of<IOperationCompressor>(),
+                    new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy()),
+                    new BestEffortRetryStrategy()),
+                new Mock<ILogger<CouchbaseCollection>>().Object,
+                new Mock<ILogger<GetResult>>().Object,
+                new Mock<IRedactor>().Object,
+                defaultCollection ? CouchbaseCollection.DefaultCollectionName : "c",
+                defaultCollection
+                    ? Mock.Of<IScope>(scope => scope.IsDefaultScope == true &&
+                                               scope.Name == Scope.DefaultScopeName)
+                    : Mock.Of<IScope>(scope => scope.IsDefaultScope == false && scope.Name == "s"),
+                new NoopRequestTracer(),
+                NullFallbackTypeSerializerProvider.Instance,
+                Mock.Of<IServiceProvider>());
+
+            return (collection, bucket);
+        }
+
+        internal record DispatchedOp(string OpType, string Key, uint? Cid);
+
+        /// <summary>
+        /// Serves GET_CID and nothing else: every other operation is recorded and then failed, so
+        /// the collection method unwinds immediately and the test can look at what it sent.
+        /// </summary>
+        internal class CidFakeBucket : BucketBase
+        {
+            private readonly List<DispatchedOp> _dispatched = new();
+            private readonly object _lock = new();
+
+            public CidFakeBucket(BucketConfig config)
+                : base(config.Name,
+                    new ClusterContext(null,
+                        new ClusterOptions().WithPasswordAuthentication("username", "password")),
+                    new Mock<IScopeFactory>().Object,
+                    CreateRetryOrchestrator(),
+                    new Mock<ILogger>().Object,
+                    new TypedRedactor(RedactionLevel.None),
+                    new Mock<IBootstrapperFactory>().Object,
+                    NoopRequestTracer.Instance,
+                    new Mock<IOperationConfigurator>().Object,
+                    new BestEffortRetryStrategy(), null)
+            {
+                CurrentConfig = config;
+                KeyMapper = new VBucketKeyMapper(config, new VBucketServerMap(config.VBucketServerMap),
+                    new VBucketFactory(new Mock<ILogger<VBucket>>().Object));
+            }
+
+            /// <summary>Whether a GET_CID was sent.</summary>
+            public bool FetchedCid { get; private set; }
+
+            /// <summary>
+            /// Which path the GET_CID took. PopulateCidAsync(retryIfFailure: false) must reach
+            /// SendAsync, not RetryAsync - the observable difference the no-retry lazy exists for.
+            /// </summary>
+            public bool FetchedCidViaRetry { get; private set; }
+
+            /// <summary>
+            /// Answer GET_CID with a Success status and no body, which is what makes
+            /// GetCid.GetValueAsUint() return null.
+            /// </summary>
+            public bool ServeEmptyCidBody { get; set; }
+
+            /// <summary>Snapshot of what was dispatched, GET_CID aside.</summary>
+            public IReadOnlyList<DispatchedOp> Dispatched
+            {
+                get
+                {
+                    lock (_lock)
+                    {
+                        return _dispatched.ToList();
+                    }
+                }
+            }
+
+            public virtual Task<ResponseStatus> Dispatch(IOperation operation, bool viaRetry = true)
+            {
+                if (operation is GetCid getCid)
+                {
+                    FetchedCid = true;
+                    FetchedCidViaRetry = viaRetry;
+
+                    if (ServeEmptyCidBody)
+                    {
+                        return Task.FromResult(ResponseStatus.Success);
+                    }
+
+                    var response = MemoryPool<byte>.Shared.RentAndSlice(GetCidResponse.Length);
+                    GetCidResponse.AsMemory().CopyTo(response.Memory);
+                    getCid.Read(response);
+
+                    return Task.FromResult(ResponseStatus.Success);
+                }
+
+                lock (_lock)
+                {
+                    _dispatched.Add(new DispatchedOp(operation.GetType().Name, operation.Key, operation.Cid));
+                }
+
+                return Task.FromException<ResponseStatus>(
+                    new TemporaryFailureException("The fake bucket serves no documents."));
+            }
+
+            private static IRetryOrchestrator CreateRetryOrchestrator()
+            {
+                var mock = new Mock<IRetryOrchestrator>();
+
+                mock.Setup(m => m.RetryAsync(It.IsAny<BucketBase>(), It.IsAny<IOperation>(),
+                        It.IsAny<CancellationTokenPair>()))
+                    .Returns((BucketBase bucket, IOperation op, CancellationTokenPair _) =>
+                        ((CidFakeBucket) bucket).Dispatch(op));
+
+                return mock.Object;
+            }
+
+            internal override Task<ResponseStatus> SendAsync(IOperation op, CancellationTokenPair token = default) =>
+                Dispatch(op, viaRetry: false);
+
+            public override ICouchbaseCollectionManager Collections => throw new NotImplementedException();
+
+#pragma warning disable CS0618, CS0672 // Obsolete View service members
+            public override IViewIndexManager ViewIndexes => throw new NotImplementedException();
+
+            public override Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument,
+                string viewName, ViewOptions options = null) => throw new NotImplementedException();
+#pragma warning restore CS0618, CS0672
+
+            public override Task ForceConfigUpdateAsync() => throw new NotImplementedException();
+
+            public override IScope Scope(string scopeName) => throw new NotImplementedException();
+
+            internal override Task BootstrapAsync(IClusterNode bootstrapNodes) => throw new NotImplementedException();
+
+            public override Task ConfigUpdatedAsync(BucketConfig newConfig) => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionTests.cs
@@ -341,7 +341,7 @@ namespace Couchbase.UnitTests.KeyValue
                 new Mock<ILogger<GetResult>>().Object,
                 new Mock<IRedactor>().Object,
                 CouchbaseCollection.DefaultCollectionName,
-                Mock.Of<IScope>(),
+                Mock.Of<IScope>(scope => scope.IsDefaultScope == true && scope.Name == Scope.DefaultScopeName),
                 new NoopRequestTracer(),
                 NullFallbackTypeSerializerProvider.Instance,
                 serviceProviderMock.Object);

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
@@ -256,7 +256,7 @@ namespace Couchbase.UnitTests.KeyValue
                 new Mock<ILogger<GetResult>>().Object,
                 new Mock<IRedactor>().Object,
                 CouchbaseCollection.DefaultCollectionName,
-                Mock.Of<IScope>(),
+                Mock.Of<IScope>(scope => scope.IsDefaultScope == true && scope.Name == Scope.DefaultScopeName),
                 new NoopRequestTracer(),
                 NullFallbackTypeSerializerProvider.Instance,
                 Mock.Of<IServiceProvider>());

--- a/tests/Couchbase.UnitTests/KeyValue/LookupInResultTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/LookupInResultTests.cs
@@ -1,3 +1,4 @@
+using Couchbase.Core;
 using System.Threading.Tasks;
 using Couchbase.Core.Exceptions;
 using Couchbase.Core.Exceptions.KeyValue;
@@ -33,7 +34,7 @@ namespace Couchbase.UnitTests.KeyValue
 
             var op = new MultiLookup<byte[]>("thekey", specs);
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             op.Transcoder = new JsonTranscoder();
             op.Transcoder.Serializer = new DefaultSerializer();
@@ -70,7 +71,7 @@ namespace Couchbase.UnitTests.KeyValue
 
             var op = new MultiLookup<byte[]>("thekey", specs);
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             op.Transcoder = new JsonTranscoder();
             op.Transcoder.Serializer = new DefaultSerializer();

--- a/tests/Couchbase.UnitTests/KeyValue/MutateInResultTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/MutateInResultTests.cs
@@ -44,7 +44,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(responsePacket));
 
             var result = new MutateInResult(op);
@@ -70,7 +70,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             var result = new MutateInResult(op);
@@ -102,7 +102,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             var result = new MutateInResult(op);

--- a/tests/Couchbase.UnitTests/Transactions/PreserveTtlCapabilityTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/PreserveTtlCapabilityTests.cs
@@ -1,0 +1,69 @@
+using Couchbase.Client.Transactions.Support;
+using Couchbase.Core;
+using Couchbase.UnitTests.KeyValue;
+using Couchbase.KeyValue;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Transactions
+{
+    /// <summary>
+    /// The transactions layer used to pass <c>Bucket.SupportsCollections</c> as the PreserveTtl flag,
+    /// with a comment calling it "a proxy for supporting TTLs". They are unrelated capabilities: every
+    /// node in a mixed-version cluster can support collections while some node has not negotiated
+    /// PreserveTtl, and CouchbaseCollection throws FeatureNotAvailableException for exactly that
+    /// combination - so the proxy had transactions asking for something the cluster would refuse.
+    /// </summary>
+    public class PreserveTtlCapabilityTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Capability_Comes_From_The_Cluster_Not_From_Collections(bool clusterSupportsPreserveTtl)
+        {
+            var bucket = FakeBucket(supportsPreserveTtl: clusterSupportsPreserveTtl);
+            var collection = CollectionOn(bucket);
+
+            Assert.Equal(clusterSupportsPreserveTtl, collection.SupportsPreserveTtl());
+        }
+
+        /// <summary>
+        /// Collections support must not be what decides this. Here the bucket supports collections
+        /// while the cluster cannot preserve expiry, which is the mixed-version case the old proxy got
+        /// wrong.
+        /// </summary>
+        [Fact]
+        public void Collections_Support_Does_Not_Imply_PreserveTtl()
+        {
+            var bucket = FakeBucket(supportsPreserveTtl: false);
+            var collection = CollectionOn(bucket);
+
+            Assert.True(bucket.SupportsCollections);
+            Assert.False(collection.SupportsPreserveTtl());
+        }
+
+        /// <summary>
+        /// Protostellar buckets are not a <see cref="BucketBase"/> and have no ClusterContext to ask,
+        /// so they keep the old proxy rather than silently losing TTL preservation.
+        /// </summary>
+        [Fact]
+        public void A_bucket_without_a_cluster_context_falls_back_to_collections_support()
+        {
+            var bucket = Mock.Of<IBucket>(b => b.SupportsCollections == true);
+            var collection = CollectionOn(bucket);
+
+            Assert.True(collection.SupportsPreserveTtl());
+        }
+
+        private static ICouchbaseCollection CollectionOn(IBucket bucket) =>
+            Mock.Of<ICouchbaseCollection>(collection =>
+                collection.Scope == Mock.Of<IScope>(scope => scope.Bucket == bucket));
+
+        private static CouchbaseCollectionCollectionIdTests.CidFakeBucket FakeBucket(bool supportsPreserveTtl)
+        {
+            var bucket = CouchbaseCollectionCollectionIdTests.CreateBucketWithCollections();
+            bucket.Context.SupportsPreserveTtl = supportsPreserveTtl;
+            return bucket;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

KV operations could address the wrong collection.

Whether a request carries a collection-ID prefix on the front of the document key is decided by what the *connection* negotiated with the server. The SDK decided it from its own state instead, so the two could disagree — and when they did, the server read part of the document key as the collection ID, or read the prefix as part of the key. Either way the operation silently hits the wrong collection, and neither side can detect it: both frames are structurally valid and nothing in the packet distinguishes them.

Underneath that, nothing in the code *forced* an operation to resolve a collection ID before sending it. There were 23 hand-copied guards doing it by convention, and an operation that skipped them compiled fine — which is how `GetPrimary` went four years without one.

This PR keys the decision on the connection, funnels every KV operation through a single place that cannot be skipped, and fixes the related defects found on the way — including two that meant a failed connection handshake could never be handled at all.

**2983 unit tests pass on net8.0 and net10.0**; the solution builds clean in Release. 51 tests are new, and every new assertion was checked by deliberately breaking the code to confirm the test catches it (table near the bottom).

Two tickets: **NCBC-4285** is the narrow defect, **NCBC-4287** is why it was possible.

---

## What was wrong, and what changed

Each item stands alone — no ticket needed to follow it.

### 1. The prefix decision came from client state, not the connection

`OperationBase.WriteKey` wrote a collection-ID prefix whenever it happened to be holding a CID (`Cid.HasValue`). Whether the server *parses* one is fixed by what that connection negotiated in HELO. The two disagree in both directions, and both are silent:

- prefix written on a connection that never negotiated collections → the server treats the prefix byte as part of the document ID, computes the vbucket without it, and the document becomes unreachable
- no prefix on a connection that did → the server reads the first byte of the document key as the collection ID

`WriteKey` now takes the connection's negotiated state, which `SendAsync` already holds and reads six lines below for `Json` and `SnappyCompression`.

### 2. Nothing forced an operation to resolve a collection ID

23 copies of the same guard, 19 copies of the identity stamp, and no compiler help. New `PrepareAsync(op, options)` resolves the CID, stamps `BucketName`/`SName`/`CName`/`Cid`, configures the operation and returns the rented token source — **the caller needs that return value in order to dispatch**, so an operation that skips preparation does not compile.

`ThrowIfBootStrapFailed` deliberately stays at the top of each method: folding it in would move an early exit to after the request span is opened, and it was never the defect.

### 3. `GetPrimary` never resolved its collection ID — NCBC-4285

Reached via `GetAllReplicasAsync`. It was a near-identical copy of `GetReplica` twelve lines below, which *did* have the guard — added five weeks later by NCBC-2881, which missed this one. Fixed as a consequence of item 2 rather than by its own patch.

Rarely surfaced because `PopulateCidAsync` short-circuits once a CID is cached, so only a `GetAllReplicasAsync` that was the first such call on a collection instance was exposed. It becomes a reliable wrong answer once a bucket's lifetime collection count passes ~120, where CIDs stop fitting in the single leb128 byte an ASCII key leaves room for.

### 4. A failed HELO was swallowed and the connection kept

The response status was discarded, `GetValue()` returned null on anything but success, and the caller quietly assigned `ServerFeatureSet.Empty` — leaving a connection in the pool with no negotiated features while operations were still framed as though it had them. Fault injection against 3.9.0 showed this produces exactly the NUL-byte-prefixed document IDs reported in the NCBC-4146 support cases. HELO failure now fails the connection.

### 5. …and a failed HELO could never reach its own error handling

In `ClusterNode.ExecuteOp`, success returns early and every other status fell through to `ErrorMap.TryGetGetErrorCode(...)`. The error map is fetched *after* HELO, so it is null, and every connection-initialisation failure became a `NullReferenceException` before any caller saw the status. Item 4 was unreachable until this was null-guarded.

### 6. A missing collection ID went on the wire

New `RequiresCollectionId` on `OperationBase`, defaulting to `true` — the safe answer, so an operation added without a thought about framing fails loudly rather than silently addressing the wrong collection. The 15 connection- and cluster-level operations whose key is not a document ID override it to `false`. A null CID on a collections-negotiated connection now throws instead of being sent.

### 7. Key length ignored the prefix

`Key`'s setter validated the document ID alone against the 250-byte limit, but the key field carries the collection ID too. A 250-byte key therefore failed as a bare `ArgumentOutOfRangeException` from inside `OperationHeader.KeyLength`, deep in the write path. Now validated at framing time with a message that says what happened. Java validates the same way, prefix included.

### 8. Buckets without collections left the CID null

A memcached bucket has only the default collection, but the connection may still have negotiated collections — in which case the server reads a CID from every key, and the right value is 0. Leaving it null is why **every KV operation against a memcached bucket failed with `CollectionNotFound` after burning the full `KvTimeout`**. Now resolves to 0.

### 9. A named collection on a cluster without collections was sent anyway

It cannot be satisfied, so it now throws `FeatureNotAvailableException` at the API boundary instead of failing with `CollectionNotFound` after the full timeout. Matches the JVM's `BaseKeyValueRequest.encodedExternalKeyWithCollection`.

### 10. `_default._default` cost a `GET_CID` round trip

The default scope and collection are defined to be collection ID 0. Now resolved directly, saving a round trip on the first operation against most collections.

### 11. Cluster-wide feature flags were last-write-wins

`ClusterContext.SupportsPreserveTtl` and `SupportsBinaryXattr` describe the cluster but were assigned from whichever node initialised last, at **seven separate sites each overwriting the one before** — so in a mixed-version cluster the answer depended on ordering. Now recomputed as the conjunction over every node that has negotiated, at the membership choke points (`AddNode`/`RemoveNode`) and when a node finishes negotiating, since a node is often added before its features are known. Nodes that have not negotiated are skipped rather than counted as unsupporting, so the flags do not flap to false while a node comes up.

They stay fields rather than computed properties because they are read on every mutation; turning a field read into an enumeration of the node list is not a trade worth making there.

### 12. Transactions used collections support as a proxy for PreserveTtl support

`DocumentRepository.cs` passed `Bucket.SupportsCollections` as the `PreserveTtl` flag, with a comment calling it *"a proxy for supporting TTLs"*. Two unrelated capabilities. Item 11 turns that from flaky into reliably wrong during a rolling upgrade — transactions would request a feature the cluster then refuses. Five call sites now read the real capability, via a helper that falls back to the old proxy for Protostellar, which has no `ClusterContext` to ask.

### 13. `GetCidLazyNoRetry` retried

Both lazies were built with `retryIfFailure: true`, so the no-retry one retried. Currently only reachable via `PopulateCidAsync(retryIfFailure: false, forceUpdate: false)`, which nothing calls — the one non-retry caller passes `forceUpdate: true` and takes a branch that bypasses the lazies. A trap for the next caller rather than a live bug.

### 14. A successful `GET_CID` with an empty body produced a null CID

`GetValueAsUint()` returns null for a Success response whose body is empty or unparseable, and that null was assigned to `Cid` and carried to the wire. It now fails at the lookup, where the cause is still known. The *deliberate* null from the older-server fallback path is untouched — that one means "this server has no collections", which is a different answer.

### 15. `ClusterContext.SupportsCollections` was dead

A public settable property that nothing assigned and nothing read — permanently false while reading as authoritative. Two tests were setting it in object initialisers, which rather makes the case. Removed.

### 16. `ExecuteLookupIn` resolved the CID unconditionally

Not behind `RequiresCid()`, so subdoc lookups forced a `GET_CID` round trip on buckets that do not support collections — plausibly one contributor to item 8.

### 17. `ScanAsync`'s guard was load-bearing

`PartitionScan` builds its own operations and reads `_collection.Cid` as a plain property, so it cannot go through the funnel. Removing `ScanAsync`'s guard broke range scans; caught because 23 removed guards produced only 19 `PrepareAsync` sites. It now calls the extracted `EnsureCollectionIdAsync`, which `PrepareAsync` also uses, so there is one implementation of the resolve.

---

## Behaviour changes to accept consciously

- **Item 11 is a tightening.** In a mixed-version cluster where some nodes lack `PreserveTtl`, callers who currently get it by luck of initialisation order now get `FeatureNotAvailableException`. That is the point; the alternative is sending the flag to a node that does not implement it.
- **Item 9 moves an error earlier** — from a timeout to an immediate throw at the API boundary.
- **Item 16 removes a round trip** on non-collections buckets.
- **The internal `get_cid` span now nests inside the operation's span** rather than preceding it, because the resolve happens inside `PrepareAsync`. Avoiding this would mean resolving before the span opens, i.e. back to a per-method call, which is the property this change exists to remove.
- **`Observe` keeps the old client-side rule.** It frames its key inside the body with an explicit length and is dead code pending removal, so it is passed `Cid.HasValue` to reproduce exactly what it did before.

## How it was verified

Every new assertion was checked by breaking the code and confirming the test fails — not by the test passing.

| Deliberate break | Result |
| --- | --- |
| `PrepareAsync` stops stamping `Cid` | 22 failures, *"dispatched Delete for key 'thekey' with Cid null"* |
| `PrepareAsync` stops resolving | 22 failures, *"never fetched a collection ID"* |
| one entry dropped from the coverage table | *"Add to the collection ID coverage table: DecrementAsync"* |
| resolve removed from `ScanAsync` | exactly 1 failure, `ScanAsync` |
| `WriteKey` reverted to `Cid.HasValue` | both framing-polarity tests fail |
| `SaslStep`'s opt-out removed | exemption-set test fails |
| key-length check removed | max-length-key test fails |
| default-collection fallback removed | memcached test fails |
| HELO status check reverted | HELO test fails |
| error-map null guard removed | HELO test fails with the original NRE |
| boundary throw removed | named-collection test fails |
| default-collection shortcut removed | no-lookup test fails |
| cluster flags reverted to last-write-wins | 2 of its 5 tests fail |
| transactions proxy restored | 2 of its 4 tests fail |
| `GetCidLazyNoRetry` reverted to retrying | no-retry test fails |
| empty-body CID check removed | empty-body test fails |

Two of those tests initially passed while testing nothing: the cluster-feature tests agreed with last-write-wins until the node ordering was flipped so the permissive node is added last. Caught by the mutation, not by review.

**The exemption list in item 6 is pinned by a reflection test** over every `OperationBase` subclass rather than maintained by hand, because drafting it by hand had already produced a bug — `SaslStart` and `SaslList` were exempt but `SaslStep` was not, and since HELO completes before authentication that would have thrown on every non-TLS connection. Only the opt-outs are pinned: `true` is safe, so a new document operation needs no test change; `false` is the answer that can corrupt data.

Not verifiable locally: **net48**, which is Windows-only in `SdkTestTargets` and has no macOS reference assemblies. CI's Windows leg is the check.

## Test fixtures corrected rather than code

- `CouchbaseCollectionTests` and `CouchbaseCollectionZoneAwareTests` built collections with `Mock.Of<IScope>()`, which reports `IsDefaultScope` as false — so every fake collection looked like a *named* collection on a bucket without collections, and item 9's throw fired. They now describe the default scope, which is what they always meant.
- Tests that build packets against a mocked `IConnection` now supply `ServerFeatureSet.Empty`, since the framing path reads it where the old code short-circuited past it. Collections off means their expected bytes are unchanged.

## Deliberately not covered

- **`PartitionScan` stays outside the funnel** (item 17). Its `RangeScanCancel` writes no key, so routing it through `PrepareAsync` would change that frame.
- **`MutateIn`'s `OptionalFlags` still reads cluster-scoped `SubdocBinaryXattr`** rather than the connection's. That is the one remaining place where a *frame* is decided from cluster state, and it needs the same plumbing `WriteKey` just got.
- **The dead `Observe` operation** is left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
