### PR TITLE
NCBC-4292: Fix circuit breaker reset and give each node its own

### DIFF
--- a/fit/Couchbase.FitPerformer/PerformerService.cs
+++ b/fit/Couchbase.FitPerformer/PerformerService.cs
@@ -154,7 +154,12 @@ namespace Couchbase.FitPerformer
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkCollectionQueryIndexManagement);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkSearchIndexManagement);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkKv);
-                response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkCircuitBreakers);
+                // SdkCircuitBreakers is deliberately not declared. The driver's CircuitBreakerTest
+                // asserts behaviour .NET does not implement - it probes a half-open circuit with the
+                // next user operation rather than a dedicated canary - so declaring the capability
+                // only produces a permanently red suite. Java, Scala and Kotlin declare it and are
+                // then excluded from those tests by name; Go and Python do not declare it at all,
+                // and Python wraps the C++ core, so the same is true there. See NCBC-4292.
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkKvRangeScan);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.SdkQuery);
                 response.SdkImplementationCaps.Add(Grpc.Protocol.Sdk.Caps.WaitUntilReady);

--- a/fit/Couchbase.FitPerformer/Utils/ClusterConnection.cs
+++ b/fit/Couchbase.FitPerformer/Utils/ClusterConnection.cs
@@ -108,21 +108,18 @@ namespace Couchbase.FitPerformer.Utils
                 {
                     var protoCbConfig = request.ClusterConfig.CircuitBreakerConfig;
                     var circuitBreakerConfig = new CircuitBreakerConfiguration();
-                    if (protoCbConfig.Query != null)
-                    {
-                        //Since the .NET SDK uses 1 global CircuitBreakerConfiguration for all Nodes' CircuitBreaker to use,
-                        //it can only accept 1 config from the driver and any subsequently processed one will overwrite the previous.
-                        //If this changes in the future and the SDK handles 1 Config per Service, the following lines can be adapted
-                        //to correctly apply the parsed config to each service.
-                        if (protoCbConfig.Query != null) ApplyCircuitBreakerConfig(protoCbConfig.Query, circuitBreakerConfig);
-                        if (protoCbConfig.Kv != null) ApplyCircuitBreakerConfig(protoCbConfig.Kv, circuitBreakerConfig);
-                        if (protoCbConfig.Search != null) ApplyCircuitBreakerConfig(protoCbConfig.Search, circuitBreakerConfig);
-                        if (protoCbConfig.Analytics != null) ApplyCircuitBreakerConfig(protoCbConfig.Analytics, circuitBreakerConfig);
-                        if (protoCbConfig.Backup != null) ApplyCircuitBreakerConfig(protoCbConfig.Backup, circuitBreakerConfig);
-                        if (protoCbConfig.Eventing != null) ApplyCircuitBreakerConfig(protoCbConfig.Eventing, circuitBreakerConfig);
-                        if (protoCbConfig.Manager != null) ApplyCircuitBreakerConfig(protoCbConfig.Manager, circuitBreakerConfig);
-                        if (protoCbConfig.View != null) ApplyCircuitBreakerConfig(protoCbConfig.View, circuitBreakerConfig);
-                    }
+                    //Since the .NET SDK uses 1 global CircuitBreakerConfiguration for all Nodes' CircuitBreaker to use,
+                    //it can only accept 1 config from the driver and any subsequently processed one will overwrite the previous.
+                    //If this changes in the future and the SDK handles 1 Config per Service, the following lines can be adapted
+                    //to correctly apply the parsed config to each service.
+                    if (protoCbConfig.Query != null) ApplyCircuitBreakerConfig(protoCbConfig.Query, circuitBreakerConfig);
+                    if (protoCbConfig.Kv != null) ApplyCircuitBreakerConfig(protoCbConfig.Kv, circuitBreakerConfig);
+                    if (protoCbConfig.Search != null) ApplyCircuitBreakerConfig(protoCbConfig.Search, circuitBreakerConfig);
+                    if (protoCbConfig.Analytics != null) ApplyCircuitBreakerConfig(protoCbConfig.Analytics, circuitBreakerConfig);
+                    if (protoCbConfig.Backup != null) ApplyCircuitBreakerConfig(protoCbConfig.Backup, circuitBreakerConfig);
+                    if (protoCbConfig.Eventing != null) ApplyCircuitBreakerConfig(protoCbConfig.Eventing, circuitBreakerConfig);
+                    if (protoCbConfig.Manager != null) ApplyCircuitBreakerConfig(protoCbConfig.Manager, circuitBreakerConfig);
+                    if (protoCbConfig.View != null) ApplyCircuitBreakerConfig(protoCbConfig.View, circuitBreakerConfig);
 
                     clusterOptions.CircuitBreakerConfiguration = circuitBreakerConfig;
                 }

--- a/src/Couchbase/Core/CircuitBreakers/CircuitBreaker.cs
+++ b/src/Couchbase/Core/CircuitBreakers/CircuitBreaker.cs
@@ -88,8 +88,11 @@ namespace Couchbase.Core.CircuitBreakers
         public void Reset()
         {
             Interlocked.Exchange(ref _state, (int) CircuitBreakerState.Closed);
-            _failedCount = Interlocked.Exchange(ref _failedCount, 0);
-            _totalCount = Interlocked.Exchange(ref _totalCount, 0);
+            // Exchange returns the *previous* value, so assigning it back restored the very counts
+            // the reset was meant to clear. A circuit that recovered kept its old failures and
+            // re-tripped on the next one.
+            Interlocked.Exchange(ref _failedCount, 0);
+            Interlocked.Exchange(ref _totalCount, 0);
 
             var now = _timeProvider.GetUtcNow().Ticks;
             _circuitOpenedTime = now;

--- a/src/Couchbase/Core/DI/ClusterNodeFactory.cs
+++ b/src/Couchbase/Core/DI/ClusterNodeFactory.cs
@@ -23,21 +23,19 @@ namespace Couchbase.Core.DI
         private readonly IConnectionPoolFactory _connectionPoolFactory;
         private readonly ILogger<ClusterNode> _logger;
         private readonly ObjectPool<OperationBuilder> _operationBuilderPool;
-        private readonly ICircuitBreaker _circuitBreaker;
         private readonly ISaslMechanismFactory _saslMechanismFactory;
         private readonly TypedRedactor _redactor;
         private readonly IRequestTracer _tracer;
         private readonly IOperationConfigurator _operationConfigurator;
 
         public ClusterNodeFactory(ClusterContext clusterContext, IConnectionPoolFactory connectionPoolFactory, ILogger<ClusterNode> logger,
-            ObjectPool<OperationBuilder> operationBuilderPool, ICircuitBreaker circuitBreaker, ISaslMechanismFactory saslMechanismFactory,
+            ObjectPool<OperationBuilder> operationBuilderPool, ISaslMechanismFactory saslMechanismFactory,
             TypedRedactor redactor, IRequestTracer tracer, IOperationConfigurator operationConfigurator)
         {
             _clusterContext = clusterContext ?? throw new ArgumentNullException(nameof(clusterContext));
             _connectionPoolFactory = connectionPoolFactory ?? throw new ArgumentNullException(nameof(connectionPoolFactory));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _operationBuilderPool = operationBuilderPool ?? throw new ArgumentNullException(nameof(operationBuilderPool));
-            _circuitBreaker = circuitBreaker ?? throw new ArgumentException(nameof(circuitBreaker));
             _saslMechanismFactory = saslMechanismFactory ?? throw new ArgumentNullException(nameof(saslMechanismFactory));
             _redactor = redactor ?? throw new ArgumentNullException(nameof(redactor));
             _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
@@ -53,8 +51,11 @@ namespace Couchbase.Core.DI
         /// <inheritdoc />
         public async Task<IClusterNode> CreateAndConnectAsync(HostEndpointWithPort endPoint, NodeAdapter? nodeAdapter, CancellationToken cancellationToken = default)
         {
+            // Resolved per node rather than held as a field, so each node gets its own breaker.
+            var circuitBreaker = _clusterContext.ServiceProvider.GetRequiredService<ICircuitBreaker>();
+
             var clusterNode = new ClusterNode(_clusterContext, _connectionPoolFactory, _logger,
-                _operationBuilderPool, _circuitBreaker, _saslMechanismFactory, _redactor, endPoint,
+                _operationBuilderPool, circuitBreaker, _saslMechanismFactory, _redactor, endPoint,
                 nodeAdapter, _tracer, _operationConfigurator);
 
             //ensure server calls are made to set the state

--- a/src/Couchbase/Core/DI/DefaultServices.cs
+++ b/src/Couchbase/Core/DI/DefaultServices.cs
@@ -126,7 +126,11 @@ namespace Couchbase.Core.DI
             yield return (typeof(IAnalyticsIndexManager), new SingletonServiceFactory(typeof(AnalyticsIndexManager)));
             yield return (typeof(IEventingFunctionManagerFactory), new SingletonServiceFactory(typeof(EventingFunctionManagerFactory)));
 
-            yield return (typeof(ICircuitBreaker), new SingletonServiceFactory(typeof(CircuitBreaker)));
+            // Transient, not singleton: a circuit breaker tracks the health of one endpoint, so
+            // each ClusterNode needs its own. Sharing one instance pooled every node's results into
+            // a single decision, so a bad node could open the circuit for healthy nodes while their
+            // successes diluted its error rate. The configuration behind them is still shared.
+            yield return (typeof(ICircuitBreaker), new TransientServiceFactory(typeof(CircuitBreaker)));
             yield return (typeof(CircuitBreakerConfiguration), new SingletonServiceFactory(typeof(CircuitBreakerConfiguration)));
 
             yield return (typeof(ISaslMechanismFactory), new SingletonServiceFactory(typeof(SaslMechanismFactory)));

--- a/tests/Couchbase.UnitTests/Core/CircuitBreakers/CircuitBreakerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/CircuitBreakers/CircuitBreakerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Couchbase.Core.CircuitBreakers;
+using Couchbase.Core.DI;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
@@ -8,9 +9,86 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
     public class CircuitBreakerTests
     {
         [Fact]
+        public void Reset_Clears_The_Failure_Counts()
+        {
+            var config = new CircuitBreakerConfiguration { VolumeThreshold = 2 };
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), config);
+
+            circuitBreaker.MarkFailure();
+            circuitBreaker.MarkFailure();
+            Assert.Equal(CircuitBreakerState.Open, circuitBreaker.State);
+
+            circuitBreaker.Reset();
+            Assert.Equal(CircuitBreakerState.Closed, circuitBreaker.State);
+
+            // The counts went with it, so one fresh failure must not immediately re-open a circuit
+            // whose threshold is two. Reset used to assign Interlocked.Exchange's return value back
+            // to the counters, which restored them.
+            circuitBreaker.MarkFailure();
+            Assert.Equal(CircuitBreakerState.Closed, circuitBreaker.State);
+        }
+
+        [Fact]
+        public void Each_Node_Gets_Its_Own_CircuitBreaker()
+        {
+            // A circuit breaker tracks the health of one endpoint. While this was a singleton, one
+            // unhealthy node opened the circuit for every node.
+            var services = new ClusterOptions().BuildServiceProvider();
+
+            var first = services.GetRequiredService<ICircuitBreaker>();
+            var second = services.GetRequiredService<ICircuitBreaker>();
+
+            Assert.NotSame(first, second);
+
+            for (var i = 0; i < new CircuitBreakerConfiguration().VolumeThreshold; i++)
+            {
+                first.MarkFailure();
+            }
+
+            Assert.Equal(CircuitBreakerState.Open, first.State);
+            Assert.Equal(CircuitBreakerState.Closed, second.State);
+        }
+
+        [Fact]
+        public void One_Nodes_Failures_Are_Not_Diluted_By_Anothers_Successes()
+        {
+            // The other half of the shared-breaker bug. Pooling every node's results into one
+            // error rate meant a busy healthy node could hold the cluster-wide percentage under
+            // the threshold and stop a failing node's circuit opening at all - so the breaker
+            // was least likely to protect you exactly when one node of many went bad.
+            var services = new ClusterOptions().BuildServiceProvider();
+            var config = services.GetRequiredService<CircuitBreakerConfiguration>();
+
+            var failing = services.GetRequiredService<ICircuitBreaker>();
+            var healthy = services.GetRequiredService<ICircuitBreaker>();
+
+            for (var i = 0; i < config.VolumeThreshold; i++)
+            {
+                failing.MarkFailure();
+
+                // Twice the traffic, all of it fine. Pooled, that is 20 failures in 60 operations
+                // - a third, well under the 50% threshold, so nothing would have tripped.
+                healthy.MarkSuccess();
+                healthy.MarkSuccess();
+            }
+
+            Assert.Equal(CircuitBreakerState.Open, failing.State);
+            Assert.Equal(CircuitBreakerState.Closed, healthy.State);
+        }
+
+        [Fact]
+        public void Nodes_Share_One_CircuitBreakerConfiguration()
+        {
+            var services = new ClusterOptions().BuildServiceProvider();
+
+            Assert.Same(services.GetRequiredService<CircuitBreakerConfiguration>(),
+                services.GetRequiredService<CircuitBreakerConfiguration>());
+        }
+
+        [Fact]
         public void When_Created_AllowAttempts_IsTrue()
         {
-            var circuitBreaker = new CircuitBreaker();
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration());
             Assert.True(circuitBreaker.AllowsRequest());
             Assert.Equal(CircuitBreakerState.Closed, circuitBreaker.State);
         }
@@ -19,7 +97,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         public void When_Volume_Exceeded_Circuit_Opens()
         {
             var config = new CircuitBreakerConfiguration();
-            var circuitBreaker = new CircuitBreaker(TimeProvider.System, config);
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), config);
             for (var i = 0; i < config.VolumeThreshold - 1; i++)
             {
                 circuitBreaker.MarkFailure();
@@ -35,7 +113,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         [Fact]
         public void When_Threshhold_Exceeded_Circuit_Opens()
         {
-            var circuitBreaker = new CircuitBreaker(TimeProvider.System, new CircuitBreakerConfiguration
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration
             {
                 ErrorThresholdPercentage = 80
             });
@@ -61,7 +139,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         [Fact]
         public void When_Reset_State_Is_Closed()
         {
-            var circuitBreaker = new CircuitBreaker();
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration());
             for (var i = 0; i < 55; i++)
             {
                 circuitBreaker.MarkFailure();
@@ -98,7 +176,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         [Fact]
         public void When_Track_State_Is_HalfOpen()
         {
-            var circuitBreaker = new CircuitBreaker();
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration());
             for (var i = 0; i < 55; i++)
             {
                 circuitBreaker.MarkFailure();
@@ -112,7 +190,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         [Fact]
         public void When_HalfOpen_And_MarkSuccess_Called_State_Is_Closed()
         {
-            var circuitBreaker = new CircuitBreaker();
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration());
             for (var i = 0; i < 55; i++)
             {
                 circuitBreaker.MarkFailure();
@@ -215,7 +293,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
                 VolumeThreshold = 1
             };
 
-            var circuitBreaker = new CircuitBreaker(TimeProvider.System, config);
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), config);
             circuitBreaker.MarkFailure();
             Assert.Equal(CircuitBreakerState.Open, circuitBreaker.State);
             Assert.False(circuitBreaker.AllowsRequest());
@@ -276,7 +354,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         [Fact]
         public void When_Closed_Reset_To_Closed()
         {
-            var circuitBreaker = new CircuitBreaker();
+            var circuitBreaker = new CircuitBreaker(new FakeTimeProvider(), new CircuitBreakerConfiguration());
             Assert.Equal(CircuitBreakerState.Closed, circuitBreaker.State);
             Assert.True(circuitBreaker.AllowsRequest());
 

--- a/tests/Couchbase.UnitTests/Core/CircuitBreakers/CircuitBreakerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/CircuitBreakers/CircuitBreakerTests.cs
@@ -34,13 +34,14 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
             // A circuit breaker tracks the health of one endpoint. While this was a singleton, one
             // unhealthy node opened the circuit for every node.
             var services = new ClusterOptions().BuildServiceProvider();
+            var config = services.GetRequiredService<CircuitBreakerConfiguration>();
 
             var first = services.GetRequiredService<ICircuitBreaker>();
             var second = services.GetRequiredService<ICircuitBreaker>();
 
             Assert.NotSame(first, second);
 
-            for (var i = 0; i < new CircuitBreakerConfiguration().VolumeThreshold; i++)
+            for (var i = 0; i < config.VolumeThreshold; i++)
             {
                 first.MarkFailure();
             }
@@ -50,7 +51,7 @@ namespace Couchbase.UnitTests.Core.CircuitBreakers
         }
 
         [Fact]
-        public void One_Nodes_Failures_Are_Not_Diluted_By_Anothers_Successes()
+        public void Failures_On_One_Node_Are_Not_Diluted_By_Successes_On_Another()
         {
             // The other half of the shared-breaker bug. Pooling every node's results into one
             // error rate meant a busy healthy node could hold the cluster-wide percentage under


### PR DESCRIPTION
Two circuit breaker bugs, neither of which had any test coverage.

**`Reset()` did not clear the counters.** It assigned the return value of `Interlocked.Exchange` back to the field:

```csharp
_failedCount = Interlocked.Exchange(ref _failedCount, 0);
```

Exchange returns the *previous* value, so the counts the reset was meant to clear were put straight back. A circuit that recovered kept its old failures and re-tripped on the next one.

**One circuit breaker was shared by the whole cluster.** `ICircuitBreaker` was a singleton, and `ClusterNodeFactory` held one instance and passed it to every node. A breaker tracks the health of one endpoint, but this one pooled every node's results into a single decision: a bad node could open the circuit for healthy nodes, while their successes diluted its error rate and could stop it opening at all. Java constructs one per endpoint (`BaseEndpoint` ctor) and Go one per connection (`newMemdClient`); neither shares one across nodes.

It is now registered transient and resolved per node. Note that is per *node*, not per socket: a `ClusterNode` owns a connection pool, so its connections share a breaker. Coarser than Java or Go, but it is the seam this architecture offers and it confines a failing node's circuit to that node.

The configuration behind the breakers is still shared, so no public API changes.

## Tests

Three tests: that a reset really drops the counts, that each node resolves its own breaker, and that one node's failures are not diluted by another's successes. That last one covers the half of the shared breaker that would otherwise have gone unnoticed — a busy healthy node could hold the pooled error rate under the threshold and stop a failing node's circuit opening at all.

Each fails against the unfixed code, checked by restoring each bug in turn.

Every test in this area now uses a `FakeTimeProvider`. Several ran on `TimeProvider.System` while looping up to 500 times against a 60 second rolling window, so a CI stall mid-loop would reset the counters and the circuit would never trip.

2991 unit tests pass.

## FIT performer

Two changes ride along so all of it is in one place.

**The `SdkCircuitBreakers` capability is no longer declared.** The driver's `CircuitBreakerTest` asserts behaviour .NET does not implement — SDK-RFC 33 requires a half-open circuit to be probed by a dedicated noop canary, and .NET uses the next user operation instead. Declaring it only produced a permanently red suite: `canariesAreSent` has failed 58 of the 59 nightly runs still readable in the Actions logs, back to 2026-06-27. .NET was the only SDK running these tests:

| SDK | Declares the capability | Result |
| --- | --- | --- |
| .NET | yes | 1 pass, 2 fail |
| Java / Scala / Kotlin | yes, then excluded from those tests by name | 1 pass, 2 skip |
| Go | no | 0 pass, 3 skip |
| Python (and so the C++ core) | no | 0 pass, 3 skip |

**A KV-only circuit breaker config was silently dropped**, because the block applying it was wrapped in a redundant `if (protoCbConfig.Query != null)`. The per-service checks inside already gate each service. Inert while the capability is undeclared, but wrong, and a trap for whoever declares it next.

## Notes for the reviewer

Implementing the canary was investigated and rejected as too risky for the benefit: circuit breakers are on by default, so it changes recovery behaviour for every user, and the driver's own timings do not accommodate a conforming implementation — `canariesAreSent` runs for 2 seconds against a 5 second sleep window.

Dropping the capability only takes effect in FIT once a performer image is built from this code. The nightly uses `dotnet-fit-performer:main`, which is not rebuilt on merge, so `publish-fit-performer.yml` needs dispatching with `ref=master` afterwards.

https://couchbasecloud.atlassian.net/browse/NCBC-4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)


