### PR TITLE
NCBC-4291: Fix cross-Cluster lost-cleanup interference from a static field

### DIFF
--- a/src/Couchbase/Client/Transactions/Cleanup/LostTransactions/LostTransactionManager.cs
+++ b/src/Couchbase/Client/Transactions/Cleanup/LostTransactions/LostTransactionManager.cs
@@ -29,8 +29,17 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
         // generating function for the value under contention when it doesn't actually end up doing an insert
         // because someone else got there first.   The Lazy<T> insures the actual initialization of the lazy is
         // only done once.   You can see tests fail when this isn't the case.
-        private static readonly ConcurrentDictionary<Keyspace, Lazy<PerCollectionCleaner>>
-            CollectionsToClean = new();
+        //
+        // This must be an instance field, not static: one LostTransactionManager exists per Cluster (see
+        // Transactions.cs), and DisposeAsync() below tears down every PerCollectionCleaner in this dictionary.
+        // A static dictionary made that cross-instance: closing any one Cluster's Transactions (e.g. a
+        // short-lived connection opened just to run a test) would GetOrAdd-reuse another still-open Cluster's
+        // cleaner for a shared keyspace, then dispose it and remove its client record out from under that
+        // other, still-active Cluster - silently killing its lost cleanup with no error anywhere. This is
+        // exactly the mechanism behind lost-cleanup entries that are never picked up despite the cleaner
+        // logging clean, complete passes throughout.
+        private readonly ConcurrentDictionary<Keyspace, Lazy<PerCollectionCleaner>>
+            _collectionsToClean = new();
 
         private readonly ICluster _cluster;
         private readonly TimeSpan _cleanupWindow;
@@ -39,16 +48,16 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
 
         public string ClientUuid { get; }
         public ICleanupTestHooks TestHooks { get; set; } = DefaultCleanupTestHooks.Instance;
-        public List<Keyspace> CollectionsBeingCleaned => CollectionsToClean.Keys.ToList();
+        public List<Keyspace> CollectionsBeingCleaned => _collectionsToClean.Keys.ToList();
 
         public void AddCollection(ICouchbaseCollection collection)
         {
             // we need to add _only_ if the collection isn't already being cleaned...
-            _logger.LogInformation($"AddCollection called, currently cleaning {CollectionsToClean.Count} collections");
+            _logger.LogInformation($"AddCollection called, currently cleaning {_collectionsToClean.Count} collections");
             // We already hold a live collection here, so seed the cache to avoid re-resolving.
             // Force the lazy's Value so the cleaner is actually created.
             var keyspace = new Keyspace(collection);
-            _ = CollectionsToClean.GetOrAdd(keyspace,
+            _ = _collectionsToClean.GetOrAdd(keyspace,
                 ks => new Lazy<PerCollectionCleaner>(() => CleanerForCollection(ks, startDisabled: false, resolved: collection))).Value;
         }
 
@@ -56,7 +65,7 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
         // loop. Synchronous — no resolution, no blocking.
         private void RegisterCollection(Keyspace keyspace)
         {
-            _ = CollectionsToClean.GetOrAdd(keyspace,
+            _ = _collectionsToClean.GetOrAdd(keyspace,
                 ks => new Lazy<PerCollectionCleaner>(() => CleanerForCollection(ks, startDisabled: false))).Value;
         }
 
@@ -80,7 +89,7 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
                 _logger.LogDebug("Registering configured cleanup collection {keyspace}", keyspace);
                 RegisterCollection(keyspace);
             }
-            _logger.LogDebug($"LostTransactionManager {ClientUuid} started with {CollectionsToClean.Count} collections to be cleaned");
+            _logger.LogDebug($"LostTransactionManager {ClientUuid} started with {_collectionsToClean.Count} collections to be cleaned");
         }
 
         public void Start()
@@ -99,9 +108,9 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
         private async Task RemoveClientEntries()
         {
 
-            while (!CollectionsToClean.IsEmpty)
+            while (!_collectionsToClean.IsEmpty)
             {
-                var buckets = CollectionsToClean.ToArray();
+                var buckets = _collectionsToClean.ToArray();
                 List<ValueTask> disposeTasks = new();
                 // populate disposeTasks with all the DisposeAsync tasks first.
                 foreach (var bkt in buckets)
@@ -125,7 +134,7 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
                     // now remove them from the CollectionsToClean Dictionary.
                     foreach (var bkt in buckets)
                     {
-                        var success = CollectionsToClean.TryRemove(bkt.Key, out _);
+                        var success = _collectionsToClean.TryRemove(bkt.Key, out _);
                         _logger.LogDebug(
                             "Removed cleaner '{bkt}' from collections to clean {status}", bkt.Value,
                             success ? "successfully" : "unsuccessfully");
@@ -147,10 +156,10 @@ namespace Couchbase.Client.Transactions.Cleanup.LostTransactions
         // dictionary entry (the cleaner stops its own timer).
         private void RemoveFromCleanupSet(Keyspace keyspace)
         {
-            if (CollectionsToClean.TryRemove(keyspace, out _))
-            {
-                _logger.LogInformation("Removed collection {keyspace} from the cleanup set (not found)", keyspace);
-            }
+            var success = _collectionsToClean.TryRemove(keyspace, out _);
+            _logger.LogInformation(
+                "Collection {keyspace} reported as not found by server; removed from cleanup set {status}", keyspace,
+                success ? "successfully" : "unsuccessfully");
         }
     }
 }

--- a/tests/Couchbase.UnitTests/Transactions/LostTransactionManagerTests.cs
+++ b/tests/Couchbase.UnitTests/Transactions/LostTransactionManagerTests.cs
@@ -51,4 +51,32 @@ public class LostTransactionManagerTests
         Assert.Equal(before, manager.CollectionsBeingCleaned.Count);
         await manager.DisposeAsync();
     }
+
+    /// <summary>
+    /// Regression test: <c>CollectionsToClean</c> was previously
+    /// <c>static</c>, shared by every <see cref="LostTransactionManager"/>
+    /// in the process even though one is created per Cluster. Disposing any one manager (e.g. a short-lived
+    /// Cluster opened just for a single test/operation) would tear down and remove another still-active
+    /// Cluster's <see cref="PerCollectionCleaner"/> for a shared keyspace - silently killing that other Cluster's lost
+    /// cleanup with no error anywhere. This is the mechanism behind lost-cleanup entries that are never
+    /// picked up despite the cleaner logging clean, complete passes throughout.
+    /// </summary>
+    [Fact]
+    public async Task DisposingOneManager_DoesNotAffectAnotherManagers_RegisteredCollections()
+    {
+        var keyspace = new Keyspace("bucket", "scope", "collection");
+
+        var manager1 = Create(new List<Keyspace> { keyspace });
+        var manager2 = Create(new List<Keyspace> { keyspace });
+
+        Assert.Contains(keyspace, manager1.CollectionsBeingCleaned);
+        Assert.Contains(keyspace, manager2.CollectionsBeingCleaned);
+
+        await manager2.DisposeAsync();
+
+        // manager2 disposing must not reach into manager1's (separate) set of collections being cleaned.
+        Assert.Contains(keyspace, manager1.CollectionsBeingCleaned);
+
+        await manager1.DisposeAsync();
+    }
 }


### PR DESCRIPTION
LostTransactionManager.CollectionsToClean was `static`, shared by every LostTransactionManager in the process, even though exactly one is created per Cluster (see Transactions.cs). Two Cluster instances registering cleanup for the same keyspace would GetOrAdd-reuse a single, shared PerCollectionCleaner. Disposing either Cluster's Transactions instance (e.g. a short-lived connection opened just for one operation) then tore down and removed that shared cleaner's client record - silently killing lost cleanup for the *other*, still-active Cluster with no error anywhere.

This was found via FIT: LostCleanupForSDKIntegrationTest and LostTxnsCleanupTest intermittently fail because a forced-expired ATR entry is never picked up, even though the cleaner's own logs show it completing full, clean scan passes throughout the test's wait window - consistent with the cleaner responsible for that keyspace having been disposed by an unrelated connection's teardown partway through the test class (which does open extra per-test connections with cleanup enabled alongside the shared one, matching the "2 simultaneously connected Cluster instances" diagnostic warning seen in the same test runs).

Fix: make CollectionsToClean an instance field, so each Cluster's LostTransactionManager owns and disposes only its own cleaners. Added DisposingOneManager_DoesNotAffectAnotherManagers_RegisteredCollections, verified to fail against the old `static` field and pass with this fix.

Change-Id: I4a302fdc3388aebfdf431e28e6187942dadd7320