### PR TITLE
NCBC-4287: Funnel KV operations through PrepareAsync NCBC-4285: Resolve the collection ID in GetPrimary

### DIFF
--- a/src/Couchbase/KeyValue/CouchbaseCollection.cs
+++ b/src/Couchbase/KeyValue/CouchbaseCollection.cs
@@ -32,6 +32,12 @@ namespace Couchbase.KeyValue
     internal sealed class CouchbaseCollection : ICouchbaseCollection, IBinaryCollection, IInternalCollection
     {
         public const string DefaultCollectionName = "_default";
+
+        /// <summary>
+        /// The collection ID of the default collection. Also the correct ID for a bucket that does
+        /// not support collections at all, when the connection has negotiated collections.
+        /// </summary>
+        internal const uint DefaultCollectionId = 0;
         private const string NoPreferredServerGroupMessage = "No preferred Server group was set in the ClusterOptions.";
         private readonly string? _preferredServerGroup;
         private readonly bool _rangeScanSupported;
@@ -118,14 +124,11 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ScanOptions.Default;
+
+            //PartitionScan builds its own operations and reads Cid directly, so it cannot go
+            //through PrepareAsync: resolve the collection ID before handing it this collection.
+            await EnsureCollectionIdAsync().ConfigureAwait(false);
 
             var mutationTokens = options.ConsistencyTokens;
 
@@ -203,13 +206,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetOptions.Default;
 
             // TODO: Since we're actually using LookupIn for Get requests, which operation name should we use?
@@ -226,16 +222,10 @@ namespace Couchbase.KeyValue
                 using var getOp = new Get<byte[]>
                 {
                     Key = id,
-                    Cid = Cid,
-                    BucketName = _bucket.Name,
-                    CName = Name,
-                    SName = ScopeName,
                     Span = rootSpan,
                     PreferReturns = options.PreferReturn
                 };
-                _operationConfigurator.Configure(getOp, options);
-
-                using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getOp);
+                using var ctp = await PrepareAsync(getOp, options).ConfigureAwait(false);
                 var status = await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
 
                 var result = new GetResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider, status)
@@ -308,28 +298,15 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ExistsOptions.Default;
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetMetaExists, options.RequestSpanValue);
             using var getMetaOp = new GetMeta
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(getMetaOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getMetaOp);
+            using var ctp = await PrepareAsync(getMetaOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(getMetaOp, ctp.TokenPair).ConfigureAwait(false);
             var result = getMetaOp.GetValue();
 
@@ -352,29 +329,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= InsertOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.AddInsert, options.RequestSpanValue);
             using var insertOp = new Add<T>(_bucket.Name, id)
             {
                 Content = content,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                SName = ScopeName,
-                CName = Name,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(insertOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, insertOp);
+            using var ctp = await PrepareAsync(insertOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(insertOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(insertOp.Cas, null, insertOp.MutationToken);
         }
@@ -391,13 +355,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= ReplaceOptions.Default;
 
             //Reality check for preserveTtl server support
@@ -412,18 +369,12 @@ namespace Couchbase.KeyValue
             {
                 Content = content,
                 Cas = options.CasValue,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
-            _operationConfigurator.Configure(replaceOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, replaceOp);
+            using var ctp = await PrepareAsync(replaceOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(replaceOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(replaceOp.Cas, null, replaceOp.MutationToken, status);
         }
@@ -438,31 +389,18 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= RemoveOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.DeleteRemove, options.RequestSpanValue);
             using var removeOp = new Delete
             {
                 Key = id,
                 Cas = options.CasValue,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 DurabilityLevel = options.DurabilityLevel,
                 DurabilityTimeout = TimeSpan.FromMilliseconds(1500),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(removeOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, removeOp);
+            using var ctp = await PrepareAsync(removeOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(removeOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
         }
@@ -478,29 +416,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UnlockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Unlock, options.RequestSpanValue);
             using var unlockOp = new Unlock
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Cas = cas,
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(unlockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, unlockOp);
+            using var ctp = await PrepareAsync(unlockOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(unlockOp, ctp.TokenPair).ConfigureAwait(false);
         }
 
@@ -510,29 +435,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UnlockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Unlock);
             using var unlockOp = new Unlock
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Cas = cas,
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(unlockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, unlockOp);
+            using var ctp = await PrepareAsync(unlockOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(unlockOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
         }
@@ -553,30 +465,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= TouchOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Touch, options.RequestSpanValue);
             using var touchOp = new Touch
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                SName = ScopeName,
-                CName = Name,
                 Expires = expiry.ToTtl(),
                 DurabilityTimeout = TimeSpan.FromMilliseconds(1500),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn,
             };
-            _operationConfigurator.Configure(touchOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, touchOp);
+            using var ctp = await PrepareAsync(touchOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(touchOp, ctp.TokenPair).ConfigureAwait(false);
             options.Status = status;
             return status == ResponseStatus.Success
@@ -594,27 +493,14 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetAndTouchOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAndTouch, options.RequestSpanValue);
             using var getAndTouchOp = new GetT<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expires = expiry.ToTtl(),
                 Span = rootSpan
             };
-            _operationConfigurator.Configure(getAndTouchOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getAndTouchOp);
+            using var ctp = await PrepareAsync(getAndTouchOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(getAndTouchOp, ctp.TokenPair).ConfigureAwait(false);
 
             return new  GetResult(getAndTouchOp.ExtractBody(), getAndTouchOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
@@ -637,29 +523,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= GetAndLockOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.GetAndLock, options.RequestSpanValue);
             using var getAndLockOp = new GetL<byte[]>
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Expiry = lockTime.ToTtl(),
                 Span = rootSpan,
                 PreferReturns = options.PreferReturn
             };
-            _operationConfigurator.Configure(getAndLockOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getAndLockOp);
+            using var ctp = await PrepareAsync(getAndLockOp, options).ConfigureAwait(false);
             var status = await _bucket.RetryAsync(getAndLockOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetResult(getAndLockOp.ExtractBody(), getAndLockOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider, status)
             {
@@ -683,13 +556,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= UpsertOptions.Default;
 
             //Reality check for preserveTtl server support
@@ -703,19 +569,13 @@ namespace Couchbase.KeyValue
             using var upsertOp = new Set<T>(_bucket.Name, id)
             {
                 Content = content,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
-                Cid = Cid,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
 
-            _operationConfigurator.Configure(upsertOp, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, upsertOp);
+            using var ctp = await PrepareAsync(upsertOp, options).ConfigureAwait(false);
             await _bucket.RetryAsync(upsertOp, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(upsertOp.Cas, null, upsertOp.MutationToken);
         }
@@ -732,13 +592,6 @@ namespace Couchbase.KeyValue
             _bucket.ThrowIfBootStrapFailed();
             if (specs.Count() > 16) throw new InvalidArgumentException("Too many specs in Lookup operation (Limited to 16)");
             var opts = options?.AsReadOnly() ?? LookupInOptions.DefaultReadOnly;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupIn, opts.RequestSpan);
             using var lookup = await ExecuteLookupIn(id, specs, opts, rootSpan).ConfigureAwait(false);
@@ -758,13 +611,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
             var opts = options?.AsReadOnly() ?? LookupInAnyReplicaOptions.DefaultReadOnly;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAnyReplica, opts.RequestSpan);
             var vBucket = VBucketForReplicas(id);
@@ -817,13 +663,6 @@ namespace Couchbase.KeyValue
             // A top-level failure of the lookup (here, too many specs) must produce an empty stream
             // rather than throwing - unlike LookupIn/LookupInAnyReplica.
             if (specs.Count() > 16) yield break;
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.LookupInAllReplicas, opts.RequestSpan);
             var enumeratedSpecs = specs.ToList();
@@ -888,9 +727,6 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Get the collection ID
-            await PopulateCidAsync().ConfigureAwait(false);
-
             //add the virtual xattr attribute to get the doc expiration time
             if (options.Expiry)
             {
@@ -924,19 +760,13 @@ namespace Couchbase.KeyValue
 
             var lookup = new MultiLookup<byte[]>(id, specs, options.ReplicaIndex)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 DocFlags = docFlags,
                 Span = span,
                 PreferReturns = options.PreferReturn,
             };
             try
             {
-                _operationConfigurator.Configure(lookup, options);
-
-                using var ctp = CreateRetryTimeoutCancellationTokenSource(options, lookup);
+                using var ctp = await PrepareAsync(lookup, options).ConfigureAwait(false);
                 var status = await _bucket.RetryAsync(lookup, ctp.TokenPair).ConfigureAwait(false);
                 return lookup;
             }
@@ -958,13 +788,6 @@ namespace Couchbase.KeyValue
         {
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             options ??= MutateInOptions.Default;
 
@@ -1023,11 +846,7 @@ namespace Couchbase.KeyValue
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.MutateIn, options.RequestSpanValue);
             using var mutation = new MultiMutation<byte[]>(id, specs)
             {
-                BucketName = _bucket.Name,
                 Cas = options.CasValue,
-                Cid = Cid,
-                CName = Name,
-                SName = ScopeName,
                 Expires = options.ExpiryValue.ToTtl(),
                 DurabilityLevel = options.DurabilityLevel,
                 DocFlags = docFlags,
@@ -1035,9 +854,7 @@ namespace Couchbase.KeyValue
                 Span = rootSpan,
                 PreserveTtl = options.PreserveTtlValue
             };
-            _operationConfigurator.Configure(mutation, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, mutation);
+            using var ctp = await PrepareAsync(mutation, options).ConfigureAwait(false);
             await _bucket.RetryAsync(mutation, ctp.TokenPair).ConfigureAwait(false);
 
 #pragma warning disable 618 // MutateInResult is marked obsolete until it is made internal
@@ -1071,29 +888,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= AppendOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Append, options.RequestSpanValue);
             using var op = new Append<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Content = value,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Cas = options.CasValue
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(op.Cas, null, op.MutationToken);
         }
@@ -1108,29 +912,16 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= PrependOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Prepend, options.RequestSpanValue);
             using var op = new Prepend<byte[]>(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Content = value,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Cas = options.CasValue
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new MutationResult(op.Cas, null, op.MutationToken);
         }
@@ -1145,30 +936,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= IncrementOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Increment, options.RequestSpanValue);
             using var op = new Increment(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Delta = options.DeltaValue,
                 Initial = options.InitialValue,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Expires = options.ExpiryValue.ToTtl()
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new CounterResult(op.GetValue(), op.Cas, null, op.MutationToken);
         }
@@ -1183,30 +961,17 @@ namespace Couchbase.KeyValue
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
 
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             options ??= DecrementOptions.Default;
             using var rootSpan = RootSpan(OuterRequestSpans.ServiceSpan.Kv.Decrement, options.RequestSpanValue);
             using var op = new Decrement(_bucket.Name, id)
             {
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Delta = options.DeltaValue,
                 Initial = options.InitialValue,
                 DurabilityLevel = options.DurabilityLevel,
                 Span = rootSpan,
                 Expires = options.ExpiryValue.ToTtl()
             };
-            _operationConfigurator.Configure(op, options);
-
-            using var ctp = CreateRetryTimeoutCancellationTokenSource(options, op);
+            using var ctp = await PrepareAsync(op, options).ConfigureAwait(false);
             await _bucket.RetryAsync(op, ctp.TokenPair).ConfigureAwait(false);
             return new CounterResult(op.GetValue(), op.Cas, null, op.MutationToken);
         }
@@ -1220,13 +985,6 @@ namespace Couchbase.KeyValue
         {
             //sanity check for deferred bootstrapping errors
             _bucket.ThrowIfBootStrapFailed();
-
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
 
             options ??= GetAnyReplicaOptions.Default;
 
@@ -1385,16 +1143,10 @@ namespace Couchbase.KeyValue
             using var getOp = new Get<object>
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = childSpan
             };
-            _operationConfigurator.Configure(getOp, options);
-
             using var ctp =
-                CreateRetryTimeoutCancellationTokenSource((ITimeoutOptions) options, getOp);
+                await PrepareAsync(getOp, (ITimeoutOptions) options).ConfigureAwait(false);
             await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetReplicaResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
             {
@@ -1410,27 +1162,14 @@ namespace Couchbase.KeyValue
         private async Task<IGetReplicaResult> GetReplica(string id, short index, IRequestSpan span,
             CancellationToken cancellationToken, ITranscoderOverrideOptions options)
         {
-            //Check to see if the CID is needed
-            if (RequiresCid())
-            {
-                //Get the collection ID
-                await PopulateCidAsync().ConfigureAwait(false);
-            }
-
             using var childSpan = _tracer.RequestSpan(OuterRequestSpans.ServiceSpan.Kv.ReplicaRead, span);
             using var getOp = new ReplicaRead<object>(id, index)
             {
                 Key = id,
-                Cid = Cid,
-                BucketName = _bucket.Name,
-                CName = Name,
-                SName = ScopeName,
                 Span = childSpan
             };
-            _operationConfigurator.Configure(getOp, options);
-
             using var ctp =
-                CreateRetryTimeoutCancellationTokenSource((ITimeoutOptions) options, getOp);
+                await PrepareAsync(getOp, (ITimeoutOptions) options).ConfigureAwait(false);
             await _bucket.RetryAsync(getOp, ctp.TokenPair).ConfigureAwait(false);
             return new GetReplicaResult(getOp.ExtractBody(), getOp.Transcoder, _getLogger, _fallbackTypeSerializerProvider)
             {
@@ -1442,6 +1181,91 @@ namespace Couchbase.KeyValue
                 IsActive = false
             };
         }
+
+        #endregion
+
+        #region Operation Preparation
+
+        /// <summary>
+        /// Prepares a key/value operation for dispatch: resolves the collection ID if this bucket
+        /// supports collections, stamps the operation with this collection's identity, applies the
+        /// configured services, and rents the retry/timeout token source needed to send it.
+        /// </summary>
+        /// <param name="op">The operation to prepare.</param>
+        /// <param name="options">Options for the operation.</param>
+        /// <returns>
+        /// The rented token source, which the caller owns and must dispose. The caller needs its
+        /// <c>TokenPair</c> in order to dispatch, which is what stops this method from being
+        /// skipped when a new operation is added: see NCBC-4285, where <c>GetPrimary</c> was a
+        /// near-identical copy of <c>GetReplica</c> that never resolved its collection ID.
+        /// </returns>
+        private async Task<CancellationTokenPairSourceWrapper> PrepareAsync(OperationBase op,
+            ITimeoutOptions options)
+        {
+            await EnsureCollectionIdAsync().ConfigureAwait(false);
+
+            op.BucketName = _bucket.Name;
+            op.SName = ScopeName;
+            op.CName = Name;
+            op.Cid = Cid;
+
+            _operationConfigurator.Configure(op, options);
+
+            return CreateRetryTimeoutCancellationTokenSource(options, op);
+        }
+
+        /// <summary>
+        /// Resolves the collection ID, if this bucket supports collections and it is not already
+        /// cached.
+        /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="PrepareAsync"/>, which does this as well and cannot be skipped. This is
+        /// separate only for the range scan path: <see cref="PartitionScan"/> builds its own
+        /// operations and reads <see cref="Cid"/> directly, so the ID has to be resolved before it
+        /// is handed this collection.
+        /// </remarks>
+        private async ValueTask EnsureCollectionIdAsync()
+        {
+            if (!_bucket.SupportsCollections)
+            {
+                if (!IsDefaultCollection)
+                {
+                    //Asking for a named collection on a cluster that has none cannot be satisfied.
+                    //Say so at the boundary rather than sending an operation whose collection the
+                    //server has no way to resolve, which used to surface as CollectionNotFound after
+                    //the full KvTimeout. Matches the JVM's
+                    //BaseKeyValueRequest.encodedExternalKeyWithCollection.
+                    throw new FeatureNotAvailableException(
+                        "Collections are not supported by this cluster or bucket, so the collection " +
+                        $"'{ScopeName}.{Name}' cannot be used.");
+                }
+
+                //Only the default collection exists here - a memcached bucket, or a pre-7.0 server.
+                //The connection may still have negotiated collections in HELO, in which case the
+                //server reads a leb128 collection ID from the start of every key, and the correct
+                //value is 0. Leaving it null is why every KV operation against a memcached bucket
+                //failed with CollectionNotFound after burning the full KvTimeout.
+                Cid ??= DefaultCollectionId;
+                return;
+            }
+
+            if (IsDefaultCollection)
+            {
+                //The default scope and collection are defined to be collection ID 0, so there is
+                //nothing to look up. This saves a GET_CID round trip on the first operation against
+                //every default collection, which is most of them.
+                Cid ??= DefaultCollectionId;
+                return;
+            }
+
+            //Check to see if the CID is needed
+            if (RequiresCid())
+            {
+                //Get the collection ID
+                await PopulateCidAsync().ConfigureAwait(false);
+            }
+        }
+
 
         #endregion
 
@@ -1491,7 +1315,7 @@ namespace Couchbase.KeyValue
                         () => GetCidWithFallbackAsync(retryIfFailure: true),
                         LazyThreadSafetyMode.ExecutionAndPublication);
                     GetCidLazyNoRetry ??= new Lazy<Task<uint?>>(
-                        () => GetCidWithFallbackAsync(retryIfFailure: true),
+                        () => GetCidWithFallbackAsync(retryIfFailure: false),
                         LazyThreadSafetyMode.ExecutionAndPublication);
                 }
 
@@ -1546,16 +1370,23 @@ namespace Couchbase.KeyValue
             var options = new GetOptions();
             _operationConfigurator.Configure(getCid, options.Transcoder(_rawStringTranscoder));
             using var ctp = CreateRetryTimeoutCancellationTokenSource(options, getCid);
-            if (retryIfFailure)
-            {
-                await _bucket.RetryAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
-            }
-            else
-            {
-                await _bucket.SendAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
-            }
+            var status = retryIfFailure
+                ? await _bucket.RetryAsync(getCid, ctp.TokenPair).ConfigureAwait(false)
+                : await _bucket.SendAsync(getCid, ctp.TokenPair).ConfigureAwait(false);
 
             var resultWithValue = getCid.GetValueAsUint();
+
+            if (status == ResponseStatus.Success && !resultWithValue.HasValue)
+            {
+                //GetValueAsUint returns null for a Success response whose body is empty or cannot be
+                //parsed. That null used to be assigned to Cid and carried to the wire; it now fails
+                //at framing time, but with a message about the operation rather than about the
+                //lookup, so name what actually happened while we still know it. The deliberate null
+                //from GetCidWithFallbackAsync's UnsupportedException path is untouched: that one
+                //means the server has no collections, which is a different answer.
+                ThrowHelper.ThrowCollectionIdNotResolvedException(ScopeName, Name);
+            }
+
             return resultWithValue;
         }
 

--- a/src/Couchbase/Utils/ThrowHelper.cs
+++ b/src/Couchbase/Utils/ThrowHelper.cs
@@ -90,6 +90,15 @@ namespace Couchbase.Utils
         public static void ThrowNodeUnavailableException(string message) =>
             throw new NodeNotAvailableException(message);
 
+        /// <summary>
+        /// GET_CID came back successful but carried no usable collection ID.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowCollectionIdNotResolvedException(string scopeName, string collectionName) =>
+            throw new CouchbaseException(
+                $"The server returned a successful GET_CID for '{scopeName}.{collectionName}' with no " +
+                "usable collection ID in the body, so there is nothing to frame operations with.");
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T EnsureNotNullForDataStructures<T>(this T? value)
             where T : notnull

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionCollectionIdTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionCollectionIdTests.cs
@@ -1,0 +1,473 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Core.Bootstrapping;
+using Couchbase.Core.Configuration.Server;
+using Couchbase.Core.DI;
+using Couchbase.Core.Diagnostics.Tracing;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.Exceptions.KeyValue;
+using Couchbase.Core.IO.Compression;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Operations.Collections;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Core.IO.Transcoders;
+using Couchbase.Core.Logging;
+using Couchbase.Core.Retry;
+using Couchbase.Core.Sharding;
+using Couchbase.KeyValue;
+using Couchbase.KeyValue.RangeScan;
+using Couchbase.Management.Collections;
+using Couchbase.Management.Views;
+using Couchbase.UnitTests.Utils;
+using Couchbase.Utils;
+using Couchbase.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Moq;
+using Xunit;
+
+namespace Couchbase.UnitTests.KeyValue
+{
+    /// <summary>
+    /// Every key/value operation must resolve the collection ID before it dispatches. If it does
+    /// not, and the connection negotiated collections in HELO, the server reads the first byte of
+    /// the document key as a leb128 collection ID and the operation silently addresses the wrong
+    /// collection: NCBC-4285, where GetPrimary was a near-identical copy of GetReplica that had
+    /// never been given the guard.
+    ///
+    /// The point of these tests is <see cref="Every_public_operation_is_covered"/>. A table of
+    /// operations only proves something about the operations someone remembered to add, so the
+    /// reflection test fails when the public surface grows past the table.
+    /// </summary>
+    public class CouchbaseCollectionCollectionIdTests
+    {
+        private const string DocId = "thekey";
+
+        /// <summary>The collection ID encoded in <see cref="GetCidResponse"/>.</summary>
+        private const uint FakeCid = 0x17;
+
+        /// <summary>
+        /// A real GET_CID success response, taken from
+        /// <c>CollectionOperationTests.Test_GetCid_WithValue</c>. Serving a genuine packet means the
+        /// collection actually ends up holding a CID, so the tests can assert on the value that
+        /// reached the wire rather than merely that a fetch was attempted.
+        /// </summary>
+        private static readonly byte[] GetCidResponse =
+        [
+            0x18, 0xbb, 0x03, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x1a,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x1f, 0x00, 0x00, 0x00, 0x17
+        ];
+
+        private static readonly LookupInSpec[] LookupSpecs = [LookupInSpec.Get("name")];
+        private static readonly MutateInSpec[] MutateSpecs = [MutateInSpec.Upsert("name", "mike")];
+
+        /// <summary>
+        /// One entry per public operation. Keys are labels rather than bare method names so the two
+        /// UnlockAsync overloads can both appear; <see cref="Every_public_operation_is_covered"/>
+        /// matches on the part before any generic marker.
+        /// </summary>
+        private static readonly Dictionary<string, Func<CouchbaseCollection, Task>> Operations = new()
+        {
+            ["GetAsync"] = c => c.GetAsync(DocId),
+            ["ExistsAsync"] = c => c.ExistsAsync(DocId),
+            ["UpsertAsync"] = c => c.UpsertAsync(DocId, new { name = "mike" }),
+            ["InsertAsync"] = c => c.InsertAsync(DocId, new { name = "mike" }),
+            ["ReplaceAsync"] = c => c.ReplaceAsync(DocId, new { name = "mike" }),
+            ["RemoveAsync"] = c => c.RemoveAsync(DocId),
+            ["UnlockAsync"] = c => c.UnlockAsync(DocId, 0UL),
+            ["UnlockAsync<T>"] = c => c.UnlockAsync<object>(DocId, 0UL),
+            ["TouchAsync"] = c => c.TouchAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["TouchWithCasAsync"] = c => c.TouchWithCasAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAndTouchAsync"] = c => c.GetAndTouchAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAndLockAsync"] = c => c.GetAndLockAsync(DocId, TimeSpan.FromSeconds(10)),
+            ["GetAnyReplicaAsync"] = c => c.GetAnyReplicaAsync(DocId),
+            ["GetAllReplicasAsync"] = c => Task.WhenAll(c.GetAllReplicasAsync(DocId)),
+            ["LookupInAsync"] = c => c.LookupInAsync(DocId, LookupSpecs),
+            ["LookupInAnyReplicaAsync"] = c => c.LookupInAnyReplicaAsync(DocId, LookupSpecs),
+            ["LookupInAllReplicasAsync"] = c => Drain(c.LookupInAllReplicasAsync(DocId, LookupSpecs)),
+            ["MutateInAsync"] = c => c.MutateInAsync(DocId, MutateSpecs),
+            ["ScanAsync"] = c => Drain(c.ScanAsync(new RangeScan())),
+            ["AppendAsync"] = c => c.AppendAsync(DocId, [1, 2, 3]),
+            ["PrependAsync"] = c => c.PrependAsync(DocId, [1, 2, 3]),
+            ["IncrementAsync"] = c => c.IncrementAsync(DocId),
+            ["DecrementAsync"] = c => c.DecrementAsync(DocId)
+        };
+
+        public static TheoryData<string> OperationLabels => new(Operations.Keys);
+
+        /// <summary>
+        /// ScanAsync cannot be asserted the same way as the rest: PartitionScan builds its own
+        /// operations and reads Cid off the collection, so nothing it sends carries the document
+        /// key. Its coverage is the collection-level assertion that the ID was resolved at all.
+        /// </summary>
+        private const string ScanLabel = "ScanAsync";
+
+        [Theory]
+        [MemberData(nameof(OperationLabels))]
+        public async Task Operation_resolves_the_collection_id_before_dispatch(string label)
+        {
+            var (collection, bucket) = CreateCollection();
+
+            try
+            {
+                await Operations[label](collection).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Every operation fails - the fake bucket serves no documents. What it put on the
+                // wire before failing is the point.
+            }
+
+            Assert.True(bucket.FetchedCid, $"{label} never fetched a collection ID.");
+            Assert.Equal(FakeCid, collection.Cid!.Value);
+
+            var keyedOps = bucket.Dispatched.Where(op => op.Key == DocId).ToList();
+
+            // Without this the assertion below passes for an operation that dispatched nothing.
+            if (label != ScanLabel)
+            {
+                Assert.NotEmpty(keyedOps);
+            }
+
+            Assert.All(keyedOps, op =>
+                Assert.True(op.Cid == FakeCid,
+                    $"{label} dispatched {op.OpType} for key '{op.Key}' with Cid {(op.Cid?.ToString() ?? "null")}."));
+        }
+
+        /// <summary>
+        /// The table above is only as good as its coverage, and a new operation added without an
+        /// entry is exactly how NCBC-4285 happened. This fails when the public surface outgrows it.
+        /// </summary>
+        [Fact]
+        public void Every_public_operation_is_covered()
+        {
+            var surface = typeof(ICouchbaseCollection).GetMethods()
+                .Concat(typeof(IBinaryCollection).GetMethods())
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+                .Distinct()
+                .ToList();
+
+            var covered = Operations.Keys
+                .Select(label => label.Split('<')[0])
+                .ToHashSet();
+
+            var missing = surface.Where(name => !covered.Contains(name)).ToList();
+
+            Assert.True(missing.Count == 0,
+                $"Add to the collection ID coverage table: {string.Join(", ", missing)}. Every " +
+                "key/value operation has to resolve the collection ID before it dispatches, or the " +
+                "server reads the first byte of the document key as the collection ID (NCBC-4285).");
+        }
+
+        /// <summary>
+        /// The CID is cached on the collection and PopulateCidAsync short-circuits on it, so each
+        /// case needs its own collection or every case after the first passes for the wrong reason.
+        /// </summary>
+        [Fact]
+        public void Each_case_starts_without_a_collection_id()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            Assert.Null(collection.Cid);
+            Assert.False(bucket.FetchedCid);
+        }
+
+        /// <summary>
+        /// A bucket with no collections - a memcached bucket - still talks to a connection that
+        /// negotiated collections in HELO, so the server reads a leb128 collection ID from every key.
+        /// The default collection, 0, is the right one, and there is nothing to look up. Leaving the
+        /// CID null is why every KV operation against a memcached bucket failed with
+        /// CollectionNotFound after burning the full KvTimeout.
+        /// </summary>
+        [Fact]
+        public async Task A_bucket_without_collections_uses_the_default_collection_id()
+        {
+            var (collection, bucket) = CreateCollection(supportsCollections: false, defaultCollection: true);
+
+            await Invoke(() => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.False(bucket.FetchedCid);
+            Assert.True(collection.Cid.HasValue,
+                "A bucket without collections left the CID null, so a collections-negotiated " +
+                "connection would read the first byte of the key as the collection ID.");
+            Assert.Equal(CouchbaseCollection.DefaultCollectionId, collection.Cid!.Value);
+            AssertAllKeyedOpsCarry(bucket, CouchbaseCollection.DefaultCollectionId);
+        }
+
+        /// <summary>
+        /// Asking for a named collection on a cluster or bucket that has none cannot be satisfied, so
+        /// say so at the boundary instead of sending an operation whose collection the server cannot
+        /// resolve - which surfaced as CollectionNotFound after the full KvTimeout. Matches the JVM's
+        /// BaseKeyValueRequest.encodedExternalKeyWithCollection.
+        /// </summary>
+        [Fact]
+        public async Task A_named_collection_without_collections_support_throws()
+        {
+            var (collection, bucket) = CreateCollection(supportsCollections: false, defaultCollection: false);
+
+            var exception = await Assert.ThrowsAsync<FeatureNotAvailableException>(
+                () => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.Contains("s.c", exception.Message);
+            Assert.Empty(bucket.Dispatched);
+        }
+
+        /// <summary>
+        /// The default scope and collection are defined to be collection ID 0, so the first operation
+        /// against them should not spend a GET_CID round trip discovering that.
+        /// </summary>
+        [Fact]
+        public async Task The_default_collection_needs_no_lookup()
+        {
+            var (collection, bucket) = CreateCollection(defaultCollection: true);
+
+            await Invoke(() => collection.GetAsync(DocId)).ConfigureAwait(false);
+
+            Assert.False(bucket.FetchedCid);
+            Assert.Equal(CouchbaseCollection.DefaultCollectionId, collection.Cid!.Value);
+            AssertAllKeyedOpsCarry(bucket, CouchbaseCollection.DefaultCollectionId);
+        }
+
+        /// <summary>
+        /// PopulateCidAsync(retryIfFailure: false) is meant to send the GET_CID without going through
+        /// the retry orchestrator, but both lazies were built with retryIfFailure: true, so the
+        /// no-retry one retried. Only reachable with forceUpdate false, which nothing currently does -
+        /// a trap for the next caller rather than a live bug.
+        /// </summary>
+        [Fact]
+        public async Task A_no_retry_collection_id_fetch_does_not_go_through_the_retry_path()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            await collection.PopulateCidAsync(retryIfFailure: false).ConfigureAwait(false);
+
+            Assert.True(bucket.FetchedCid);
+            Assert.False(bucket.FetchedCidViaRetry,
+                "PopulateCidAsync(retryIfFailure: false) went through the retry path.");
+        }
+
+        [Fact]
+        public async Task A_retrying_collection_id_fetch_does_go_through_the_retry_path()
+        {
+            var (collection, bucket) = CreateCollection();
+
+            await collection.PopulateCidAsync(retryIfFailure: true).ConfigureAwait(false);
+
+            Assert.True(bucket.FetchedCid);
+            Assert.True(bucket.FetchedCidViaRetry);
+        }
+
+        /// <summary>
+        /// GetCid.GetValueAsUint() returns null for a Success response whose body is empty or cannot
+        /// be parsed. That null used to be assigned to Cid and carried to the wire; it must fail where
+        /// the cause is still known.
+        /// </summary>
+        [Fact]
+        public async Task A_successful_get_cid_with_no_body_fails_at_the_lookup()
+        {
+            var (collection, bucket) = CreateCollection();
+            bucket.ServeEmptyCidBody = true;
+
+            var exception = await Assert.ThrowsAsync<CouchbaseException>(
+                () => collection.PopulateCidAsync().AsTask()).ConfigureAwait(false);
+
+            Assert.Contains("s.c", exception.Message);
+            Assert.Null(collection.Cid);
+        }
+
+        private static async Task Invoke(Func<Task> operation)
+        {
+            try
+            {
+                await operation().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // The fake bucket serves no documents. What went on the wire is the point.
+            }
+        }
+
+        private static void AssertAllKeyedOpsCarry(CidFakeBucket bucket, uint expected)
+        {
+            var keyedOps = bucket.Dispatched.Where(op => op.Key == DocId).ToList();
+            Assert.NotEmpty(keyedOps);
+            Assert.All(keyedOps, op => Assert.Equal(expected, op.Cid!.Value));
+        }
+
+        private static async Task Drain<T>(IAsyncEnumerable<T> source)
+        {
+            await foreach (var _ in source.ConfigureAwait(false))
+            {
+            }
+        }
+
+        private static (CouchbaseCollection Collection, CidFakeBucket Bucket) CreateCollection(
+            bool supportsCollections = true, bool defaultCollection = false)
+        {
+            var config = ResourceHelper.ReadResource(@"Documents\Configs\configWithReplicasAndServerGroups.json",
+                InternalSerializationContext.Default.BucketConfig);
+
+            // Every key maps to the same topology. Unlike the zone-aware fixture, collections are
+            // supported here - that is the whole point - and range scans too, so ScanAsync gets
+            // past its feature check.
+            config.VBucketServerMap.VBucketMap = Enumerable.Repeat<short[]>([1, 0, 2, 3], 1024).ToArray();
+            config.BucketCapabilities = supportsCollections
+                ?
+                [
+                    BucketCapabilities.COLLECTIONS,
+                    BucketCapabilities.RANGE_SCAN,
+                    BucketCapabilities.SUBDOC_REPLICA_READ
+                ]
+                :
+                [
+                    BucketCapabilities.RANGE_SCAN,
+                    BucketCapabilities.SUBDOC_REPLICA_READ
+                ];
+
+            var bucket = new CidFakeBucket(config);
+
+            var collection = new CouchbaseCollection(bucket,
+                new OperationConfigurator(new LegacyTranscoder(),
+                    Mock.Of<IOperationCompressor>(),
+                    new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy()),
+                    new BestEffortRetryStrategy()),
+                new Mock<ILogger<CouchbaseCollection>>().Object,
+                new Mock<ILogger<GetResult>>().Object,
+                new Mock<IRedactor>().Object,
+                defaultCollection ? CouchbaseCollection.DefaultCollectionName : "c",
+                defaultCollection
+                    ? Mock.Of<IScope>(scope => scope.IsDefaultScope == true &&
+                                               scope.Name == Scope.DefaultScopeName)
+                    : Mock.Of<IScope>(scope => scope.IsDefaultScope == false && scope.Name == "s"),
+                new NoopRequestTracer(),
+                NullFallbackTypeSerializerProvider.Instance,
+                Mock.Of<IServiceProvider>());
+
+            return (collection, bucket);
+        }
+
+        internal record DispatchedOp(string OpType, string Key, uint? Cid);
+
+        /// <summary>
+        /// Serves GET_CID and nothing else: every other operation is recorded and then failed, so
+        /// the collection method unwinds immediately and the test can look at what it sent.
+        /// </summary>
+        internal class CidFakeBucket : BucketBase
+        {
+            private readonly List<DispatchedOp> _dispatched = new();
+            private readonly object _lock = new();
+
+            public CidFakeBucket(BucketConfig config)
+                : base(config.Name,
+                    new ClusterContext(null,
+                        new ClusterOptions().WithPasswordAuthentication("username", "password")),
+                    new Mock<IScopeFactory>().Object,
+                    CreateRetryOrchestrator(),
+                    new Mock<ILogger>().Object,
+                    new TypedRedactor(RedactionLevel.None),
+                    new Mock<IBootstrapperFactory>().Object,
+                    NoopRequestTracer.Instance,
+                    new Mock<IOperationConfigurator>().Object,
+                    new BestEffortRetryStrategy(), null)
+            {
+                CurrentConfig = config;
+                KeyMapper = new VBucketKeyMapper(config, new VBucketServerMap(config.VBucketServerMap),
+                    new VBucketFactory(new Mock<ILogger<VBucket>>().Object));
+            }
+
+            /// <summary>Whether a GET_CID was sent.</summary>
+            public bool FetchedCid { get; private set; }
+
+            /// <summary>
+            /// Which path the GET_CID took. PopulateCidAsync(retryIfFailure: false) must reach
+            /// SendAsync, not RetryAsync - the observable difference the no-retry lazy exists for.
+            /// </summary>
+            public bool FetchedCidViaRetry { get; private set; }
+
+            /// <summary>
+            /// Answer GET_CID with a Success status and no body, which is what makes
+            /// GetCid.GetValueAsUint() return null.
+            /// </summary>
+            public bool ServeEmptyCidBody { get; set; }
+
+            /// <summary>Snapshot of what was dispatched, GET_CID aside.</summary>
+            public IReadOnlyList<DispatchedOp> Dispatched
+            {
+                get
+                {
+                    lock (_lock)
+                    {
+                        return _dispatched.ToList();
+                    }
+                }
+            }
+
+            public virtual Task<ResponseStatus> Dispatch(IOperation operation, bool viaRetry = true)
+            {
+                if (operation is GetCid getCid)
+                {
+                    FetchedCid = true;
+                    FetchedCidViaRetry = viaRetry;
+
+                    if (ServeEmptyCidBody)
+                    {
+                        return Task.FromResult(ResponseStatus.Success);
+                    }
+
+                    var response = MemoryPool<byte>.Shared.RentAndSlice(GetCidResponse.Length);
+                    GetCidResponse.AsMemory().CopyTo(response.Memory);
+                    getCid.Read(response);
+
+                    return Task.FromResult(ResponseStatus.Success);
+                }
+
+                lock (_lock)
+                {
+                    _dispatched.Add(new DispatchedOp(operation.GetType().Name, operation.Key, operation.Cid));
+                }
+
+                return Task.FromException<ResponseStatus>(
+                    new TemporaryFailureException("The fake bucket serves no documents."));
+            }
+
+            private static IRetryOrchestrator CreateRetryOrchestrator()
+            {
+                var mock = new Mock<IRetryOrchestrator>();
+
+                mock.Setup(m => m.RetryAsync(It.IsAny<BucketBase>(), It.IsAny<IOperation>(),
+                        It.IsAny<CancellationTokenPair>()))
+                    .Returns((BucketBase bucket, IOperation op, CancellationTokenPair _) =>
+                        ((CidFakeBucket) bucket).Dispatch(op));
+
+                return mock.Object;
+            }
+
+            internal override Task<ResponseStatus> SendAsync(IOperation op, CancellationTokenPair token = default) =>
+                Dispatch(op, viaRetry: false);
+
+            public override ICouchbaseCollectionManager Collections => throw new NotImplementedException();
+
+#pragma warning disable CS0618, CS0672 // Obsolete View service members
+            public override IViewIndexManager ViewIndexes => throw new NotImplementedException();
+
+            public override Task<IViewResult<TKey, TValue>> ViewQueryAsync<TKey, TValue>(string designDocument,
+                string viewName, ViewOptions options = null) => throw new NotImplementedException();
+#pragma warning restore CS0618, CS0672
+
+            public override Task ForceConfigUpdateAsync() => throw new NotImplementedException();
+
+            public override IScope Scope(string scopeName) => throw new NotImplementedException();
+
+            internal override Task BootstrapAsync(IClusterNode bootstrapNodes) => throw new NotImplementedException();
+
+            public override Task ConfigUpdatedAsync(BucketConfig newConfig) => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionTests.cs
@@ -341,7 +341,7 @@ namespace Couchbase.UnitTests.KeyValue
                 new Mock<ILogger<GetResult>>().Object,
                 new Mock<IRedactor>().Object,
                 CouchbaseCollection.DefaultCollectionName,
-                Mock.Of<IScope>(),
+                Mock.Of<IScope>(scope => scope.IsDefaultScope == true && scope.Name == Scope.DefaultScopeName),
                 new NoopRequestTracer(),
                 NullFallbackTypeSerializerProvider.Instance,
                 serviceProviderMock.Object);

--- a/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/CouchbaseCollectionZoneAwareTests.cs
@@ -256,7 +256,7 @@ namespace Couchbase.UnitTests.KeyValue
                 new Mock<ILogger<GetResult>>().Object,
                 new Mock<IRedactor>().Object,
                 CouchbaseCollection.DefaultCollectionName,
-                Mock.Of<IScope>(),
+                Mock.Of<IScope>(scope => scope.IsDefaultScope == true && scope.Name == Scope.DefaultScopeName),
                 new NoopRequestTracer(),
                 NullFallbackTypeSerializerProvider.Instance,
                 Mock.Of<IServiceProvider>());


### PR DESCRIPTION
Part 3 of 4, splitting #167. **Independent of #168 and #169** — but **#171 is stacked on this one.**

**Review order: 2 of 4** — #169 → **#170** → #171. #168 is independent and readable at any point.
**Read #169 first**: it is the smallest of the four and establishes the premise that the connection, not client state, is the authority.
**Merging**: independent of #168 and #169, but #171 is stacked on this branch.

Two files carry almost all of it: `CouchbaseCollection.cs` (−297/+75) and the new test file.

## Summary

Every collection-oriented KV method repeated the same preamble by hand: check whether the collection ID is needed, resolve it, stamp the operation with the collection's identity, configure it, rent a token source. **23 copies of the guard, 19 of the identity stamp, and no compiler help** — an operation that skipped them compiled fine.

That's how NCBC-4285 happened. `GetPrimary` was a near-identical copy of `GetReplica` twelve lines below, made before the guard was added to `GetReplica` by NCBC-2881 five weeks later, and it went four years without one.

## The problems

1. **Nothing forced an operation to resolve a collection ID.**
2. **`GetPrimary` never did** — NCBC-4285. Reached via `GetAllReplicasAsync`, it dispatched an unprefixed key, so a collections-negotiated server reads the first byte of the document key as the collection ID. Masked because `PopulateCidAsync` short-circuits once a CID is cached; becomes reliable once a bucket's lifetime collection count passes ~120.
3. **A bucket with no collections left the CID null** — why every KV operation against a memcached bucket failed with `CollectionNotFound` after burning the full `KvTimeout`.
4. **A named collection on a cluster without collections was sent anyway**, failing the same way rather than being refused at the boundary.
5. **`_default._default` cost a `GET_CID` round trip**, though it's defined to be collection ID 0.
6. **A successful `GET_CID` with an empty body produced a null CID**, assigned and carried to the wire.
7. **`GetCidLazyNoRetry` retried** — both lazies built with `retryIfFailure: true`. Latent: only reachable via `PopulateCidAsync(false, false)`, which nothing calls.
8. **`ExecuteLookupIn` resolved unconditionally**, forcing a `GET_CID` on buckets without collections.

## What to look at

`PrepareAsync` returns the rented token source, and **the caller needs it in order to dispatch** — so an operation that skips preparation doesn't compile. That's the property that prevents recurrence.

`ThrowIfBootStrapFailed` deliberately stays at the top of each method: folding it in would move an early exit to after the request span is opened, and it was never the defect.

**`ScanAsync` can't use the funnel.** `PartitionScan` builds its own operations and reads `collection.Cid` directly, and its `RangeScanCancel` writes no key, so routing it through would change that frame. It calls the extracted `EnsureCollectionIdAsync`, which `PrepareAsync` also uses, so there's one implementation of the resolve.

## Verification

2962 tests pass on net8.0 and net10.0, 41 new.

The coverage is table-driven, one entry per public operation — 19 on `ICouchbaseCollection`, 4 on `IBinaryCollection`. The part that matters is the **reflection test that fails when the public surface outgrows the table**, because a table alone only proves something about the operations someone remembered to add.

Checked by mutation: dropping the stamp or the resolve from `PrepareAsync` fails 22 tests each, deleting one table entry names it, and removing the resolve from `ScanAsync` fails exactly one — which is the regression this change introduced, caught by hand before the tests existed because 23 removed guards produced only 19 `PrepareAsync` sites.

## Two intentional deltas

- `ExecuteLookupIn` no longer forces a `GET_CID` on non-collections buckets.
- The internal `get_cid` span now nests inside the operation's span rather than preceding it, because the resolve happens inside `PrepareAsync`.

## Fixtures corrected rather than code

`CouchbaseCollectionTests` and `CouchbaseCollectionZoneAwareTests` built collections with `Mock.Of<IScope>()`, which reports `IsDefaultScope` as false — so every fake collection looked like a *named* collection on a bucket without collections, and problem 4's throw fired. They now describe the default scope, which is what they always meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
