### PR TITLE
NCBC-4295: Bump the released version to 3.9.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- update this after a release-->
-    <CouchbaseNetClientReleasedVersion>3.9.5</CouchbaseNetClientReleasedVersion>
+    <CouchbaseNetClientReleasedVersion>3.9.6</CouchbaseNetClientReleasedVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- libraries typically include NetStandardTargets for widest use cases -->


### PR DESCRIPTION
Source hygiene ahead of tagging 3.9.6. `CouchbaseNetClientReleasedVersion`
3.9.5 -> 3.9.6 in `Directory.Build.props`.

The published version comes from the git tag rather than this property, so
this is not on the critical path for the release — but it should not lag it,
and it is step 2 of the NCBC-4295 release checklist.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)