### PR TITLE
NCBC-4281: Publish to NuGet via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,25 @@ jobs:
             echo "include_otel=$INCLUDE_OTEL"
           } >> "$GITHUB_OUTPUT"
 
+      # NUGET_USER is needed by every path out of this workflow: a smoke dispatch mints a
+      # key in smoke-summary, while a publish dispatch and a release event mint one in
+      # publish-nuget. So it is checked unconditionally, and here rather than at those
+      # steps - a misconfiguration costs ten seconds instead of three OS builds and a
+      # Windows pack. The message carries the rule the nuget.org docs do not state.
+      - name: Verify NUGET_USER is configured
+        shell: bash
+        env:
+          NUGET_USER: ${{ secrets.NUGET_USER }}
+        run: |
+          if [ -z "$NUGET_USER" ]; then
+            echo "::error::NUGET_USER is not set. It must hold the nuget.org username of the" \
+                 "person who CREATED the trusted publishing policy, not the organization that" \
+                 "owns it. Passing the organization name fails the token exchange with" \
+                 "HTTP 401 'No matching trust policy owned by user'." >&2
+            exit 1
+          fi
+          echo "✓ NUGET_USER is set"
+
       # Constrains what the publish jobs are allowed to build. `pack` signs, and
       # publish-nuget ships, whatever `version_tag` resolves to - and the semver
       # check above is satisfied by a *branch* named 3.9.7 just as well as by a tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,13 +299,30 @@ jobs:
             artifacts/*.nupkg
             artifacts/*.snupkg
 
+  # Publishes via NuGet Trusted Publishing (OIDC) rather than a stored API key.
+  # nuget.org holds a trusted publishing policy naming this repository owner, this
+  # repository, and this workflow file - so renaming release.yml breaks publishing,
+  # and no other workflow file in this repo can obtain a key. The policy is
+  # configured in the nuget.org UI (username -> Trusted Publishing), and is owned
+  # by the `couchbase` organization because that is the only nuget.org account that
+  # owns all three package IDs. A policy covers every package its owner owns.
+  #
+  # NUGET_USER is not a credential: it is the nuget.org username of the person who
+  # *created* the policy, which is not the same as the organization that owns it.
+  # Passing the org name gets HTTP 401 "No matching trust policy owned by user" -
+  # verified on run 33427080103. That also means the policy is tied to one person's
+  # account: if they leave the org it goes inactive, and releases stop.
+  #
+  # Nothing else in this repo records that the policy exists, so if publishing starts
+  # failing with no code change, check that it is still active in the nuget.org UI.
   publish-nuget:
     name: Publish to NuGet
     runs-on: ubuntu-latest
     needs: [validate-inputs, pack]
     if: needs.validate-inputs.outputs.publish == 'true'
-    env:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    permissions:
+      id-token: write   # required to mint the GitHub OIDC token for nuget.org
+      contents: read
     steps:
       - name: Download Packages Artifact
         uses: actions/download-artifact@v4
@@ -319,11 +336,21 @@ jobs:
           dotnet-version: 10.0.x
           cache: false
 
+      # Deliberately the last step before the push: the key nuget.org issues is
+      # valid for one hour, and all three pushes must complete inside it.
+      - name: NuGet login (OIDC -> short-lived API key)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish packages and symbols to NuGet
         shell: bash
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
         run: |
           if [ -z "$NUGET_API_KEY" ]; then
-            echo "NUGET_API_KEY secret is required to publish." >&2
+            echo "NuGet login did not return an API key." >&2
             exit 1
           fi
           shopt -s nullglob
@@ -418,6 +445,30 @@ jobs:
           aws s3 rm "s3://${S3_BUCKET}/${KEY}" \
             || echo "⚠ Could not delete smoke object (role may lack s3:DeleteObject) — harmless, remove manually."
 
+      # The NuGet equivalent of the S3 round-trip above. Obtaining the key is a
+      # separate step from pushing, so publish=false can prove the whole trust
+      # path - OIDC token, policy match, key issuance - without publishing. This
+      # is what a stored NUGET_API_KEY could never do: it was only ever exercised
+      # by a real release, so an expired or wrongly scoped key stayed invisible
+      # until the release was already half done.
+      - name: Smoke test NuGet publish access (OIDC)
+        id: nuget_login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Verify NuGet key was issued
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
+        run: |
+          # Never echo the key itself, only whether one came back.
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "NuGet login returned no API key." >&2
+            exit 1
+          fi
+          echo "✓ nuget.org issued a short-lived API key for this workflow."
+
       - name: Summary
         shell: bash
         run: |
@@ -426,7 +477,8 @@ jobs:
             echo ""
             echo "- Tag: \`${{ needs.validate-inputs.outputs.tag }}\`"
             echo "- Version: \`${{ needs.validate-inputs.outputs.version }}\`"
-            echo "- AWS S3 publish access: ✅ verified via OIDC role \`SDK_GHA\`"
+            echo "- AWS S3 publish access (packages bucket): ✅ verified via OIDC role \`SDK_GHA\`"
+            echo "- NuGet publish access: ✅ short-lived key issued via Trusted Publishing"
             echo "- Packages built:"
             for pkg in ./artifacts/*.nupkg; do echo "  - \`$(basename "$pkg")\`"; done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,17 @@ jobs:
       include_main: ${{ steps.compute.outputs.include_main }}
       include_di: ${{ steps.compute.outputs.include_di }}
       include_otel: ${{ steps.compute.outputs.include_otel }}
+      sha: ${{ steps.verify_ref.outputs.sha }}
     steps:
+      # Full history and all tags: verify_ref below has to resolve the tag and test
+      # its reachability from the release branches.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false
+
       - id: compute
         name: Compute tag, version, and flags
         shell: bash
@@ -97,6 +107,65 @@ jobs:
             echo "include_otel=$INCLUDE_OTEL"
           } >> "$GITHUB_OUTPUT"
 
+      # Constrains what the publish jobs are allowed to build. `pack` signs, and
+      # publish-nuget ships, whatever `version_tag` resolves to - and the semver
+      # check above is satisfied by a *branch* named 3.9.7 just as well as by a tag.
+      # Tags are not covered by any ruleset today, so without this an untouched
+      # release.yml will build and sign an arbitrary commit for anyone who can push.
+      #
+      # Two properties are established here:
+      #   - the ref is a real tag, not a branch that happens to look like a version
+      #   - that tag points into a long-lived release branch, so the code being
+      #     released is code that landed on a shared branch
+      #
+      # The second is only as strong as the review rules on those branches: if
+      # RELEASE_BRANCHES can be pushed to without approval, this proves provenance
+      # but not review. It also cannot defend against a modified copy of this file
+      # dispatched from another branch, since the check travels with the file. It
+      # closes the no-edit path; a ruleset on tag creation and a protected
+      # environment on the publish jobs are what make it a boundary.
+      - id: verify_ref
+        name: Verify the release ref is a tag on a release branch
+        shell: bash
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+          PUBLISH: ${{ steps.compute.outputs.publish }}
+          # Branches a release tag is allowed to point into. Every 3.x release to
+          # date is on master; 3.10 is the next-minor branch. Add a branch here, in
+          # a reviewed PR, before releasing from it.
+          RELEASE_BRANCHES: master 3.10
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            if [ "$PUBLISH" = "true" ]; then
+              echo "::error::No tag '$TAG' exists. version_tag must name an existing" \
+                   "tag; a branch or an unpushed version is not enough to release." >&2
+              exit 1
+            fi
+            # Smoke runs legitimately name a version that has not been tagged yet.
+            echo "::notice::No tag '$TAG' yet - smoke run, provenance check skipped."
+            exit 0
+          fi
+
+          SHA="$(git rev-parse "refs/tags/$TAG^{commit}")"
+
+          for branch in $RELEASE_BRANCHES; do
+            if ! git rev-parse -q --verify "refs/remotes/origin/$branch^{commit}" >/dev/null; then
+              echo "::error::RELEASE_BRANCHES names origin/$branch, which does not exist." >&2
+              exit 1
+            fi
+            if git merge-base --is-ancestor "$SHA" "refs/remotes/origin/$branch"; then
+              echo "✓ tag $TAG is $SHA, reachable from origin/$branch"
+              echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "::error::Tag $TAG ($SHA) is not reachable from any of: $RELEASE_BRANCHES." \
+               "A release must be built from a commit that landed on a release branch." >&2
+          exit 1
+
   build-and-test:
     name: Build & Test (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -119,11 +188,30 @@ jobs:
           ref: master
           fetch-depth: 0
 
-      - name: Checkout tag
+      # checkout treats an empty ref as "the default branch", so a missing sha would
+      # quietly build master and ship it under the release version rather than
+      # failing. validate-inputs cannot reach publish == 'true' without resolving
+      # one, but this is the step that would go wrong if that ever stopped holding,
+      # and no publish=false smoke run exercises the checkout below.
+      - name: Require a validated release commit
+        if: needs.validate-inputs.outputs.publish == 'true'
+        shell: bash
+        env:
+          SHA: ${{ needs.validate-inputs.outputs.sha }}
+        run: |
+          if [ -z "$SHA" ]; then
+            echo "::error::validate-inputs resolved no release commit; refusing to build." >&2
+            exit 1
+          fi
+          echo "Building release commit $SHA"
+
+      # The SHA verify_ref resolved, not the tag name: a tag can be moved between
+      # validation and here, and only one of those two reads would see it.
+      - name: Checkout validated release commit
         if: needs.validate-inputs.outputs.publish == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-inputs.outputs.tag }}
+          ref: ${{ needs.validate-inputs.outputs.sha }}
           fetch-depth: 0
 
       - name: Setup .NET SDK
@@ -168,11 +256,30 @@ jobs:
           ref: master
           fetch-depth: 0
 
-      - name: Checkout tag
+      # checkout treats an empty ref as "the default branch", so a missing sha would
+      # quietly build master and ship it under the release version rather than
+      # failing. validate-inputs cannot reach publish == 'true' without resolving
+      # one, but this is the step that would go wrong if that ever stopped holding,
+      # and no publish=false smoke run exercises the checkout below.
+      - name: Require a validated release commit
+        if: needs.validate-inputs.outputs.publish == 'true'
+        shell: bash
+        env:
+          SHA: ${{ needs.validate-inputs.outputs.sha }}
+        run: |
+          if [ -z "$SHA" ]; then
+            echo "::error::validate-inputs resolved no release commit; refusing to build." >&2
+            exit 1
+          fi
+          echo "Building release commit $SHA"
+
+      # The SHA verify_ref resolved, not the tag name: a tag can be moved between
+      # validation and here, and only one of those two reads would see it.
+      - name: Checkout validated release commit
         if: needs.validate-inputs.outputs.publish == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-inputs.outputs.tag }}
+          ref: ${{ needs.validate-inputs.outputs.sha }}
           fetch-depth: 0
 
       - name: Setup .NET SDK


### PR DESCRIPTION
[NCBC-4281](https://couchbasecloud.atlassian.net/browse/NCBC-4281)

> **Draft until two things exist outside this repo.** See *Before merging* below — merging early makes every `publish=false` smoke run fail.

## Problem

`NUGET_API_KEY` was last rotated **2026-07-15** and the 3.9.5 publish warned it expires in 10 days, so it has been dead since around **2026-08-20**. 3.9.6 is dated 2026-09-02.

It is also the one credential a green smoke run never exercises, because `publish-nuget` is gated on `publish == 'true'`. An expired or wrongly scoped key stays invisible until the release is half done — tag pushed, packages built and signed.

And it is a long-lived secret readable by a workflow on any branch, tied to one person's nuget.org account.

## Change 1 — Trusted Publishing

`publish-nuget` gets `id-token: write` and a `NuGet/login@v1` step **immediately before** the push loop. nuget.org issues a key valid for one hour, and one OIDC token yields exactly one key, so all three pushes share it — hence the placement.

`smoke-summary` gets the same login plus a "did a key come back" check. A `publish=false` run now proves the whole trust path — OIDC token, policy match, key issuance — without publishing. That is the NuGet equivalent of the S3 round-trip already there.

## Change 2 — constrain what a release is allowed to build

While adding the above I checked who can actually run this workflow: **27 accounts** have push access (14 admin, 10 maintain, 3 bots), and the `master` ruleset that would require review is configured but `"enforcement": "disabled"`. Tags are covered by no ruleset at all.

`validate-inputs` only checked that `version_tag` *looks* like a semver, then handed it to `actions/checkout` — which resolves a branch just as happily as a tag. So an untouched `release.yml` would build, sign with `NETSDK_SIGNKEY`, and publish an arbitrary commit for anyone who can push a ref. That path predates this PR. It is worth closing anyway, because the issued key can push releases of the packages in the policy's scope, and nothing in this repo records that the policy exists.

So `validate-inputs` now resolves the ref up front and requires it to be:

- a **real tag**, not a branch that happens to look like a version
- pointing at a commit **reachable from a release branch** (`master` or `3.10`)

and the publish jobs check out **that SHA**, not the tag name, so a tag moved between validation and build can't slip through. Smoke runs skip the check — they legitimately name a version nobody has tagged yet.

Verified against the real repo:

| `version_tag` | publish | result |
| --- | --- | --- |
| `3.9.5` | true | ✓ resolves to `930cad057`, reachable from `origin/master` |
| `3.9.6` | true | ✗ no such tag |
| `3.9.6` | false | ✓ skipped, smoke run |
| `ps9` | true | ✗ real tag, not reachable from `master` or `3.10` |
| branch `9.9.9` | true | ✗ not a tag |

`3.10` is in `RELEASE_BRANCHES` because it is a live branch with commits not on master; an ancestor-of-master-only check would break the first 3.10 release. Adding a branch there is a reviewed edit to this file, which is the intended friction.

## What this deliberately does not fix

Dispatching a *modified* copy of `release.yml` from a branch defeats the check, because the check travels with the file — and the nuget policy matches on repository and workflow filename, not on ref. Closing that needs two repo-admin changes, neither of which belongs in this PR:

1. Enable the existing `master` ruleset, and add one restricting creation of `[0-9]*.[0-9]*.[0-9]*` tags.
2. A protected environment on the publish jobs — a deployment branch policy is evaluated against `github.ref`, so it is the only control that rejects a run dispatched from an attacker's branch. It is also the only thing that would stop an arbitrary branch from reading `NETSDK_SIGNKEY`, which is the long-lived secret that stays valuable however we publish.

Follow-up ticket to come.

## Before merging

1. A trusted publishing policy on nuget.org, owned by the **`couchbase` organization** — the only account that owns all three package IDs. Repository Owner `couchbase`, Repository `couchbase-net-client`, Workflow File `release.yml`, Environment blank. Scope it to **push only new versions** of the three package IDs explicitly, not a `Couchbase*` glob and not "push new packages and versions" — all three IDs already exist, so a release never needs to create one.
2. A `NUGET_USER` repo secret holding the nuget.org username of the person who **created** the policy — not the organization that owns it. Passing the org name returns HTTP 401 `No matching trust policy owned by user` (run 33427080103). Not a credential; it tells nuget.org whose policies to check.

Then dispatch this branch with `publish=false` and `version_tag=3.9.5` to smoke the whole thing before merging.

`NUGET_API_KEY` stays in place for now; reverting is a one-line change back to `secrets.NUGET_API_KEY`. Drop it once 3.9.6 has shipped on OIDC.


[NCBC-4281]: https://couchbasecloud.atlassian.net/browse/NCBC-4281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

