### PR TITLE
CI: run unit tests on release branch pushes, and let FIT choose the server version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,19 @@ on:
   push:
     branches:
       - master
+      # Release branches ("3.10") and patch branches ("3.9.5"). These take direct pushes -
+      # chiefly a merge from master to bring the branch up to date - which no pull_request
+      # event covers, so without these they would land untested.
+      #
+      # Deliberately narrow rather than '*', which a6802f287 removed because a branch with an
+      # open PR then runs everything twice, once for push and once for pull_request. Release
+      # branches are only ever PR targets, never PR heads, so they cannot double-run.
+      #
+      # These are GitHub filter patterns, not regexes: '+' means one or more of the preceding
+      # character, and '.' is a literal dot. Both patterns are needed because a pattern must
+      # match the whole ref, so the two-part one does not match "3.9.5".
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/fit-testing-dotnet.yml
+++ b/.github/workflows/fit-testing-dotnet.yml
@@ -37,6 +37,15 @@ on:
           pull the image. Use "main" to test master's SDK from a branch.
         required: false
         type: string
+      env_override:
+        description: >-
+          Overrides applied to fit-cli's environments.json5, as comma-separated <path>=<value>
+          pairs. Chiefly useful for testing a feature against a server the presets do not default
+          to, e.g. "defaults.clusterVersion=8.1.0-2710". Only meaningful for presets that deploy
+          the cluster themselves (the on-prem ones) — Capella presets take their version from
+          Capella, and ignore it.
+        required: false
+        type: string
 
 permissions:
   id-token: write   # required for GitHub OIDC
@@ -85,3 +94,6 @@ jobs:
       # nightly: scheduled runs supply no inputs and workflow_dispatch defaults only apply to
       # dispatches, so this literal is what the nightly actually uses.
       channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'latest' }}
+      # Empty on the nightly, which passes no inputs — so the nightly keeps the presets' own
+      # default server version.
+      env_override: ${{ inputs.env_override }}


### PR DESCRIPTION
Two independent CI workflow fixes, kept out of the feature PRs they were found from.

## 1. Run the unit tests on pushes to release branches

The gate ran on pushes to `master` and on pull requests against any base — but on nothing else. A release branch also takes **direct pushes** that no `pull_request` event covers, chiefly a merge from master to bring the branch up to date, and those were landing untested.

Not hypothetical: bringing `3.10` up to date with master today ([f352f1a74](https://github.com/couchbase/couchbase-net-client/commit/f352f1a74)) was a merge pushed straight to the branch, and it ran no CI at all. It merged clean and the suite passes, but only because it was checked locally.

```yaml
on:
  push:
    branches:
      - master
      - '[0-9]+.[0-9]+'        # 3.10
      - '[0-9]+.[0-9]+.[0-9]+' # 3.9.5
  pull_request:
  workflow_dispatch:
```

**Both patterns are needed** — a filter pattern has to match the whole ref, so `[0-9]+.[0-9]+` does not match `3.9.5`. **These are GitHub filter patterns, not regexes**: `+` means one or more of the preceding character and `.` is a literal dot, so `3.10` matches and `dk/ncbc-4272` does not.

**Narrow rather than `'*'`**, which a6802f287 removed because a branch with an open PR then runs everything twice, once for `push` and once for `pull_request`. That does not come back here: release branches are only ever PR *targets*, never PR *heads*.

This does not widen the PR case. `pull_request:` already has no branch filter, so PRs into `master`, `3.10` or an `X.Y.Z` branch have always run the full four-OS matrix. The nightly is untouched and stays master-only: `nightly-unit-tests.yml` is `schedule:` + `workflow_dispatch:`, and GitHub runs `schedule` only on the default branch.

**Caveat:** a `push` event uses the workflow file as it exists on the pushed commit, so `3.10` gains this only once this commit reaches it, at the next master→3.10 sync — and that sync push is itself the last one not covered. Branches cut from master after this lands have it from the start.

## 2. Let FIT runs choose the server version

`fit-testing-dotnet.yml` could only test whatever server version the presets default to. It calls the shared fit-cli workflow, which builds the `fit run preset` command line itself, and a `uses:` caller can only supply declared inputs — so no change on our side could reach it.

That blocks verifying any feature needing a server newer than the preset default. Score fusion ([#173](https://github.com/couchbase/couchbase-net-client/pull/173)) was the case in point: below 8.1 every test in the driver's `ScoreFusionTest` skips, so a run against the default proves nothing. It needed a throwaway workflow on its own branch to get an answer.

[couchbaselabs/fit-cli#36](https://github.com/couchbaselabs/fit-cli/pull/36) has since added an `env_override` input to the shared workflow, so the caller can now express it. This adds the passthrough:

```
preset:       op-onprem-func-lite
env_override: defaults.clusterVersion=8.1.0-2710
```

Verified in anger before this PR existed — [run 33535906444](https://github.com/couchbase/couchbase-net-client/actions/runs/33535906444) is an ordinary dispatch using it.

`env_override` is declared in the shared workflow's `workflow_call` block, not just `workflow_dispatch`, which is what makes a `uses:` passthrough possible at all. It defaults to `""`, and the nightly supplies no inputs, so the nightly keeps deploying the presets' own default version. It only bites for presets that deploy the cluster themselves — Capella presets take their version from Capella and ignore it.

Once this lands, `throwaway-fit-8_1.yml` and the `dk/fit-8_1-throwaway` branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
