### PR TITLE
NCBC-4288: Install fit-cli from the latest channel, not ci

### DIFF
--- a/.github/workflows/fit-testing-dotnet.yml
+++ b/.github/workflows/fit-testing-dotnet.yml
@@ -28,7 +28,7 @@ on:
         description: fit-cli install channel ("latest" or "ci").
         required: false
         type: string
-        default: ci
+        default: latest
       performer_tag:
         description: >-
           Tag of the ghcr.io/couchbase/dotnet-fit-performer image to test. Defaults to the branch
@@ -79,4 +79,9 @@ jobs:
       preset: ${{ vars.FIT_CLI_PRESET || inputs.preset || 'op-multi-lite' }}
       collect_extra_diagnostics: ${{ inputs.collect_extra_diagnostics == '' && true || inputs.collect_extra_diagnostics }}
       performer: dotnet-fit-performer:${{ needs.performer-tag.outputs.tag }}
-      channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'ci' }}
+      # 'latest', not 'ci': the ci channel went stale at a 2026-08-10 build and stopped
+      # picking up fixes, which killed Capella cluster allocation from 2026-08-21 - see
+      # NCBC-4288. Note the input default above does NOT apply to the
+      # nightly: scheduled runs supply no inputs and workflow_dispatch defaults only apply to
+      # dispatches, so this literal is what the nightly actually uses.
+      channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'latest' }}


### PR DESCRIPTION
[NCBC-4288](https://couchbasecloud.atlassian.net/browse/NCBC-4288)

## Problem

The nightly installs fit-cli from the `ci` channel, which has been frozen at a **2026-08-10** build. Since 2026-08-21 that build can no longer configure the Capella deployer, so `op-capella-sit-lite` and `op-capella-pe-sit-lite` fail about two minutes in, before a cluster is allocated:

```
cbdinocluster init left the Capella (cloud) deployer disabled on the instance,
so situational tests can't allocate clusters
```

cbdinocluster receives no Capella credentials at all — `Enabled: false` with every field blank.

## Why it's the channel

Comparing SDKs on the same night isolates it:

| SDK | channel | fit-cli built | Capella |
| --- | --- | --- | --- |
| Java (`couchbase-jvm-clients`) | `latest` | 2026-08-25 | passes |
| Go (`gocb`) | `ci` | 2026-08-10 | fails since 08-21 |
| .NET | `ci` | 2026-08-10 | fails since 08-21 |

The two that broke are exactly the two on `ci`, and both broke the same night. `ci` didn't regress — it stopped moving and never received whatever fix `latest` has.

Worth noting the trap: the `ci` binary is byte-identical on a green .NET night (08-20) and a red one (08-25), so comparing nights *within* one SDK suggests fit-cli isn't the variable. It is — by omission. Only comparing *across* SDKs shows it.

## Why we were on `ci` at all

All three callers use the same expression; Java just omits one fallback:

```yaml
# .NET / Go   channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'ci' }}
# Java        channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel }}
```

On a **scheduled** run `inputs` is empty and `workflow_dispatch` defaults don't apply, so .NET and Go fall through to the literal `'ci'` while Java resolves to empty and the installer picks `latest`. **The `default: ci` on the input never applied to the nightly** — only to manual dispatch. The comment in the diff records that, since it's genuinely surprising.

## Verified

Dispatched `op-capella-sit-lite` from this branch: fit-cli `a9682b67` built 2026-08-26, **zero occurrences of the deployer error**, cluster allocated, suite ran. The one failure was `CbDinoRebalanceTest.horizontalScaleInFrom4To3Nodes` with `cbdinocluster command 'buckets list …' failed with exit code 2` — harness-level, and already a known flake in the nightly baseline.

## Scope

Interim. The open question is which channel nightlies are *meant* to use — three SDKs currently disagree and `ci` hasn't published in over two weeks. That needs a conversation with the fit-cli team, after which we stay on `latest` or go back. Reverting is a one-line change.

Also changes which fit-cli every nightly runs, so an unfamiliar failure in the next run is worth suspecting the tool before the SDK.

`gocb` has the same defect and is still on `ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NCBC-4288]: https://couchbasecloud.atlassian.net/browse/NCBC-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ