### PR TITLE
NCBC-4287: Frame the collection ID from the connection, not client state

### DIFF
--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslList.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslList.cs
@@ -7,6 +7,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     /// </summary>
     internal sealed class SaslList : OperationBase<string>
     {
+        /// <inheritdoc />
+        // mechanism negotiation, no document key.
+        internal override bool RequiresCollectionId => false;
+
         internal override void WriteExtras(OperationBuilder builder)
         {
         }

--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslStart.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslStart.cs
@@ -8,6 +8,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     // ReSharper disable once IdentifierTypo
     internal class SaslStart : OperationBase<string>
     {
+        /// <inheritdoc />
+        // authentication runs after HELO but before any collection exists.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SaslStart;
 
         internal override void WriteExtras(OperationBuilder builder)

--- a/src/Couchbase/Core/IO/Operations/Authentication/SaslStep.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SaslStep.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
     /// </summary>
     internal class SaslStep : SaslStart
     {
+        /// <inheritdoc />
+        // authentication runs after HELO but before any collection exists.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SaslStep;
     }
 }

--- a/src/Couchbase/Core/IO/Operations/Authentication/SelectBucket.cs
+++ b/src/Couchbase/Core/IO/Operations/Authentication/SelectBucket.cs
@@ -2,6 +2,10 @@ namespace Couchbase.Core.IO.Operations.Authentication
 {
     internal sealed class SelectBucket : OperationBase
     {
+        /// <inheritdoc />
+        // the key is the bucket name.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.SelectBucket;
     }
 }

--- a/src/Couchbase/Core/IO/Operations/Collections/GetCid.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetCid.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetCid : OperationBase<string>
     {
+        /// <inheritdoc />
+        // the key is the fully qualified collection name - this is what resolves a CID.
+        internal override bool RequiresCollectionId => false;
+
         /// <summary>
         /// Creates a key either by the Key property or the Content property.
         /// <remarks>Early server versions used the Key for the collection name; later versions use the Content property.</remarks>

--- a/src/Couchbase/Core/IO/Operations/Collections/GetManifest.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetManifest.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetManifest :  OperationBase<Manifest>
     {
+        /// <inheritdoc />
+        // manifest request, no document key.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode  => OpCode.GetCollectionsManifest;
 
         protected override void BeginSend()

--- a/src/Couchbase/Core/IO/Operations/Collections/GetSid.cs
+++ b/src/Couchbase/Core/IO/Operations/Collections/GetSid.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.Collections
 {
     internal sealed class GetSid : OperationBase<uint?>
     {
+        /// <inheritdoc />
+        // the key is the scope name.
+        internal override bool RequiresCollectionId => false;
+
         public override bool RequiresVBucketId => false;
 
         public override OpCode OpCode => OpCode.GetSidByName;

--- a/src/Couchbase/Core/IO/Operations/Config.cs
+++ b/src/Couchbase/Core/IO/Operations/Config.cs
@@ -49,6 +49,10 @@ namespace Couchbase.Core.IO.Operations
 
     internal sealed class Config : OperationBase<BucketConfig>
     {
+        /// <inheritdoc />
+        // cluster map request, no document key.
+        internal override bool RequiresCollectionId => false;
+
         internal HostEndpointWithPort EndPoint { get; set; }
 
         internal ulong? Epoch { get; set; }

--- a/src/Couchbase/Core/IO/Operations/Configuration/ClusterMapChangeNotification.cs
+++ b/src/Couchbase/Core/IO/Operations/Configuration/ClusterMapChangeNotification.cs
@@ -7,6 +7,10 @@ namespace Couchbase.Core.IO.Operations.Configuration;
 
 internal sealed class ClusterMapChangeNotification : OperationBase<BucketConfig>
 {
+    /// <inheritdoc />
+    // a server push, no document key.
+    internal override bool RequiresCollectionId => false;
+
     public override OpCode OpCode => OpCode.ClusterMapChangeNotification;
 
     protected override void ReadExtras(ReadOnlySpan<byte> buffer)

--- a/src/Couchbase/Core/IO/Operations/Errors/GetErrorMap.cs
+++ b/src/Couchbase/Core/IO/Operations/Errors/GetErrorMap.cs
@@ -5,11 +5,15 @@ namespace Couchbase.Core.IO.Operations.Errors
 {
     internal sealed class GetErrorMap : OperationBase<ErrorMapDto>
     {
+        /// <inheritdoc />
+        // writes no key at all.
+        internal override bool RequiresCollectionId => false;
+
         private const int DefaultVersion = 2; // will be configurable at some point
 
         public ErrorMap ErrorMap { get; set; }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
 

--- a/src/Couchbase/Core/IO/Operations/Hello.cs
+++ b/src/Couchbase/Core/IO/Operations/Hello.cs
@@ -12,6 +12,10 @@ namespace Couchbase.Core.IO.Operations
 {
     internal sealed class Hello : OperationBase<ServerFeatures[]>
     {
+        /// <inheritdoc />
+        // the key is a connection identifier, and this runs before any bucket is selected.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.Helo;
 
         internal override void WriteBody(OperationBuilder builder)

--- a/src/Couchbase/Core/IO/Operations/Noop.cs
+++ b/src/Couchbase/Core/IO/Operations/Noop.cs
@@ -2,9 +2,13 @@ namespace Couchbase.Core.IO.Operations
 {
     internal sealed class Noop : OperationBase
     {
+        /// <inheritdoc />
+        // writes no key at all.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.NoOp;
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
     }

--- a/src/Couchbase/Core/IO/Operations/Observe.cs
+++ b/src/Couchbase/Core/IO/Operations/Observe.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Core.IO.Operations
         {
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
         }
 
@@ -24,7 +24,10 @@ namespace Couchbase.Core.IO.Operations
             const int vBucketAndLengthSize = sizeof(ushort) * 2;
             var buffer = builder.GetSpan(vBucketAndLengthSize + OperationHeader.MaxKeyLength + Leb128.MaxLength);
 
-            var keyLength = WriteKey(buffer.Slice(vBucketAndLengthSize));
+            //Observe frames its key inside the body with an explicit length, and is dead code
+            //pending removal, so it keeps the old client-side rule rather than the connection's
+            //negotiated state: passing Cid.HasValue reproduces exactly what WriteKey used to do.
+            var keyLength = WriteKey(buffer.Slice(vBucketAndLengthSize), Cid.HasValue);
 
             // ReSharper disable once PossibleInvalidOperationException
             ByteConverter.FromInt16(VBucketId.Value, buffer);

--- a/src/Couchbase/Core/IO/Operations/OperationBase.cs
+++ b/src/Couchbase/Core/IO/Operations/OperationBase.cs
@@ -86,6 +86,18 @@ namespace Couchbase.Core.IO.Operations
         /// <inheritdoc />
         public uint? Cid { get; set; }
 
+        /// <summary>
+        /// Whether this operation addresses a document, and must therefore carry a leb128 collection
+        /// ID when the connection has negotiated collections.
+        /// </summary>
+        /// <remarks>
+        /// True is the default because it is the safe value: an operation added without a thought
+        /// about framing then fails loudly instead of silently addressing the wrong collection.
+        /// Connection and cluster level operations - HELO, SASL, SELECT_BUCKET, GET_CID and the like
+        /// - carry a key that is not a document ID and must override this to false.
+        /// </remarks>
+        internal virtual bool RequiresCollectionId => true;
+
         public byte[]? EncodedKey { get; set; }
 
         /// <inheritdoc />
@@ -534,35 +546,63 @@ namespace Couchbase.Core.IO.Operations
         /// Writes the key to an <see cref="OperationBuilder"/>.
         /// </summary>
         /// <param name="builder">The builder.</param>
-        internal virtual void WriteKey(OperationBuilder builder)
+        /// <param name="collectionsEnabled">
+        /// Whether the connection this operation is being written for negotiated collections in
+        /// HELO, and will therefore read a leb128 collection ID from the start of the key.
+        /// </param>
+        internal virtual void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
-            var keyLength = Cid.HasValue ?
+            var keyLength = collectionsEnabled && RequiresCollectionId ?
                 OperationHeader.MaxKeyLength + Leb128.MaxLength :
                 OperationHeader.MaxKeyLength;
 
             var buffer = builder.GetSpan(keyLength);
 
-            var length = WriteKey(buffer);
+            var length = WriteKey(buffer, collectionsEnabled);
 
             builder.Advance(length);
         }
 
         /// <summary>
-        /// Write the <see cref="Key"/>, with <see cref="Cid"/> if present, to a buffer.
+        /// Write the <see cref="Key"/> to a buffer, prefixed with the leb128 <see cref="Cid"/> when
+        /// the connection has negotiated collections and this operation addresses a document.
         /// </summary>
         /// <param name="buffer">Target buffer.</param>
+        /// <param name="collectionsEnabled">
+        /// Whether the connection this operation is being written for negotiated collections in
+        /// HELO, and will therefore read a leb128 collection ID from the start of the key.
+        /// </param>
         /// <returns>Number of bytes written.</returns>
-        protected int WriteKey(Span<byte> buffer)
+        protected int WriteKey(Span<byte> buffer, bool collectionsEnabled)
         {
             var length = 0;
 
-            //Default collection does not need the CID
-            if (Cid.HasValue)
+            //Whether the server parses a leb128 collection ID at offset 0 is fixed by what this
+            //connection negotiated in HELO, not by whether we happen to be holding a CID. Deciding
+            //it from client-side state is what corrupted document keys in NCBC-4146, in both
+            //directions: a prefix the server does not parse becomes part of the document ID, and a
+            //missing prefix makes the server read the first byte of the key as the collection.
+            if (collectionsEnabled && RequiresCollectionId)
             {
+                if (!Cid.HasValue)
+                {
+                    ThrowHelper.ThrowMissingCollectionIdException(OpCode);
+                }
+
                 length += Leb128.Write(buffer, Cid.GetValueOrDefault());
             }
 
             length += ByteConverter.FromString(Key, buffer.Slice(length));
+
+            if (length > OperationHeader.MaxKeyLength)
+            {
+                //The key field carries the collection ID as well as the document ID, so the prefix
+                //eats into the same 250 byte budget - a 250 byte key does not fit once a CID is
+                //prepended. The Key setter only validates the document ID on its own, so this used
+                //to surface from OperationHeader.KeyLength as a bare ArgumentOutOfRangeException
+                //from inside the write path. Java validates the same way, prefix included.
+                ThrowHelper.ThrowKeyTooLongForCollectionIdException(length);
+            }
 
             return length;
         }
@@ -626,7 +666,7 @@ namespace Couchbase.Core.IO.Operations
                 WriteExtras(builder);
 
                 builder.AdvanceToSegment(OperationSegment.Key);
-                WriteKey(builder);
+                WriteKey(builder, connection.ServerFeatures.Collections);
 
                 builder.AdvanceToSegment(OperationSegment.Body);
                 WriteBody(builder);

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCancel.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCancel.cs
@@ -6,6 +6,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanCancel : OperationBase<SlicedMemoryOwner<byte>>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - identified by the scan UUID.
+        internal override bool RequiresCollectionId => false;
+
         public override OpCode OpCode => OpCode.RangeScanCancel;
 
         public override bool RequiresVBucketId => true;
@@ -15,7 +19,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
             //no body
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanContinue.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanContinue.cs
@@ -11,6 +11,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanContinue : OperationBase<IDictionary<string, IScanResult>>, IObserver<SlicedMemoryOwner<byte>>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - identified by the scan UUID.
+        internal override bool RequiresCollectionId => false;
+
         //To hold the intermediate responses
         private List<SlicedMemoryOwner<byte>> _responses = new();
 
@@ -49,7 +53,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 
         public ILogger<GetResult> Logger { get;set; }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCreate.cs
+++ b/src/Couchbase/Core/IO/Operations/RangeScan/RangeScanCreate.cs
@@ -5,6 +5,10 @@ namespace Couchbase.Core.IO.Operations.RangeScan
 {
     internal sealed class RangeScanCreate : OperationBase<IScanTypeExt>, IPreMappedVBucketOperation
     {
+        /// <inheritdoc />
+        // writes no key - the collection travels in the body.
+        internal override bool RequiresCollectionId => false;
+
         //https://github.com/couchbase/kv_engine/blob/master/docs/range_scans/range_scan_create.md
 
         public override bool RequiresVBucketId => true;
@@ -18,7 +22,7 @@ namespace Couchbase.Core.IO.Operations.RangeScan
             //no extras
         }
 
-        internal override void WriteKey(OperationBuilder builder)
+        internal override void WriteKey(OperationBuilder builder, bool collectionsEnabled)
         {
             //no key
         }

--- a/src/Couchbase/Utils/ThrowHelper.cs
+++ b/src/Couchbase/Utils/ThrowHelper.cs
@@ -110,6 +110,33 @@ namespace Couchbase.Utils
                 $"The server returned a successful GET_CID for '{scopeName}.{collectionName}' with no " +
                 "usable collection ID in the body, so there is nothing to frame operations with.");
 
+        /// <summary>
+        /// The document key plus its leb128 collection ID prefix exceeds the 250 byte key field.
+        /// </summary>
+        [DoesNotReturn]
+        public static void ThrowKeyTooLongForCollectionIdException(int length) =>
+            throw new InvalidArgumentException(
+                $"The key is too long: {length} bytes including the collection ID prefix, and the " +
+                $"maximum is {OperationHeader.MaxKeyLength}. On a connection that has negotiated " +
+                "collections the prefix shares the key field with the document ID, so the document " +
+                "ID has to be shorter than the maximum by the size of the prefix.");
+
+        /// <summary>
+        /// The connection negotiated collections, so the server will read a leb128 collection ID at
+        /// offset 0 of the key, but the operation has no collection ID to write. Sending it would
+        /// make the server treat the first byte of the document key as the collection.
+        /// </summary>
+        /// <remarks>
+        /// This is an SDK bug rather than a user error: an operation reached the wire without going
+        /// through collection ID resolution. See NCBC-4285 and NCBC-4287.
+        /// </remarks>
+        [DoesNotReturn]
+        public static void ThrowMissingCollectionIdException(OpCode opCode) =>
+            throw new CouchbaseException(
+                $"The {opCode} operation has no collection ID, but the connection has negotiated " +
+                "collections and the server will read one from the start of the key. The operation " +
+                "was dispatched without resolving a collection ID.");
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T EnsureNotNullForDataStructures<T>(this T? value)
             where T : notnull

--- a/tests/Couchbase.LoadTests/Core/IO/Operations/OperationBaseWriteKey.cs
+++ b/tests/Couchbase.LoadTests/Core/IO/Operations/OperationBaseWriteKey.cs
@@ -29,7 +29,7 @@ namespace Couchbase.LoadTests.Core.IO.Operations
 
         private class FakeOperation : Get<string>
         {
-            public void WriteKeyPublic(OperationBuilder builder) => WriteKey(builder);
+            public void WriteKeyPublic(OperationBuilder builder) => WriteKey(builder, collectionsEnabled: false);
         }
     }
 }

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/CollectionIdFramingTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/CollectionIdFramingTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Couchbase.Core.Exceptions;
+using Couchbase.Core.IO.Operations;
+using Couchbase.Core.IO.Operations.Authentication;
+using Couchbase.Core.IO.Operations.Collections;
+using Couchbase.Utils;
+using Xunit;
+
+namespace Couchbase.UnitTests.Core.IO.Operations
+{
+    /// <summary>
+    /// Whether a KV frame carries a leb128 collection ID prefix is a per-connection fact, fixed by
+    /// what that connection negotiated in HELO. Deciding it from client-side state is NCBC-4146, and
+    /// it corrupts keys in both directions: a prefix the server does not parse becomes part of the
+    /// document ID, and a missing prefix makes the server read the first byte of the key as the
+    /// collection.
+    /// </summary>
+    public class CollectionIdFramingTests
+    {
+        private const string Key = "user::1";
+        private const uint Cid = 23;
+
+        /// <summary>Exposes the protected framing method for a document operation.</summary>
+        private class TestableGet : Get<byte[]>
+        {
+            public int Frame(Span<byte> buffer, bool collectionsEnabled) => WriteKey(buffer, collectionsEnabled);
+        }
+
+        /// <summary>
+        /// Stands in for the connection and cluster level operations - HELO, SASL, SELECT_BUCKET and
+        /// the rest are sealed or awkward to construct, and which of them opt out is pinned by
+        /// <see cref="Only_connection_and_cluster_operations_opt_out_of_the_collection_id"/>. What is
+        /// under test here is what opting out does to the frame.
+        /// </summary>
+        private class TestableConnectionOperation : Get<byte[]>
+        {
+            internal override bool RequiresCollectionId => false;
+
+            public int Frame(Span<byte> buffer, bool collectionsEnabled) => WriteKey(buffer, collectionsEnabled);
+        }
+
+        [Fact]
+        public void Collections_negotiated_writes_the_prefix()
+        {
+            var op = new TestableGet { Key = Key, Cid = Cid };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal(Key.Length + 1, length);
+            Assert.Equal(Cid, buffer[0]);
+            Assert.Equal(Key, System.Text.Encoding.UTF8.GetString(buffer, 1, Key.Length));
+        }
+
+        /// <summary>
+        /// Polarity A of NCBC-4146: the SDK used to write a prefix whenever it happened to be holding
+        /// a CID, even on a connection that never negotiated collections. The server then read the
+        /// prefix byte as part of the document ID.
+        /// </summary>
+        [Fact]
+        public void Collections_not_negotiated_writes_no_prefix_even_holding_a_cid()
+        {
+            var op = new TestableGet { Key = Key, Cid = Cid };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: false);
+
+            Assert.Equal(Key.Length, length);
+            Assert.Equal(Key, System.Text.Encoding.UTF8.GetString(buffer, 0, Key.Length));
+        }
+
+        /// <summary>
+        /// Polarity B, and the NCBC-4285 defect: no prefix on a connection that negotiated
+        /// collections means the server eats the first byte of the key. Refuse to send it.
+        /// </summary>
+        [Fact]
+        public void Collections_negotiated_without_a_cid_throws_rather_than_corrupting_the_key()
+        {
+            var op = new TestableGet { Key = Key };
+            var buffer = new byte[64];
+
+            var exception = Assert.Throws<CouchbaseException>(() => op.Frame(buffer, collectionsEnabled: true));
+
+            Assert.Contains("no collection ID", exception.Message);
+        }
+
+        /// <summary>
+        /// The default collection is CID 0, which is a real prefix and not the same frame as no
+        /// prefix at all. Getting these two confused is the origin of the whole defect class.
+        /// </summary>
+        [Fact]
+        public void Default_collection_writes_a_zero_prefix()
+        {
+            var op = new TestableGet { Key = Key, Cid = 0 };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal(Key.Length + 1, length);
+            Assert.Equal(0, buffer[0]);
+        }
+
+        /// <summary>
+        /// SELECT_BUCKET's key is a bucket name, and it is sent before any collection exists. It must
+        /// neither be prefixed nor throw for the absent CID.
+        /// </summary>
+        [Fact]
+        public void An_operation_that_addresses_no_document_is_never_prefixed()
+        {
+            var op = new TestableConnectionOperation { Key = "travel-sample" };
+            var buffer = new byte[64];
+
+            var length = op.Frame(buffer, collectionsEnabled: true);
+
+            Assert.Equal("travel-sample".Length, length);
+            Assert.Equal("travel-sample", System.Text.Encoding.UTF8.GetString(buffer, 0, length));
+        }
+
+        /// <summary>
+        /// The key field carries the collection ID as well as the document ID, so a 250 byte key does
+        /// not fit once a prefix is prepended. The Key setter only checks the document ID on its own,
+        /// so this used to surface from OperationHeader.KeyLength as a bare
+        /// ArgumentOutOfRangeException from inside the write path.
+        /// </summary>
+        [Fact]
+        public void A_maximum_length_key_does_not_fit_once_prefixed()
+        {
+            var op = new TestableGet { Key = new string('k', 250), Cid = Cid };
+            var buffer = new byte[512];
+
+            var exception = Assert.Throws<InvalidArgumentException>(
+                () => op.Frame(buffer, collectionsEnabled: true));
+
+            Assert.Contains("collection ID prefix", exception.Message);
+        }
+
+        [Fact]
+        public void A_key_that_leaves_room_for_the_prefix_is_accepted()
+        {
+            //Cid 23 is one leb128 byte, so 249 + 1 is exactly the budget.
+            var op = new TestableGet { Key = new string('k', 249), Cid = Cid };
+            var buffer = new byte[512];
+
+            Assert.Equal(250, op.Frame(buffer, collectionsEnabled: true));
+        }
+
+        /// <summary>
+        /// And the full 250 is still fine when no prefix is going to be written.
+        /// </summary>
+        [Fact]
+        public void A_maximum_length_key_still_fits_without_collections()
+        {
+            var op = new TestableGet { Key = new string('k', 250), Cid = Cid };
+            var buffer = new byte[512];
+
+            Assert.Equal(250, op.Frame(buffer, collectionsEnabled: false));
+        }
+
+        /// <summary>
+        /// This is the test that matters. RequiresCollectionId defaults to true because true is the
+        /// safe answer: an operation added without a thought about framing then fails loudly instead
+        /// of silently addressing the wrong collection. So the default is deliberately not pinned -
+        /// only the opt-outs are, because an opt-out is the answer that can corrupt data.
+        ///
+        /// If this fails because you added an operation, decide which it is. Does it address a
+        /// document? Then it needs a collection ID and you should not be here. Is it a connection or
+        /// cluster level operation whose key is not a document ID? Then add it below.
+        /// </summary>
+        [Fact]
+        public void Only_connection_and_cluster_operations_opt_out_of_the_collection_id()
+        {
+            string[] expected =
+            [
+                "ClusterMapChangeNotification", // a server push, no document key
+                "Config",                       // cluster map request
+                "GetCid",                       // the key is a collection name - this resolves CIDs
+                "GetErrorMap",                  // writes no key
+                "GetManifest",                  // manifest request
+                "GetSid",                       // the key is a scope name
+                "Hello",                        // the key is a connection identifier
+                "Noop",                         // writes no key
+                "RangeScanCancel",              // writes no key, identified by scan UUID
+                "RangeScanContinue",            // writes no key, identified by scan UUID
+                "RangeScanCreate",              // writes no key, collection travels in the body
+                "SaslList",                     // mechanism negotiation
+                "SaslStart",                    // authentication, before any collection exists
+                "SaslStep",                     // authentication, before any collection exists
+                "SelectBucket"                  // the key is the bucket name
+            ];
+
+            var actual = typeof(OperationBase).Assembly.GetTypes()
+                .Where(type => typeof(OperationBase).IsAssignableFrom(type) && type != typeof(OperationBase))
+                .Where(type => type.GetProperty(nameof(OperationBase.RequiresCollectionId),
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.DeclaredOnly) is not null)
+                .Select(type => type.Name)
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// SASL is the trap worth a test of its own: HELO completes before authentication, so by the
+        /// time SaslStep runs the connection has already negotiated collections while no collection
+        /// exists. An exemption list drafted by hand had SaslStart and SaslList but not SaslStep,
+        /// which would have failed authentication on every non-TLS connection.
+        /// </summary>
+        [Fact]
+        public void Every_sasl_operation_opts_out()
+        {
+            Assert.False(new SaslStart().RequiresCollectionId);
+            Assert.False(new SaslStep().RequiresCollectionId);
+            Assert.False(new SaslList().RequiresCollectionId);
+        }
+
+        [Fact]
+        public void A_document_operation_requires_a_collection_id_by_default()
+        {
+            Assert.True(new Get<byte[]>().RequiresCollectionId);
+            Assert.True(new Set<byte[]>("bucket", Key).RequiresCollectionId);
+            Assert.True(new Delete().RequiresCollectionId);
+        }
+    }
+}

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/PacketFormatVBucketIdTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/PacketFormatVBucketIdTests.cs
@@ -28,7 +28,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Build complete packet
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -58,7 +58,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -113,7 +113,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -207,7 +207,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Full packet creation process
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -247,7 +247,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/SubDocument/MultiMutationTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/SubDocument/MultiMutationTests.cs
@@ -38,7 +38,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations.SubDocument
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
 
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             using (op.ParseCommandValues())
@@ -47,7 +47,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations.SubDocument
             }
 
             op.Reset();
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             Assert.Equal(10, op.MutateCommands.Count);
 

--- a/tests/Couchbase.UnitTests/Core/IO/Operations/VBucketIdBugFixIntegrationTests.cs
+++ b/tests/Couchbase.UnitTests/Core/IO/Operations/VBucketIdBugFixIntegrationTests.cs
@@ -29,7 +29,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act - Execute the complete packet building process
             operation.WriteExtras(builder);
-            operation.WriteKey(builder);
+            operation.WriteKey(builder, collectionsEnabled: false);
             operation.WriteBody(builder);
 
             var header = operation.CreateHeader(DataType.Json);
@@ -67,7 +67,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
                 // Act
                 operation.WriteExtras(builder);
-                operation.WriteKey(builder);
+                operation.WriteKey(builder, collectionsEnabled: false);
                 operation.WriteBody(builder);
 
                 var header = operation.CreateHeader(DataType.Json);
@@ -135,7 +135,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
 
             // Act
             operation.WriteExtras(builder2);
-            operation.WriteKey(builder2);
+            operation.WriteKey(builder2, collectionsEnabled: false);
             operation.WriteBody(builder2);
 
             var header2 = operation.CreateHeader(DataType.Json);
@@ -165,7 +165,7 @@ namespace Couchbase.UnitTests.Core.IO.Operations
                 };
 
                 operation.WriteExtras(builder);
-                operation.WriteKey(builder);
+                operation.WriteKey(builder, collectionsEnabled: false);
                 operation.WriteBody(builder);
 
                 var header = operation.CreateHeader(DataType.Json);

--- a/tests/Couchbase.UnitTests/KeyValue/LookupInResultTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/LookupInResultTests.cs
@@ -1,3 +1,4 @@
+using Couchbase.Core;
 using System.Threading.Tasks;
 using Couchbase.Core.Exceptions;
 using Couchbase.Core.Exceptions.KeyValue;
@@ -33,7 +34,7 @@ namespace Couchbase.UnitTests.KeyValue
 
             var op = new MultiLookup<byte[]>("thekey", specs);
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             op.Transcoder = new JsonTranscoder();
             op.Transcoder.Serializer = new DefaultSerializer();
@@ -70,7 +71,7 @@ namespace Couchbase.UnitTests.KeyValue
 
             var op = new MultiLookup<byte[]>("thekey", specs);
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
             op.Transcoder = new JsonTranscoder();
             op.Transcoder.Serializer = new DefaultSerializer();

--- a/tests/Couchbase.UnitTests/KeyValue/MutateInResultTests.cs
+++ b/tests/Couchbase.UnitTests/KeyValue/MutateInResultTests.cs
@@ -44,7 +44,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(responsePacket));
 
             var result = new MutateInResult(op);
@@ -70,7 +70,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             var result = new MutateInResult(op);
@@ -102,7 +102,7 @@ namespace Couchbase.UnitTests.KeyValue
                 Transcoder = new JsonTranscoder()
             };
             op.OperationBuilderPool = new DefaultObjectPool<OperationBuilder>(new OperationBuilderPoolPolicy());
-            await op.SendAsync(new Mock<IConnection>().Object);
+            await op.SendAsync(Mock.Of<IConnection>(c => c.ServerFeatures == ServerFeatureSet.Empty));
             op.Read(new FakeMemoryOwner<byte>(bytes));
 
             var result = new MutateInResult(op);


### PR DESCRIPTION
Part 4 of 4, splitting #167 — the last one. #168, #169 and #170 are all merged, so this now targets master directly and its prerequisites are satisfied: #170 supplies the CID resolution this relies on (without it this would break `GetAllReplicasAsync`), and #169 means `ServerFeatureSet.Empty` no longer conflates "supports nothing" with "we could not tell".

Rebased onto master on 2026-08-31 to clear a conflict. The conflict was not a real code clash: #170 was squash-merged, so master carried its change as one new commit while this branch still carried the original, and git saw two unrelated commits touching the same lines. Rebasing with the duplicated commit dropped replays cleanly — the diff is unchanged at 25 files, +391/−32, identical to before the rebase.

25 files, but 15 of them are a four-line override.

## Summary

Whether a KV frame carries a leb128 collection-ID prefix is a **per-connection** fact, fixed by what that connection negotiated in HELO. `WriteKey` decided it from client-side state — `Cid.HasValue` — and the two disagree in both directions:

- **prefix on a connection that never negotiated collections** — the server reads the prefix byte as part of the document ID, and the vbucket was computed by hashing the key *without* it, so the document exists but its own ID no longer maps to where it lives
- **no prefix on a connection that did** — the server reads the first byte of the document key as the collection ID

Neither is detectable at either end. Both frames are structurally valid, `keylen` honestly describes the field, and nothing in the packet says which form was intended.

## The problems

1. **The prefix decision came from client state**, not the connection.
2. **A missing collection ID went on the wire** rather than being refused.
3. **Key length was validated without the prefix.** The `Key` setter checks the document ID alone against the 250-byte limit, but the prefix shares that field — so a 250-byte key failed as a bare `ArgumentOutOfRangeException` from inside `OperationHeader.KeyLength`, deep in the write path. Java validates including the prefix.

## What to look at

`OperationBase.WriteKey` now takes the connection's negotiated state, which `SendAsync` already holds and reads for `Json` and `SnappyCompression` six lines below.

`RequiresCollectionId` defaults to **true** — the safe answer, so an operation added without a thought about framing fails loudly rather than silently addressing the wrong collection. The 15 connection- and cluster-level operations whose key isn't a document ID override it to false.

**Read the exemption test, not the 15 files.** The list is pinned by a reflection test over every `OperationBase` subclass rather than maintained by hand, because drafting it by hand had already produced a bug: `SaslStart` and `SaslList` were exempt but **`SaslStep` was not**, and since HELO completes before authentication that would have thrown on every non-TLS connection. Only the opt-outs are pinned — `true` is safe, so a new document operation needs no test change; `false` is the answer that can corrupt data.

`Observe` keeps the old client-side rule. It frames its key inside the body with an explicit length and is dead code pending removal, so it's passed `Cid.HasValue` to reproduce exactly what it did before.

## Dependencies

**#170 (the funnel) — hard.** Without it `GetPrimary` resolves no collection ID, so problem 2's throw fires on every `GetAllReplicasAsync` against a collections cluster. Hence the stacking: CI would *not* catch this, because the framing tests use mocked connections with collections off, and the coverage table that would catch it lives in #170.

**#169 (HELO) — please merge that first too.** `ServerFeatureSet.Empty` means both "the server supports nothing" and "we could not tell" until a failed HELO stops producing it, so framing keyed on it is unsafe in exactly the failed-HELO case this is meant to fix.

## Verification

2973 tests pass on net8.0 and net10.0, 11 new.

Checked by mutation: reverting `WriteKey` to `Cid.HasValue` fails both framing-polarity tests, removing `SaslStep`'s opt-out fails the exemption set, and removing the key-length check fails the maximum-length-key test.

Tests that build packets against a mocked `IConnection` now supply `ServerFeatureSet.Empty`, since the framing path reads it where the old code short-circuited past it. Collections off means their expected bytes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

