### PR TITLE
NCBC-4288: Install fit-cli from the ci channel again, not latest

### DIFF
--- a/.github/workflows/fit-testing-dotnet.yml
+++ b/.github/workflows/fit-testing-dotnet.yml
@@ -25,10 +25,10 @@ on:
         type: boolean
         default: true
       channel:
-        description: fit-cli install channel ("latest" or "ci").
+        description: fit-cli install channel ("ci" or "latest").
         required: false
         type: string
-        default: latest
+        default: ci
       performer_tag:
         description: >-
           Tag of the ghcr.io/couchbase/dotnet-fit-performer image to test. Defaults to the branch
@@ -88,12 +88,20 @@ jobs:
       preset: ${{ vars.FIT_CLI_PRESET || inputs.preset || 'op-multi-lite' }}
       collect_extra_diagnostics: ${{ inputs.collect_extra_diagnostics == '' && true || inputs.collect_extra_diagnostics }}
       performer: dotnet-fit-performer:${{ needs.performer-tag.outputs.tag }}
-      # 'latest', not 'ci': the ci channel went stale at a 2026-08-10 build and stopped
-      # picking up fixes, which killed Capella cluster allocation from 2026-08-21 - see
-      # NCBC-4288. Note the input default above does NOT apply to the
-      # nightly: scheduled runs supply no inputs and workflow_dispatch defaults only apply to
-      # dispatches, so this literal is what the nightly actually uses.
-      channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'latest' }}
+      # 'ci', not 'latest'. NCBC-4288 moved this to 'latest' because the ci channel had gone
+      # stale at a 2026-08-10 build, which killed Capella cluster allocation. That is no longer
+      # true - ci is rebuilt alongside latest - and latest has since regressed: it passes
+      # --capella-create-pool to `cbdinocluster init`, which rejects it as an unknown flag, so
+      # every Capella preset dies during setup and reports no results at all.
+      #
+      # Measured 2026-09-03: latest (built 13:18:31Z) fails at init, ci (built 13:16:30Z, two
+      # minutes earlier) completes op-capella-sit-lite 5/5. Revisit once fit-cli no longer
+      # passes a flag the installed cbdinocluster does not have.
+      #
+      # Note the input default above does NOT apply to the nightly: scheduled runs supply no
+      # inputs and workflow_dispatch defaults only apply to dispatches, so this literal is what
+      # the nightly actually uses.
+      channel: ${{ vars.FIT_CLI_CHANNEL || inputs.channel || 'ci' }}
       # Empty on the nightly, which passes no inputs — so the nightly keeps the presets' own
       # default server version.
       env_override: ${{ inputs.env_override }}


### PR DESCRIPTION
Every Capella preset in the nightly currently dies during setup and reports **no results at all** — not a failure count, nothing. The `latest` fit-cli build passes `--capella-create-pool` to `cbdinocluster init`, and the cbdinocluster on the runner rejects it:

```
Error: unknown flag: --capella-create-pool
failed to initialize command line parser: unknown flag: --capella-create-pool
```

This ticket originally moved the workflow to `latest` because `ci` had gone stale at a 2026-08-10 build, which had killed Capella allocation. **That is no longer the case** — `ci` is rebuilt alongside `latest`, and the two are now minutes apart rather than weeks.

## Measured 2026-09-03

| | Channel | fit-cli built | Capella result |
| --- | --- | --- | --- |
| Nightly [33698833736](https://github.com/couchbase/couchbase-net-client/actions/runs/33698833736) | `latest` | 13:**18**:31Z | flag error ×4, no results table |
| Manual [33705293735](https://github.com/couchbase/couchbase-net-client/actions/runs/33705293735) | `ci` | 13:**16**:30Z | **`op-capella-sit-lite` 5/5, 100%** |

Two minutes apart in build time, and only `latest` carries the regression.

## Change

The channel literal used by scheduled runs, and the `workflow_dispatch` default, both back to `ci`. The comment records what was measured and the condition for revisiting — fit-cli should not pass a flag the installed cbdinocluster lacks, and once that's fixed either channel should work.

## Scope

Functional presets are unaffected by the channel; on-prem and CNG have been nominally identical all week under both. This is Capella-only.

Two other nightly problems are **not** fixed here:

- `op-cng-sit-lite` is not being scheduled at all, despite being part of `op-multi-sit-lite`. So situational coverage is currently zero even with this change, until that's understood.
- `cbdinocluster`'s cleanup path fails once enough orphaned resources accumulate — `DeleteVpcEndpoints` is passed more than the AWS per-call limit of 25, and Capella returns 429 `TooManyLoginAttempts` during long destroy polls. Those bit the nightlies from 08-29 to 09-02 and will return; they need fixing in cbdinocluster.

https://couchbasecloud.atlassian.net/browse/NCBC-4288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
