### PR TITLE
NCBC-4287: Derive cluster feature support from every node

### DIFF
--- a/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
+++ b/src/Couchbase/Client/Transactions/Cleanup/Cleaner.cs
@@ -153,7 +153,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                                 opts => opts.Cas(op.Cas)
                                     .Durability(cleanupRequest.GetDurabilityLevel())
                                     .AccessDeleted(true)
-                                    .PreserveTtl(collection.Scope.Bucket.SupportsCollections)
+                                    .PreserveTtl(collection.SupportsPreserveTtl())
                                     .Timeout(_keyValueTimeout)).CAF();
                         }
                         else
@@ -177,7 +177,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                                 specs.Remove(TransactionFields.TransactionInterfacePrefixOnly, isXattr: true),
                             opts => opts.Cas(op.Cas)
                                 .AccessDeleted(true)
-                                .PreserveTtl(collection.Scope.Bucket.SupportsCollections)
+                                .PreserveTtl(collection.SupportsPreserveTtl())
                                 .Timeout(_keyValueTimeout)).CAF();
                     }).CAF();
             }
@@ -249,7 +249,7 @@ namespace Couchbase.Client.Transactions.Cleanup
                         .Flags(op.StagedContent!.Transcoder.GetFormat(content))
                         .Timeout(_keyValueTimeout)
                         .Cas(op.Cas)
-                        .PreserveTtl(coll.Scope.Bucket.SupportsCollections);
+                        .PreserveTtl(coll.SupportsPreserveTtl());
                     if (op.Expiry.HasValue)
                     {
                         opts.Expiry(op.Expiry.Value.RemainingTtl());

--- a/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
+++ b/src/Couchbase/Client/Transactions/DataAccess/DocumentRepository.cs
@@ -51,8 +51,8 @@ namespace Couchbase.Client.Transactions.DataAccess
                 .AccessDeleted(true)
                 .CreateAsDeleted(true);
 
-            // we always preserve TTLs - using SupportsCollections as a proxy for supporting TTLs
-            opts.PreserveTtl(collection.Scope.Bucket.SupportsCollections);
+            // we always preserve TTLs where the cluster can
+            opts.PreserveTtl(collection.SupportsPreserveTtl());
 
             // we set the flags when staging the insert (though, we do it again when we unstage)
             if (SupportsReplaceBodyWithXattr(collection))
@@ -363,7 +363,7 @@ namespace Couchbase.Client.Transactions.DataAccess
             new MutateInOptions().Defaults(_durability, _keyValueTimeout)
                 .Transcoder(Transactions.MetadataTranscoder)
                 .StoreSemantics(storeSemantics)
-                .PreserveTtl(collection.Scope.Bucket.SupportsCollections);
+                .PreserveTtl(collection.SupportsPreserveTtl());
 
         private List<MutateInSpec> CreateMutationSpecs(IAtrRepository atr, string opType, IContentAsWrapper content, string opId, DocumentMetadata? dm = null, DateTimeOffset? expiry = null)
         {

--- a/src/Couchbase/Client/Transactions/Support/CollectionExtensions.cs
+++ b/src/Couchbase/Client/Transactions/Support/CollectionExtensions.cs
@@ -1,10 +1,27 @@
 ﻿using System;
+using Couchbase.Core;
 using Couchbase.KeyValue;
 
 namespace Couchbase.Client.Transactions.Support
 {
     internal static class CollectionExtensions
     {
+        /// <summary>
+        /// Whether the cluster behind this collection can preserve expiry on a mutation.
+        /// </summary>
+        /// <remarks>
+        /// This used to be <c>Bucket.SupportsCollections</c>, with a comment calling it "a proxy for
+        /// supporting TTLs". They are unrelated capabilities: every node in a mixed-version cluster
+        /// can support collections while some node has not negotiated PreserveTtl, and
+        /// CouchbaseCollection throws FeatureNotAvailableException for exactly that combination - so
+        /// the proxy asked transactions to request something the cluster would then refuse.
+        /// Protostellar has no ClusterContext to ask, so it keeps the old proxy.
+        /// </remarks>
+        public static bool SupportsPreserveTtl(this ICouchbaseCollection collection) =>
+            collection.Scope.Bucket is BucketBase bucket
+                ? bucket.Context.SupportsPreserveTtl
+                : collection.Scope.Bucket.SupportsCollections;
+
         public static RemoveOptions Timeout(this RemoveOptions opts, TimeSpan? timeout)
         {
             if (timeout.HasValue)

--- a/src/Couchbase/Core/ClusterContext.cs
+++ b/src/Couchbase/Core/ClusterContext.cs
@@ -107,8 +107,6 @@ namespace Couchbase.Core
 
         public ICluster Cluster { get; }
 
-        public bool SupportsCollections { get; set; }
-
         public bool SupportsGlobalConfig { get; private set; }
 
         public bool SupportsPreserveTtl { get; internal set; }
@@ -310,7 +308,45 @@ namespace Couchbase.Core
                 _logger.LogDebug(
                     "Added node {endPoint} on {bucket} to {nodes}",
                     _redactor.SystemData(node.EndPoint), node.Owner?.Name, Nodes.Count);
+
+                RecomputeClusterFeatureSupport();
             }
+        }
+
+        /// <summary>
+        /// Recomputes the cluster-wide feature flags from every node currently managed.
+        /// </summary>
+        /// <remarks>
+        /// SupportsPreserveTtl and SupportsBinaryXattr describe the cluster, but they used to be
+        /// assigned from whichever single node was initialized last - eight separate sites, each
+        /// overwriting the one before, so the answer depended on ordering. A feature is only safe to
+        /// use if every node offers it, so this takes the conjunction. Nodes that have not negotiated
+        /// yet are skipped rather than counted as unsupporting, so the flags do not flap to false
+        /// while a node is still coming up.
+        ///
+        /// This stays a field rather than a computed property because it is read on every mutation.
+        /// </remarks>
+        internal void RecomputeClusterFeatureSupport()
+        {
+            var seenAnyNode = false;
+            var preserveTtl = true;
+            var binaryXattr = true;
+
+            foreach (var node in Nodes)
+            {
+                var features = node.ServerFeatures;
+                if (features is null)
+                {
+                    continue;
+                }
+
+                seenAnyNode = true;
+                preserveTtl &= features.PreserveTtl;
+                binaryXattr &= features.SubdocBinaryXattr;
+            }
+
+            SupportsPreserveTtl = seenAnyNode && preserveTtl;
+            SupportsBinaryXattr = seenAnyNode && binaryXattr;
         }
 
         public bool RemoveNode(IClusterNode removedNode)
@@ -322,6 +358,9 @@ namespace Couchbase.Core
                 _logger.LogDebug(
                     "Removed node {endPoint} from {nodes}", _redactor.SystemData(removedNode.EndPoint), Nodes);
                 removedNode.Dispose();
+
+                //A node leaving can restore a feature the whole cluster now offers.
+                RecomputeClusterFeatureSupport();
                 return true;
             }
             return false;
@@ -493,8 +532,6 @@ namespace Couchbase.Core
                                 node.NodesAdapter = nodeAdapter;
                                 if (node.ServerFeatures != null)
                                 {
-                                    SupportsPreserveTtl = node.ServerFeatures.PreserveTtl;
-                                    SupportsBinaryXattr = node.ServerFeatures.SubdocBinaryXattr;
                                 }
 
                                 AddNode(node);
@@ -511,8 +548,6 @@ namespace Couchbase.Core
 
                                 if (newNode.ServerFeatures != null)
                                 {
-                                    SupportsPreserveTtl = newNode.ServerFeatures.PreserveTtl;
-                                    SupportsBinaryXattr = newNode.ServerFeatures.SubdocBinaryXattr;
                                 }
 
                                 AddNode(newNode);
@@ -825,8 +860,6 @@ namespace Couchbase.Core
                             {
                                 clusterNode.Owner = bucket;
                                 await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                                SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                             }
 
                             continue;
@@ -840,8 +873,6 @@ namespace Couchbase.Core
                             {
                                 clusterNode.Owner = bucket;
                                 await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                                SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                             }
                         }
 
@@ -866,8 +897,6 @@ namespace Couchbase.Core
                         {
                             clusterNode.Owner = bucket;
                             await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                            SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                            SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                         }
                     }
                     else
@@ -885,8 +914,6 @@ namespace Couchbase.Core
                         {
                             clusterNode.Owner = bucket;
                             await clusterNode.SelectBucketAsync(bucket.Name, CancellationToken).ConfigureAwait(false);
-                            SupportsPreserveTtl = clusterNode.ServerFeatures.PreserveTtl;
-                            SupportsBinaryXattr = clusterNode.ServerFeatures.SubdocBinaryXattr;
                         }
 
                         AddNode(clusterNode);
@@ -989,10 +1016,6 @@ namespace Couchbase.Core
 
                             if (newNode.ServerFeatures != null)
                             {
-                                SupportsPreserveTtl =
-                                    newNode.ServerFeatures.PreserveTtl;
-                                SupportsBinaryXattr = newNode.ServerFeatures
-                                    .SubdocBinaryXattr;
                             }
 
                             AddNode(newNode);

--- a/src/Couchbase/Core/ClusterContext.cs
+++ b/src/Couchbase/Core/ClusterContext.cs
@@ -372,6 +372,9 @@ namespace Couchbase.Core
             {
                 removedNode.Dispose();
             }
+
+            //The bulk paths clear the list directly, so they must recompute too.
+            RecomputeClusterFeatureSupport();
         }
 
         public void RemoveAllNodes(IBucket bucket)
@@ -380,6 +383,9 @@ namespace Couchbase.Core
             {
                 removedNode.Dispose();
             }
+
+            //Nodes owned by other buckets may remain, so recompute from what is left.
+            RecomputeClusterFeatureSupport();
         }
 
         public IClusterNode GetUnassignedNode(HostEndpointWithPort endpoint)

--- a/src/Couchbase/Core/ClusterNode.cs
+++ b/src/Couchbase/Core/ClusterNode.cs
@@ -857,6 +857,11 @@ namespace Couchbase.Core
                         : ServerFeatureSet.Empty;
                     ServerFeatures = connection.ServerFeatures;
 
+                    //Cluster-wide feature support is the conjunction over every node, so it has to
+                    //be recomputed when a node finishes negotiating - a node may well have been
+                    //added before its features were known.
+                    _context.RecomputeClusterFeatureSupport();
+
                     #if DEBUG
                     _logger.LogDebug("{Features}", ServerFeatures.ToString());
                     #endif

--- a/src/Couchbase/Core/ClusterNodeList.cs
+++ b/src/Couchbase/Core/ClusterNodeList.cs
@@ -72,9 +72,14 @@ internal class ClusterNodeList : IEnumerable<IClusterNode>
         }
     }
 
+    /// <summary>
+    /// Removes all nodes owned by a bucket from the collection.
+    /// </summary>
+    /// <param name="bucket">Owner whose nodes should be removed.</param>
+    /// <returns>List of nodes that were removed.</returns>
     public IList<IClusterNode> Clear(IBucket bucket)
     {
-        lock (_nodes)
+        lock (_syncObj)
         {
             var removed = new List<IClusterNode>(_nodes.Where(x=>x.Owner == bucket));
 

--- a/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
+++ b/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
@@ -136,6 +136,108 @@ namespace Couchbase.UnitTests.Core
             Assert.InRange(chosenNodes.Count, 2, 3);
         }
 
+        #region Cluster-wide feature support
+
+        /// <summary>
+        /// SupportsPreserveTtl and SupportsBinaryXattr describe the cluster, but they used to be
+        /// assigned from whichever node initialized last, at eight separate sites each overwriting
+        /// the one before - so in a mixed-version cluster the answer depended on ordering. A feature
+        /// is only safe to use if every node offers it.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Requires_Every_Node()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            //The restrictive node is added first and the permissive one last, deliberately: under
+            //the old last-write-wins rule the permissive node would win and this would read true.
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl));
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+
+            Assert.True(context.SupportsPreserveTtl);
+            Assert.False(context.SupportsBinaryXattr);
+        }
+
+        [Fact]
+        public void Cluster_Feature_Support_When_Every_Node_Agrees()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl, ServerFeatures.SubdocBinaryXattr));
+
+            Assert.True(context.SupportsPreserveTtl);
+            Assert.True(context.SupportsBinaryXattr);
+        }
+
+        /// <summary>
+        /// Nothing is known before a node has negotiated, so nothing is claimed.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_With_No_Nodes()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            Assert.False(context.SupportsPreserveTtl);
+            Assert.False(context.SupportsBinaryXattr);
+        }
+
+        /// <summary>
+        /// A node that has been added but has not negotiated yet is skipped rather than counted as
+        /// unsupporting, so the flags do not flap to false while a node is coming up.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Ignores_Nodes_That_Have_Not_Negotiated()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl));
+            context.AddNode(Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == null &&
+                node.EndPoint == new HostEndpointWithPort("host2", 11210)));
+
+            Assert.True(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
+        /// And a lagging node leaving restores what the remaining cluster offers.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Recovers_When_A_Lagging_Node_Leaves()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            //Lagging node first, so the permissive node is the one last-write-wins would have
+            //picked - the assertion below only means something with it in this order.
+            var lagging = Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == new ServerFeatureSet(Array.Empty<ServerFeatures>()) &&
+                node.EndPoint == new HostEndpointWithPort("host1", 11210));
+            context.AddNode(lagging);
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl));
+
+            Assert.False(context.SupportsPreserveTtl);
+
+            context.RemoveNode(lagging);
+
+            Assert.True(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
+        /// Endpoints must differ: ClusterNodeList.Remove matches on EndPoint and BucketName, so nodes
+        /// sharing a default endpoint are indistinguishable and removing one removes both.
+        /// </summary>
+        private static IClusterNode NodeSupporting(string host, params ServerFeatures[] features) =>
+            Mock.Of<IClusterNode>(node =>
+                node.ServerFeatures == new ServerFeatureSet(features) &&
+                node.EndPoint == new HostEndpointWithPort(host, 11210));
+
+        #endregion
+
         private IClusterNode CreateMockedNode(string hostname, int port, NodeAdapter nodeAdapter = null)
         {
             var mockConnectionPool = new Mock<IConnectionPool>();

--- a/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
+++ b/tests/Couchbase.UnitTests/Core/ClusterContextTests.cs
@@ -228,6 +228,50 @@ namespace Couchbase.UnitTests.Core
         }
 
         /// <summary>
+        /// Cluster teardown clears the node list in bulk rather than removing nodes one at a time, so
+        /// it has to recompute as well - otherwise the flags keep describing a cluster that is gone.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Is_Cleared_When_All_Nodes_Are_Removed()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            context.AddNode(NodeSupporting("host1", ServerFeatures.PreserveTtl));
+            Assert.True(context.SupportsPreserveTtl);
+
+            context.RemoveAllNodes();
+
+            Assert.False(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
+        /// Disposing one bucket leaves the other buckets' nodes in place, so the flags must be
+        /// recomputed from what remains rather than simply cleared.
+        /// </summary>
+        [Fact]
+        public void Cluster_Feature_Support_Recomputes_When_One_Bucket_Is_Removed()
+        {
+            using var context = new ClusterContext(null,
+                new ClusterOptions().WithPasswordAuthentication("username", "password"));
+
+            var disposedBucket = Mock.Of<IBucket>(bucket => bucket.Name == "restrictive");
+
+            //The restrictive node belongs to the bucket going away, so its departure should restore
+            //the feature the remaining node offers.
+            var restrictive = NodeSupporting("host1");
+            restrictive.Owner = disposedBucket;
+            context.AddNode(restrictive);
+            context.AddNode(NodeSupporting("host2", ServerFeatures.PreserveTtl));
+
+            Assert.False(context.SupportsPreserveTtl);
+
+            context.RemoveAllNodes(disposedBucket);
+
+            Assert.True(context.SupportsPreserveTtl);
+        }
+
+        /// <summary>
         /// Endpoints must differ: ClusterNodeList.Remove matches on EndPoint and BucketName, so nodes
         /// sharing a default endpoint are indistinguishable and removing one removes both.
         /// </summary>

--- a/tests/Couchbase.UnitTests/Core/Configuration/Server/BucketConfigExtensionTests.cs
+++ b/tests/Couchbase.UnitTests/Core/Configuration/Server/BucketConfigExtensionTests.cs
@@ -633,10 +633,7 @@ public class BucketConfigExtensionTests
             Returns(Task.FromResult(node.Object));
 
         var options = new ClusterOptions().AddClusterService(clusterNodeFactory.Object).WithPasswordAuthentication("username", "password");
-        var clusterCtx = new ClusterContext(new CancellationTokenSource(), options)
-        {
-            SupportsCollections = true
-        };
+        var clusterCtx = new ClusterContext(new CancellationTokenSource(), options);
 
         var bucket = new CouchbaseBucket("default",
             clusterCtx,

--- a/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
+++ b/tests/Couchbase.UnitTests/CouchbaseBucketTests.cs
@@ -22,10 +22,7 @@ namespace Couchbase.UnitTests
         public async Task Scope_DoesNotThrow_ScopeNoteFoundException()
         {
             var bucket = new CouchbaseBucket("default",
-                new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password"))
-                {
-                    SupportsCollections = true
-                },
+                new ClusterContext(null, new ClusterOptions().WithPasswordAuthentication("username", "password")),
                 new Mock<IScopeFactory>().Object,
                 new Mock<IRetryOrchestrator>().Object,
                 new Mock<IVBucketKeyMapperFactory>().Object,

--- a/tests/Couchbase.UnitTests/Transactions/PreserveTtlCapabilityTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/PreserveTtlCapabilityTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading.Tasks;
+using Couchbase.Client.Transactions.Support;
+using Couchbase.Core;
+using Couchbase.Core.Bootstrapping;
+using Couchbase.Core.Configuration.Server;
+using Couchbase.Core.DI;
+using Couchbase.Core.Diagnostics.Tracing;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.Logging;
+using Couchbase.Core.Retry;
+using Couchbase.KeyValue;
+using Couchbase.Management.Collections;
+using Couchbase.Management.Views;
+using Couchbase.Views;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.Transactions
+{
+    /// <summary>
+    /// The transactions layer used to pass <c>Bucket.SupportsCollections</c> as the PreserveTtl flag,
+    /// with a comment calling it "a proxy for supporting TTLs". They are unrelated capabilities read
+    /// from unrelated places - collections support is a bucket capability from the cluster map, while
+    /// preserving expiry is a feature each connection negotiates in HELO - so whenever the two
+    /// diverge, transactions either ask for something the cluster will refuse or silently skip
+    /// preserving expiry on a server that supports it.
+    /// </summary>
+    public class PreserveTtlCapabilityTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Capability_Comes_From_The_Cluster_Not_From_Collections(bool clusterSupportsPreserveTtl)
+        {
+            var bucket = FakeBucket(supportsPreserveTtl: clusterSupportsPreserveTtl);
+            var collection = CollectionOn(bucket);
+
+            Assert.Equal(clusterSupportsPreserveTtl, collection.SupportsPreserveTtl());
+        }
+
+        /// <summary>
+        /// The mixed-version case the old proxy got wrong: the bucket supports collections while the
+        /// cluster cannot preserve expiry.
+        /// </summary>
+        [Fact]
+        public void Collections_Support_Does_Not_Imply_PreserveTtl()
+        {
+            var bucket = FakeBucket(supportsPreserveTtl: false);
+            var collection = CollectionOn(bucket);
+
+            Assert.True(bucket.SupportsCollections);
+            Assert.False(collection.SupportsPreserveTtl());
+        }
+
+        /// <summary>
+        /// Protostellar buckets are not a <see cref="BucketBase"/> and have no cluster context to ask,
+        /// so they keep the old proxy rather than silently losing TTL preservation.
+        /// </summary>
+        [Fact]
+        public void A_bucket_without_a_cluster_context_falls_back_to_collections_support()
+        {
+            var bucket = Mock.Of<IBucket>(b => b.SupportsCollections == true);
+            var collection = CollectionOn(bucket);
+
+            Assert.True(collection.SupportsPreserveTtl());
+        }
+
+        private static ICouchbaseCollection CollectionOn(IBucket bucket) =>
+            Mock.Of<ICouchbaseCollection>(collection =>
+                collection.Scope == Mock.Of<IScope>(scope => scope.Bucket == bucket));
+
+        private static CapabilityFakeBucket FakeBucket(bool supportsPreserveTtl)
+        {
+            var bucket = new CapabilityFakeBucket();
+            bucket.Context.SupportsPreserveTtl = supportsPreserveTtl;
+            return bucket;
+        }
+
+        /// <summary>
+        /// The smallest <see cref="BucketBase"/> that can carry a cluster context. It serves no
+        /// operations; the capability lookup under test never sends one.
+        /// </summary>
+        internal class CapabilityFakeBucket : BucketBase
+        {
+            public CapabilityFakeBucket()
+                : base("default",
+                    new ClusterContext(null,
+                        new ClusterOptions().WithPasswordAuthentication("username", "password")),
+                    new Mock<IScopeFactory>().Object,
+                    new Mock<IRetryOrchestrator>().Object,
+                    new Mock<ILogger>().Object,
+                    new TypedRedactor(RedactionLevel.None),
+                    new Mock<IBootstrapperFactory>().Object,
+                    NoopRequestTracer.Instance,
+                    new Mock<IOperationConfigurator>().Object,
+                    new BestEffortRetryStrategy(), null)
+            {
+                CurrentConfig = new BucketConfig
+                {
+                    Name = "default",
+                    BucketCapabilities = [BucketCapabilities.COLLECTIONS]
+                };
+            }
+
+            internal override Task<ResponseStatus> SendAsync(IOperation op, CancellationTokenPair token = default) =>
+                throw new NotImplementedException();
+
+            public override ICouchbaseCollectionManager Collections => throw new NotImplementedException();
+
+#pragma warning disable CS0618, CS0672 // Obsolete View service members
+            public override IViewIndexManager ViewIndexes => throw new NotImplementedException();
+
+            public override Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument,
+                string viewName, ViewOptions options = null) => throw new NotImplementedException();
+#pragma warning restore CS0618, CS0672
+
+            public override Task ForceConfigUpdateAsync() => throw new NotImplementedException();
+
+            public override IScope Scope(string scopeName) => throw new NotImplementedException();
+
+            internal override Task BootstrapAsync(IClusterNode bootstrapNodes) => throw new NotImplementedException();
+
+            public override Task ConfigUpdatedAsync(BucketConfig newConfig) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Part 1 of 4, splitting #167. **Independent — no dependency on the others.**

**Review order: 4 of 4** — #169 → #170 → #171, then **#168**. Listed last because the other three build one argument and this is a separate thread; it is readable at any point and mergeable immediately. If a second reviewer is free, it can be taken wholly in parallel.
**Read first**: nothing — it shares no logic with the others. Same *category* of bug (a cluster-scoped field holding a per-node fact), different code.
**Merging**: no dependencies in either direction.

## Summary

`SupportsPreserveTtl` and `SupportsBinaryXattr` on `ClusterContext` describe the cluster, but they were assigned from whichever node initialised last — seven separate sites, each overwriting the one before. A cluster-scoped field was holding a per-node fact, so in a mixed-version cluster the answer depended on ordering and could change as nodes came and went.

The transactions layer compounded it: `DocumentRepository` passed `Bucket.SupportsCollections` as the `PreserveTtl` flag, with a comment calling it *"a proxy for supporting TTLs"*. Two unrelated capabilities read from unrelated places — collections support is a bucket capability from the cluster map, preserving expiry is negotiated per connection in HELO. They coincided because both arrived in 7.0.

## The problems

1. **Cluster-wide flags computed from one node.** Seven assignment sites, last one wins.
2. **Transactions used the wrong capability.** Whenever the two diverge, transactions either ask for something the cluster refuses, or silently skip preserving expiry on a server that supports it.
3. **`ClusterContext.SupportsCollections` was dead** — a public settable property nothing assigned and nothing read, permanently false while reading as authoritative. Two tests were setting it in object initialisers.

## What to look at

`ClusterContext.RecomputeClusterFeatureSupport` is the substance. It runs where the answer can change — `AddNode`, `RemoveNode`, and when a node finishes negotiating, since a node is often added before its features are known. Nodes that haven't negotiated are **skipped rather than counted as unsupporting**, so the flags don't flap to false while a node is coming up.

They stay fields rather than computed properties because they're read on every mutation.

## Behaviour change worth accepting consciously

In a mixed-version cluster where some nodes lack `PreserveTtl`, callers who previously got it by luck of initialisation order now get `FeatureNotAvailableException`. That's the point — the alternative is sending the flag to a node that doesn't implement it.

Protostellar keeps the old proxy: `StellarBucket` isn't a `BucketBase` and has no cluster context to ask, and returning false there would silently stop preserving TTLs on that path.

## Verification

9 new tests, 2940 pass on net8.0 and net10.0.

Checked by mutation rather than by passing: reverting the conjunction to last-write-wins fails 2 of the 5 cluster-feature tests, and restoring the transactions proxy fails 2 of its 4. Those first two only bite because the tests add the restrictive node **first** and the permissive node last — written the other way round both rules give the same answer and the tests pass against either, which is how the first version of them was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
