### PR TITLE
NCBC-4298: Make the config streaming backoff actually back off

### DIFF
--- a/src/Couchbase/Core/Configuration/Server/Streaming/HttpStreamingConfigListener.cs
+++ b/src/Couchbase/Core/Configuration/Server/Streaming/HttpStreamingConfigListener.cs
@@ -17,7 +17,9 @@ namespace Couchbase.Core.Configuration.Server.Streaming
 {
     internal class HttpStreamingConfigListener : IDisposable, IAsyncDisposable
     {
-        private const int InitialDelayMs = 0;
+        // Has to start non-zero: the ramp below multiplies, and zero times ten stays zero, which is
+        // how a total failure came to be retried as fast as the failures came back.
+        private const int InitialDelayMs = 100;
         private const int MaxDelayMs = 10000;
         private readonly ILogger<HttpStreamingConfigListener> _logger;
         private readonly ClusterOptions _clusterOptions;
@@ -32,6 +34,13 @@ namespace Couchbase.Core.Configuration.Server.Streaming
         private bool _disposed;
 
         public bool Started { get; private set; }
+
+        /// <summary>
+        /// Waits out the backoff between rounds. Replaced in tests, which need the duration asked
+        /// for: a zero-length wait never reaches a clock, so a <see cref="TimeProvider"/> sees nothing.
+        /// </summary>
+        internal Func<TimeSpan, CancellationToken, Task> Delay { get; set; } =
+            static (duration, cancellationToken) => Task.Delay(duration, cancellationToken);
 
         public HttpStreamingConfigListener(IConfigUpdateEventSink configSubscriber, ClusterOptions clusterOptions, ICouchbaseHttpClientFactory httpClientFactory,
             IConfigHandler configHandler, ILogger<HttpStreamingConfigListener> logger)
@@ -69,18 +78,31 @@ namespace Couchbase.Core.Configuration.Server.Streaming
 
         private Task StartBackgroundTask()
         {
+            // Captured once, and used for everything below: Dispose cancels the source and then
+            // disposes it, so reading Token inside the loop would throw into the inner catch, which
+            // logged an ordinary shutdown as "HTTP Streaming error.". This read can still throw if a
+            // Dispose beats the _disposed check above - the same pre-existing window, which used to
+            // sit on the Task.Run overload - and StartListening already documents that.
+            var listenerToken = _cancellationTokenSource.Token;
+
             // Ensure that we don't flow the ExecutionContext into the long running task below
             using var flowControl = ExecutionContext.SuppressFlow();
 
+            // Deliberately not given the token, which it had been passed since 2020: that overload
+            // only declines to start the delegate, so a Dispose between scheduling and dispatch ends
+            // the task Canceled for DisposeAsync to rethrow. The loop checks the token itself.
             return Task.Run(async () =>
             {
                 var delayMs = InitialDelayMs;
-                while (!_cancellationTokenSource.IsCancellationRequested)
+                while (!listenerToken.IsCancellationRequested)
                 {
                     try
                     {
                         var nodes = _configSubscriber?.ClusterNodes.Where(x=>x.HasManagement).ToList().Shuffle();
-                        while (nodes != null && nodes.Any())
+
+                        // Per node, not just per round: a shutdown mid-round would otherwise walk every
+                        // node left in the list, logging each cancellation as "HTTP Streaming error.".
+                        while (nodes != null && nodes.Any() && !listenerToken.IsCancellationRequested)
                         {
                             try
                             {
@@ -103,7 +125,7 @@ namespace Couchbase.Core.Configuration.Server.Streaming
 
                                 var response = await httpClient.GetAsync(streamingUri.Uri,
                                     HttpCompletionOption.ResponseHeadersRead,
-                                    _cancellationTokenSource.Token).ConfigureAwait(false);
+                                    listenerToken).ConfigureAwait(false);
 
                                 response.EnsureSuccessStatusCode();
 
@@ -117,7 +139,7 @@ namespace Couchbase.Core.Configuration.Server.Streaming
                                 using var reader = new StreamReader(stream, Encoding.UTF8, false);
 
                                 string? config;
-                                while (!_cancellationTokenSource.IsCancellationRequested &&
+                                while (!listenerToken.IsCancellationRequested &&
                                        (config = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
                                 {
                                     if (config != string.Empty)
@@ -147,10 +169,20 @@ namespace Couchbase.Core.Configuration.Server.Streaming
                     // if we exited the inner loop, then all servers failed and we need to start over.
                     // however, we don't want to create a failstorm in the logs if the failure is 100%
                     // try again, but with an exponential delay of up to 10s.
-                    await Task.Delay(delayMs).ConfigureAwait(false);
+                    try
+                    {
+                        await Delay(TimeSpan.FromMilliseconds(delayMs), listenerToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Disposed while backing off. Waiting it out would leave this loop alive for
+                        // up to ten seconds after the bucket was closed.
+                        break;
+                    }
+
                     delayMs = Math.Min(delayMs * 10, MaxDelayMs);
                 }
-            }, _cancellationTokenSource.Token);
+            });
         }
 
         public void Dispose()

--- a/tests/Couchbase.UnitTests/Core/Configuration/HttpStreamingConfigListenerTests.cs
+++ b/tests/Couchbase.UnitTests/Core/Configuration/HttpStreamingConfigListenerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Net.Http;
 using System.Threading;
@@ -18,52 +19,184 @@ namespace Couchbase.UnitTests.Core.Configuration
         [Fact]
         public async Task Should_Continue_After_Failures()
         {
+            var messageHandler = new ThrowsEveryTimeMessageHandler();
+
+            // await using, not using: the sync Dispose only signals the loop to stop, DisposeAsync
+            // waits for it to finish.
+            await using var configListener =
+                CreateListener(nameof(Should_Continue_After_Failures), messageHandler);
+
+            // Skip the backoff rather than serve it — this test is about carrying on after a failure,
+            // not about timing — and hold at the third attempt so the count settles.
+            var held = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            configListener.Delay = (_, _) => messageHandler.Calls.Count < 3 ? Task.CompletedTask : held.Task;
+            configListener.StartListening();
+
+            // Every request throws, so a third attempt is proof it retried. Awaited, not polled: a
+            // listener which gives up hangs the test rather than missing a deadline (NCBC-4293).
+            await messageHandler.Calls.WaitForAsync(3);
+
+            // DisposeAsync awaits the loop, so its returning is itself proof the loop has exited.
+            configListener.Dispose();
+            held.TrySetResult(true);
+            await configListener.DisposeAsync();
+
+            // Exactly three, not at least three: it retried twice after failing.
+            Assert.Equal(3, messageHandler.Calls.Count);
+        }
+
+        [Fact]
+        public async Task Every_Node_Failing_Backs_Off_Between_Rounds()
+        {
+            var messageHandler = new ThrowsEveryTimeMessageHandler();
+            await using var configListener =
+                CreateListener(nameof(Every_Node_Failing_Backs_Off_Between_Rounds), messageHandler);
+
+            // Record what the listener asks to wait for, and hold at the fourth. A zero-length wait
+            // never reaches a clock, so the request is the only way to see it did not wait.
+            const int rounds = 4;
+            var backoffs = new List<TimeSpan>();
+            var rounded = new AsyncCounter();
+            var held = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            configListener.Delay = (duration, _) =>
+            {
+                lock (backoffs)
+                {
+                    backoffs.Add(duration);
+                }
+
+                rounded.Increment();
+                return rounded.Count < rounds ? Task.CompletedTask : held.Task;
+            };
+
+            configListener.StartListening();
+
+            // Four rounds is enough to show the wait growing and reaching the cap.
+            await rounded.WaitForAsync(rounds);
+
+            List<TimeSpan> waited;
+            lock (backoffs)
+            {
+                waited = new List<TimeSpan>(backoffs);
+            }
+
+            // Held at the fourth, so no further round can run while this is read.
+            configListener.Dispose();
+            held.TrySetResult(true);
+            await configListener.DisposeAsync();
+
+            // Ten times longer each round, capped at MaxDelayMs: with every endpoint failing the
+            // listener must not reattempt as fast as the failures come back.
+            Assert.Equal(
+                new[]
+                {
+                    TimeSpan.FromMilliseconds(100),
+                    TimeSpan.FromSeconds(1),
+                    TimeSpan.FromSeconds(10),
+                    TimeSpan.FromSeconds(10)
+                },
+                waited);
+        }
+
+        [Fact]
+        public async Task Disposing_During_A_Backoff_Does_Not_Wait_It_Out()
+        {
+            var messageHandler = new ThrowsEveryTimeMessageHandler();
+            await using var configListener =
+                CreateListener(nameof(Disposing_During_A_Backoff_Does_Not_Wait_It_Out), messageHandler);
+
+            // Stand in for a backoff just begun: it ends only when the listener's token is cancelled.
+            var backingOff = new AsyncCounter();
+            var backoffToken = CancellationToken.None;
+            configListener.Delay = (_, token) =>
+            {
+                backoffToken = token;
+                backingOff.Increment();
+
+                // Only wait when the token can end it: given one which cannot — the defect this
+                // guards — an unending wait would hang the test instead of failing the assert below.
+                return token.CanBeCanceled ? Task.Delay(Timeout.InfiniteTimeSpan, token) : Task.CompletedTask;
+            };
+
+            configListener.StartListening();
+            await backingOff.WaitForAsync(1);
+
+            // Fails here rather than hanging if the listener passes no token at all.
+            Assert.True(backoffToken.CanBeCanceled, "The backoff was given a token which can never be cancelled.");
+
+            // Returns only once the loop has finished, which it can only do by abandoning the wait.
+            await configListener.DisposeAsync();
+
+            Assert.True(backoffToken.IsCancellationRequested);
+        }
+
+        [Fact]
+        public async Task Disposing_Mid_Round_Does_Not_Try_The_Remaining_Nodes()
+        {
+            var messageHandler = new ThrowsEveryTimeMessageHandler();
+            await using var configListener = CreateListener(
+                nameof(Disposing_Mid_Round_Does_Not_Try_The_Remaining_Nodes), messageHandler, nodeCount: 3);
+
+            // Park the round inside the first node's request, so the close below lands with two nodes
+            // still to go. Each one tried would log its cancellation as "HTTP Streaming error." — a
+            // failstorm of one entry per management node on an ordinary bucket close.
+            var atFirstNode = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            messageHandler.OnCall = () =>
+            {
+                atFirstNode.TrySetResult(true);
+                release.Task.GetAwaiter().GetResult();
+            };
+
+            configListener.StartListening();
+            await atFirstNode.Task;
+
+            // Only the test thread disposes: two threads through Dispose can Cancel a source the
+            // other has already disposed.
+            configListener.Dispose();
+            release.TrySetResult(true);
+
+            // Returns only once the loop has exited, so the count is final.
+            await configListener.DisposeAsync();
+
+            Assert.Equal(1, messageHandler.Calls.Count);
+        }
+
+        private static HttpStreamingConfigListener CreateListener(string testName,
+            ThrowsEveryTimeMessageHandler messageHandler, int nodeCount = 1)
+        {
 #pragma warning disable CS0618 // Type or member is obsolete
             var clusterOptions = new ClusterOptions()
-                .WithConnectionString($"couchbases://NOSUCHHOST{nameof(Should_Continue_After_Failures)}")
+                .WithConnectionString($"couchbases://NOSUCHHOST{testName}")
                 .WithCredentials("UnitTestUser", "PasswordDoesn'tMatter");
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            var messageHandler = new ThrowsEveryTimeMessageHandler();
             var httpClientFactory = new MockHttpClientFactory(() => new HttpClient(messageHandler, false));
             var configHandler = new Mock<IConfigHandler>(MockBehavior.Loose).Object;
             var mockLogger = new Mock<ILogger<HttpStreamingConfigListener>>(MockBehavior.Loose).Object;
             var mockBucket = new Mock<BucketBase>();
 
             var nodeList = new BucketNodeList();
-            var clusterNode = new Mock<IClusterNode>();
-            clusterNode.Setup(x => x.NodesAdapter).Returns(new NodeAdapter
+            for (var i = 0; i < nodeCount; i++)
             {
-                MgmtApi = 8091,
-                MgmtApiSsl = 18091
-            });
+                var host = $"NOSUCHHOST{testName}{i}";
+                var clusterNode = new Mock<IClusterNode>();
+                clusterNode.Setup(x => x.NodesAdapter).Returns(new NodeAdapter
+                {
+                    MgmtApi = 8091,
+                    MgmtApiSsl = 18091
+                });
 
-            clusterNode.Setup(x => x.HasManagement).Returns(true);
-            clusterNode.Setup(x => x.KeyEndPoints).Returns(new ReadOnlyObservableCollection<HostEndpointWithPort>(new ObservableCollection<HostEndpointWithPort>()));
-            clusterNode.Setup(x => x.ManagementUri).Returns(new Uri($"http://NOSUCHHOST{nameof(Should_Continue_After_Failures)}:8091"));
-            clusterNode.Setup(x => x.EndPoint).Returns(new HostEndpointWithPort($"NOSUCHHOST{nameof(Should_Continue_After_Failures)}", 11210));
-            nodeList.Add(clusterNode.Object);
-            mockBucket.Object.Nodes.Add(clusterNode.Object);
+                clusterNode.Setup(x => x.HasManagement).Returns(true);
+                clusterNode.Setup(x => x.KeyEndPoints).Returns(new ReadOnlyObservableCollection<HostEndpointWithPort>(new ObservableCollection<HostEndpointWithPort>()));
+                clusterNode.Setup(x => x.ManagementUri).Returns(new Uri($"http://{host}:8091"));
+                clusterNode.Setup(x => x.EndPoint).Returns(new HostEndpointWithPort(host, 11210));
+                nodeList.Add(clusterNode.Object);
+                mockBucket.Object.Nodes.Add(clusterNode.Object);
+            }
 
-            // await using, not using: the sync Dispose only signals the background loop to stop, while
-            // DisposeAsync waits for it to actually finish. This is the failure path — the explicit
-            // DisposeAsync below is what the test asserts around.
-            await using var configListener = new HttpStreamingConfigListener(mockBucket.Object,
+            return new HttpStreamingConfigListener(mockBucket.Object,
                 clusterOptions, httpClientFactory, configHandler, mockLogger);
-            configListener.StartListening();
-
-            // Every request throws, and the listener has to keep going regardless. A third attempt is
-            // therefore proof that it retried after failing, and is awaited rather than polled for: a
-            // listener which gives up hangs this test, which says what went wrong, instead of failing
-            // a deadline that only says the runner was busy (NCBC-4293).
-            await messageHandler.Calls.WaitForAsync(3);
-
-            // Disposing has to stop it. DisposeAsync awaits the background loop, so its returning is
-            // itself the proof that the loop has exited and can make no further calls — there is no
-            // need to watch the call count and decide it has gone quiet enough.
-            await configListener.DisposeAsync();
-
-            Assert.True(messageHandler.Calls.Count >= 3);
         }
 
         class ThrowsEveryTimeMessageHandler : HttpMessageHandler
@@ -74,9 +207,16 @@ namespace Couchbase.UnitTests.Core.Configuration
             /// </summary>
             public AsyncCounter Calls { get; } = new();
 
+            /// <summary>
+            /// Runs on each call, before it fails, for a test which needs something to happen while the
+            /// listener is part-way through a round.
+            /// </summary>
+            public Action OnCall { get; set; }
+
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 Calls.Increment();
+                OnCall?.Invoke();
                 throw new NotImplementedException();
             }
         }


### PR DESCRIPTION
## Motivation

`HttpStreamingConfigListener` tries every management node in turn, and when all of them have failed it waits before starting the round again — with a delay meant to grow to 10 s, explicitly so that a total failure does not produce a failstorm (the comment at `HttpStreamingConfigListener.cs:158-160` says exactly that).

That backoff has never worked:

```csharp
private const int InitialDelayMs = 0;
...
await Task.Delay(delayMs).ConfigureAwait(false);
delayMs = Math.Min(delayMs * 10, MaxDelayMs);   // Math.Min(0 * 10, 10000) == 0, forever
```

`delayMs` starts at 0 and zero times ten is zero, so every round waited nothing: while all management endpoints were unreachable the client reattempted as fast as the failures came back, building an `HttpClient` and throwing and logging an exception per lap, for as long as the outage lasted. The `0` and the `* 10` ramp arrived in the same commit (NCBC-2518, 2020), so this has never worked at any point.

## Modification

Four changes.

**1. `InitialDelayMs` 0 → 100**, which is the ramp the arithmetic was clearly written for: **100 ms, 1 s, 10 s, 10 s**. Nothing else about the ramp changes.

This is *not* what the ticket asked for, and the divergence is deliberate. NCBC-4298 asked for a `0` floor — `0 → 100 ms → 1 s → 10 s` — on the grounds that keeping the first retry immediate leaves recovery from a transient blip exactly as fast as it is today, and that raising `InitialDelayMs` is "a behaviour change nobody asked for". That reasoning doesn't survive contact with the reset: `delayMs` is reset to `InitialDelayMs` on **every config line received**, not just at the start. So under a `0` floor, a node that accepts the connection, delivers one config and drops would be reconnected with no pause at all — the hot loop simply survives for the flapping case instead of the dead-endpoint case. Only a non-zero floor closes it. The ticket has been updated to match.

**2. The wait is now given the listener's cancellation token.** It had none — harmless at 0 ms, but a real wait without one would leave the background loop alive for up to ten seconds after the bucket was closed.

**3. The round now checks that token per node, not only per lap.** A shutdown landing mid-round previously walked every node still in the list, building an `HttpClient` for each and getting an immediate `TaskCanceledException` from `GetAsync`, which the inner catch logs at **Error** as `"HTTP Streaming error."` — one entry per management node on an ordinary bucket close. That's the same failstorm the backoff exists to prevent, on the shutdown path.

**4. `Task.Run` is no longer handed the token.** Copilot's second-pass finding, and correct: that overload only declines to *start* the delegate, so a `Dispose` landing between scheduling and dispatch ends the task `Canceled` for `DisposeAsync` to rethrow as `TaskCanceledException` on an ordinary shutdown. Worth noting it is **pre-existing, not introduced here** — `master` passed `_cancellationTokenSource.Token` to the same `Task.Run` since NCBC-2518 in 2020; the diff only changed which expression supplies it. It is also unreachable today, since nothing in production awaits the task and every test waits for the loop to have started before disposing. Taken anyway: the loop's first act is to check the token, so the overload buys nothing, and this is the last way `DisposeAsync` throws on a clean shutdown.

Not tested, for the same reason as the `ObjectDisposedException` below: it needs a `Dispose` to interleave between scheduling and dispatch, which is not deterministically reproducible.

The token is captured once before the loop and used throughout it: both `IsCancellationRequested` checks, the streaming request, and the wait, so the loop never touches the source. `Dispose` cancels the source and then disposes it, and reading `Token` afterwards throws `ObjectDisposedException` — which the inner catch logged as `"HTTP Streaming error."` on an ordinary shutdown. The capture itself can still throw, if a `Dispose` lands between `StartListening`'s `_disposed` check and the capture; that is the window `master` already had, which read `Token` for the `Task.Run` overload at the same point on the same thread, so it is neither new nor widened here. It surfaces to the caller, which is what `StartListening` already documents for a disposed listener.

## Tests

Four, none of which waits on a clock: the backoff grows and caps; disposal during a backoff does not wait it out; disposal mid-round does not try the remaining nodes; and the existing "keeps going after failures" test, which reached its third attempt instantly *only* because of this defect and now skips the wait rather than serving it.

They drive an internal `Delay` seam (as `RetryOrchestrator` and `StellarRetryHandler` already do) rather than a `TimeProvider`, and that is forced by the defect itself: a zero-length wait completes without ever creating a timer, so a fake clock observes nothing at all — a test built on one would hang rather than fail. Recording the *requested* duration is the only way to see a wait that never happened.

**Three of the four were mutation tested**, so no test passes vacuously (the fourth is not deterministically reproducible):

| Mutation | Result |
| --- | --- |
| `InitialDelayMs` back to `0` | backoff test fails in 112 ms — `Expected [100ms, 1s, 10s, 10s]`, `Actual [0, 0, 0, 0]` |
| token not passed to the wait | disposal test fails in 96 ms — *"The backoff was given a token which can never be cancelled"* |
| per-node token check removed | mid-round test fails — `Expected: 1`, `Actual: 3` |

The `ObjectDisposedException` behaviour is not directly tested: provoking it needs disposal to interleave with setting up a request, which costs more test machinery than a one-line fix is worth.

## Behaviour change

Deliberate, and it reaches beyond the outage case, so worth reviewing explicitly: `delayMs` is also reset to `InitialDelayMs` after **each config line received**, so reconnecting after a healthy stream ends now waits 100 ms rather than nothing.

That is what java does, and on purpose — `ClusterManagerBucketRefresher` converts a normally completed stream into an error so that it goes through the same retry path:

```java
.doOnComplete(() -> {
  // If the stream completes normally we turn it into an exception so it also gets
  // handled in the retryWhen below.
  throw new ConfigException();
})
.retryWhen(Retry.any().exponentialBackoff(Duration.ofMillis(32), Duration.ofMillis(4096)).toReactorRetry())
```

## What this PR deliberately does not do

**Pick the shape of the ramp.** ×10 reaches the 10 s ceiling after only two failed rounds — attempts land at t=0, 0.1 s, 1.1 s, 11.1 s, so three inside the first four seconds. Java doubles from 32 ms to ~4 s and gets roughly eight in the same window. For a memcached bucket that gap matters more than it looks, because this listener is the *only* ongoing config source (`ConfigHandler.Subscribe` starts it eagerly only for `MemcachedBucket`; couchbase buckets get it only when KV polling fails in a mixed cluster), so after a brief management blip a topology change can go unnoticed for up to 10 s.

The values are left alone because they are the ones already in the file — but since they have never executed in any shipped build, "already in the file" is not evidence they were ever right. Choosing them is a real decision, and a separate one from making the backoff run at all. Happy to fold a change in here if a reviewer would rather settle it now.

## Results

Unit suite green on net8.0 and net10.0 (3000 passed).

https://couchbasecloud.atlassian.net/browse/NCBC-4298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
